### PR TITLE
Bootstrax

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -36,6 +36,7 @@ Additionally, bootstrax tracks information with each run in the 'bootstrax' fiel
   - **reason**: reason for last failure, if there ever was one (otherwise this field does not exists). Thus, it's quite possible for this field to exist (and show an exception) when the state is 'done': that just means it failed at least once but succeeded later. Tracking failure history is primarily the DAQ log's reponsibility; this message is only provided for convenience.
    - **n_failures**: number of failures on this run, if there ever was one (otherwise this field does not exist).
   - **next_retry**: time after which bootstrax might retry processing this run. Like 'reason', this will refer to the last failure.
+Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is running to a collection in the DAQ database in
 """
 
 import argparse
@@ -126,7 +127,9 @@ timeouts = {
 }
 
 # Fields in the run docs that bootstrax uses
-bootstrax_projection = 'name start end number bootstrax data.host data.type data.location ini.processing_threads'.split()
+bootstrax_projection = f"name start end number bootstrax " \
+                       f"data.host data.type data.location " \
+                       f"ini.processing_threads ini.compressor".split()
 
 # Filename for temporary storage of the exception
 # This is used to communicate the exception from the strax child process
@@ -454,11 +457,22 @@ def manual_fail(*, mongo_id=None, number=None, reason=''):
     fail_run(rd, "Manually set failed state. " + reason)
 
 
+def get_compressor(rd, default_compressor="blosc"):
+    """Read the compressor method from the run_doc. Return 'blosc' if no
+    information is specified in the run_doc"""
+    try:
+        return rd["ini"]["compressor"]
+    except KeyError:
+        log_warning(f"Bootstrax couldn't read the compressor form the run_doc. "
+                    f"Assuming 'blosc' for now")
+        return default_compressor
+
+
 ##
 # Processing
 ##
 
-def run_strax(run_id, input_dir, target, n_readout_threads, debug=False):
+def run_strax(run_id, input_dir, target, n_readout_threads, compressor, debug=False):
     if debug:
         log.setLevel(logging.DEBUG)
     try:
@@ -466,6 +480,7 @@ def run_strax(run_id, input_dir, target, n_readout_threads, debug=False):
         st = new_context()
         st.make(run_id, target,
                 config=dict(input_dir=input_dir,
+                            compressor=compressor,
                             n_readout_threads=n_readout_threads),
                 max_workers=args.cores)
     except Exception as e:
@@ -531,9 +546,11 @@ def process_run(rd, send_heartbeats=True):
             # Failed before, and on autopilot: do just raw_records
             target = 'raw_records'
 
+        compressor = get_compressor(rd)
+
         strax_proc = multiprocessing.Process(
             target=run_strax,
-            args=(run_id, loc, target, n_readout_threads, args.debug))
+            args=(run_id, loc, target, n_readout_threads,compressor, args.debug))
 
         t0 = now()
         info = dict(started_processing=t0)

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -36,7 +36,15 @@ Additionally, bootstrax tracks information with each run in the 'bootstrax' fiel
   - **reason**: reason for last failure, if there ever was one (otherwise this field does not exists). Thus, it's quite possible for this field to exist (and show an exception) when the state is 'done': that just means it failed at least once but succeeded later. Tracking failure history is primarily the DAQ log's reponsibility; this message is only provided for convenience.
    - **n_failures**: number of failures on this run, if there ever was one (otherwise this field does not exist).
   - **next_retry**: time after which bootstrax might retry processing this run. Like 'reason', this will refer to the last failure.
-Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is running to a collection in the DAQ database in
+Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is running to a collection in the DAQ database into the capped collection 'eb_monitor'. This collection contains the following fields:
+  - **run**: run number,
+  - **host**: the name of the eventbuilder,
+  - **time**: the time whereon the state was reported,
+  - **pid**: the pid of this bootstrax (sub)process,
+  - **cpu_pid**: cpu usage of the bootstrax subprocess (in percent),
+  - **cpu_tot**: cpu usage on the eventbuilder (in percent),
+  - **mem_pid**: memory used by this pid of boostrax (in percent),
+  - **mem_tot**': memory used on this eventbuilder (in percent)}
 """
 
 import argparse
@@ -86,6 +94,8 @@ args = parser.parse_args()
 ##
 # Configuration
 ##
