### PR TITLE
Minor bugfix in s1_min_channels

### DIFF
--- a/straxen/plugins/plugins.py
+++ b/straxen/plugins/plugins.py
@@ -331,7 +331,7 @@ class PeakClassification(strax.Plugin):
         p = peaks
         r = np.zeros(len(p), dtype=self.dtype)
 
-        is_s1 = p['n_channels'] > self.config['s1_min_n_channels']
+        is_s1 = p['n_channels'] >= self.config['s1_min_n_channels']
         is_s1 &= p['range_50p_area'] < self.config['s1_max_width']
         r['type'][is_s1] = 1
 


### PR DESCRIPTION
The number of channels requirement needed a >=, not a >. If this fix is implemented, if the setting for s1_min_channels is, say, 3, then an S1 with exactly 3 channels will pass the cut (which I think it should).