### PR TITLE
Change the plugins needed by bootstrax.

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -157,10 +157,7 @@ def new_context():
             runid_field='number',
             new_data_path=output_folder,
             mongo_dbname=dbname),
-        register_all=[straxen.plugins.daqreader,
-                      straxen.plugins.pulse_processing, 
-                      straxen.plugins.peak_processing,                       
-                      straxen.plugins.event_processing])
+        **straxen.contexts.common_opts)
     return st
 
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -157,7 +157,10 @@ def new_context():
             runid_field='number',
             new_data_path=output_folder,
             mongo_dbname=dbname),
-        register_all=straxen.plugins.peak_processing)
+        register_all=[straxen.plugins.daqreader,
+                      straxen.plugins.pulse_processing, 
+                      straxen.plugins.peak_processing,                       
+                      straxen.plugins.event_processing])
     return st
 
 


### PR DESCRIPTION
Boostrax currently crashes as it does not have the daqreader plugin. Hence, I propose to add all that is needed to go up to the default of ```--target``` (currently ```event_info```). 

We might also opt to change this default since 'high level' changes in e.g. event building cause bootstrax to fail (which we don’t want) whereas they are not necessarily the type of data what we intent to put into Rocio.