+
+# TODO change this to the production database when DAQ commissioning is finished
 mongo_url = 'mongodb://{username}:{password}@gw:27019/xenonnt'
 dbname = 'xenonnt'
 run_collname = 'run'

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -482,7 +482,8 @@ def get_compressor(rd, default_compressor="blosc"):
 # Processing
 ##
 
-def run_strax(run_id, input_dir, target, n_readout_threads, compressor, debug=False):
+def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
+              run_start_time, debug=False):
     if debug:
         log.setLevel(logging.DEBUG)
     try:
@@ -558,9 +559,15 @@ def process_run(rd, send_heartbeats=True):
 
         compressor = get_compressor(rd)
 
+        try:
+            run_start_time = rd['start'].timestamp()
+        except Exception as e:
+            fail(f"Could not find start in datetime.datetime object: {str(e)}")
+
         strax_proc = multiprocessing.Process(
             target=run_strax,
-            args=(run_id, loc, target, n_readout_threads,compressor, args.debug))
+            args=(run_id, loc, target, n_readout_threads, compressor,
+                  run_start_time,  args.debug))
 
         t0 = now()
         info = dict(started_processing=t0)

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -23,7 +23,7 @@ __all__ = ['DAQReader']
     strax.Option('compressor', default="blosc", track=False,
                  help="Algorithm used for (de)compressing the live data"),
     strax.Option('run_start_time', default=0., type=float, track=False,
-                 help="time of start run (ns since unix epoch)"))
+                 help="time of start run (s since unix epoch)"))
 class DAQReader(strax.Plugin):
     provides = 'raw_records'
     depends_on = tuple()

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -19,7 +19,9 @@ __all__ = ['DAQReader']
     strax.Option('n_readout_threads', type=int, track=False,
                  help="Number of readout threads producing strax data files"),
     strax.Option('erase', default=False, track=False,
-                 help="Delete reader data after processing"))
+                 help="Delete reader data after processing"),
+    strax.Option('compressor', default="blosc",
+                 help="Algorithm used for (de)compressing the live data"))
 class DAQReader(strax.Plugin):
     provides = 'raw_records'
     depends_on = tuple()
@@ -79,7 +81,7 @@ class DAQReader(strax.Plugin):
 
     def _load_chunk(self, path, kind='central'):
         records = [strax.load_file(fn,
-                                   compressor='blosc',
+                                   compressor=self.config["compressor"],
                                    dtype=strax.record_dtype())
                    for fn in sorted(glob.glob(f'{path}/*'))]
         records = np.concatenate(records)

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -21,7 +21,9 @@ __all__ = ['DAQReader']
     strax.Option('erase', default=False, track=False,
                  help="Delete reader data after processing"),
     strax.Option('compressor', default="blosc", track=False,
-                 help="Algorithm used for (de)compressing the live data"))
+                 help="Algorithm used for (de)compressing the live data"),
+    strax.Option('run_start_time', default=0., type=float, track=False,
+                 help="time of start run (ns since unix epoch)"))
 class DAQReader(strax.Plugin):
     provides = 'raw_records'
     depends_on = tuple()
@@ -111,6 +113,9 @@ class DAQReader(strax.Plugin):
 
         strax.baseline(records)
         strax.integrate(records)
+
+        # convert time to time in ns since unix epoch
+        records["time"] = records["time"] + self.config["run_start_time"] * 1e9
 
         if len(records):
             timespan_sec = (records[-1]['time'] - records[0]['time']) / 1e9

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -20,7 +20,7 @@ __all__ = ['DAQReader']
                  help="Number of readout threads producing strax data files"),
     strax.Option('erase', default=False, track=False,
                  help="Delete reader data after processing"),
-    strax.Option('compressor', default="blosc",
+    strax.Option('compressor', default="blosc", track=False,
                  help="Algorithm used for (de)compressing the live data"))
 class DAQReader(strax.Plugin):
     provides = 'raw_records'


### PR DESCRIPTION
I added a feature to read the compression method used for the live data and from the run-doc and pass that on to the DAQ-reader. Since for some of the runs do not have this in the run-doc, I set the default to compression method to blosc.

Also added some info on the eb_monitor collection to bootstrax although that is not related.