### PR TITLE
Upgrade to tensorflow2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 strax>=0.7.4
-tensorflow<2
-keras
+tensorflow==2.0.0-beta1
 holoviews
 bokeh
 multihist


### PR DESCRIPTION
This upgrades straxen to use [tensorflow 2](https://www.tensorflow.org/beta). The only changes are (1) keras is imported differently, and (2) we no longer need the hack with `get_default_graph` to get tensorflow 1 to work in a threaded environment. I left in the code to run straxen on tensorflow1; once tensorflow2 is officially released we can remove this.

I checked on a small dataset (the piece of 180423_1021 provided as demo data) that the results are the same, as you would expect.

[Flamedisx](https://github.com/JelleAalbers/flamedisx) is tensorflow-2 native. Without this fix, the two packages won't run in the same environment.