### PR TITLE
Avoid platform-specific temporary file operations

### DIFF
--- a/straxen/analyses/quick_checks.py
+++ b/straxen/analyses/quick_checks.py
@@ -144,7 +144,7 @@ def event_scatter(context, run_id, events,
 
     plt.sca(ax)
     if color_range[0] is None:
-        extend = None if color_range[1] is None else 'max'
+        extend = 'neither' if color_range[1] is None else 'max'
     else:
         extend = 'min' if color_range[1] is None else 'both'
     plt.colorbar(label="S1 area fraction top",

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -8,29 +8,36 @@ test_run_id = '180423_1021'
 
 def test_straxen():
     with tempfile.TemporaryDirectory() as temp_dir:
-        print("Temporary directory is ", temp_dir)
-        os.chdir(temp_dir)
+        try:
+            print("Temporary directory is ", temp_dir)
+            os.chdir(temp_dir)
 
-        print("Downloading test data (if needed)")
-        st = straxen.contexts.demo()
+            print("Downloading test data (if needed)")
+            st = straxen.contexts.demo()
 
-        run_df = st.select_runs(available='raw_records')
-        run_id = run_df.iloc[0]['name']
-        assert run_id == test_run_id
+            run_df = st.select_runs(available='raw_records')
+            print(run_df)
+            run_id = run_df.iloc[0]['name']
+            assert run_id == test_run_id
 
-        print("Test processing")
-        df = st.get_df(run_id, 'event_info')
-        assert len(df) > 0
-        assert 'cs1' in df.columns
-        assert df['cs1'].sum() > 0
+            print("Test processing")
+            df = st.get_df(run_id, 'event_info')
+            assert len(df) > 0
+            assert 'cs1' in df.columns
+            assert df['cs1'].sum() > 0
 
-        # TODO: find a way to break up the tests
-        # surely pytest has common startup/cleanup?
+            # TODO: find a way to break up the tests
+            # surely pytest has common startup/cleanup?
 
-        print("Test mini analysis")
-        @straxen.mini_analysis(requires=('raw_records',))
-        def count_rr(raw_records):
-            return len(raw_records)
+            print("Test mini analysis")
+            @straxen.mini_analysis(requires=('raw_records',))
+            def count_rr(raw_records):
+                return len(raw_records)
 
-        n = st.count_rr(test_run_id)
-        assert n > 100
+            n = st.count_rr(test_run_id)
+            assert n > 100
+
+        # On windows, you cannot delete the current process'
+        # working directory, so we have to chdir out first.
+        finally:
+            os.chdir('..')


### PR DESCRIPTION
This PR makes straxen around some temporary file/directory practices that are not supported in python on windows, and seem pretty risky in general. Specifically, we now avoid deleting the current working directory of the process (which we did in the tests), or trying to open an already opened temporary file again (which we did to feed the neural net weights to keras).