### PR TITLE
Update peak_processing.py

### DIFF
--- a/straxen/analyses/mpl_helpers.py
+++ b/straxen/analyses/mpl_helpers.py
@@ -1,0 +1,42 @@
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+
+
+def log_y(a=None, b=None, scalar_ticks=True, tick_at=None):
+    """Make the y axis use a log scale from a to b"""
+    plt.yscale('log')
+    if a is not None:
+        if b is None:
+            a, b = a[0], a[-1]
+        ax = plt.gca()
+        plt.ylim(a, b)
+        if scalar_ticks:
+            ax.yaxis.set_major_formatter(matplotlib.ticker.FormatStrFormatter('%g'))
+            ax.set_yticks(logticks(a, b, tick_at))
+
+
+def log_x(a=None, b=None, scalar_ticks=True, tick_at=None):
+    """Make the x axis use a log scale from a to b"""
+    plt.xscale('log')
+    if a is not None:
+        if b is None:
+            a, b = a[0], a[-1]
+        plt.xlim(a, b)
+        ax = plt.gca()
+        if scalar_ticks:
+            ax.xaxis.set_major_formatter(matplotlib.ticker.FormatStrFormatter('%g'))
+            ax.set_xticks(logticks(a, b, tick_at))
+
+
+def logticks(tmin, tmax=None, tick_at=None):
+    if tick_at is None:
+        tick_at = (1, 2, 5, 10)
+    a, b = np.log10([tmin, tmax])
+    a = np.floor(a)
+    b = np.ceil(b)
+    ticks = np.sort(np.unique(np.outer(
+        np.array(tick_at), 
+        10.**np.arange(a, b)).ravel()))
+    ticks = ticks[(tmin <= ticks) & (ticks <= tmax)]
+    return ticks

--- a/straxen/mini_analysis.py
+++ b/straxen/mini_analysis.py
@@ -89,7 +89,11 @@ def mini_analysis(requires=tuple(), hv_bokeh=False):
                         dtypes,
                         selection_str=kwargs['selection_str'],
                         time_range=kwargs['time_range'],
-                        time_selection=kwargs['time_selection'])
+                        time_selection=kwargs['time_selection'],
+                        # Arguments for new context, if needed
+                        config=kwargs.get('config'),
+                        register=kwargs.get('register'),
+                        storage=kwargs.get('storage', tuple()))
 
             # If user did not give time kwargs, but the function expects
             # a time_range, add them based on the time range of the data

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -243,8 +243,6 @@ class PeakPositions(strax.Plugin):
 
 @export
 @strax.takes_config(
-    strax.Option('s1_max_width', default=80,
-                 help="Maximum S1 50% area width [ns]"),
     strax.Option('s1_max_rise_time', default=70,
                  help="Maximum S1 rise time [ns]"),
     strax.Option('s1_min_coincidence', default=3,
@@ -257,14 +255,13 @@ class PeakClassification(strax.Plugin):
     provides = 'peak_classification'
     depends_on = ('peak_basics', 'tight_coincidence')
     dtype = [('type', np.int8, 'Classification of the peak.')]
-    __version__ = '0.0.3'
+    __version__ = '0.0.4'
 
     result = {}
     def compute(self, peaks):
         result = np.zeros(len(peaks), dtype=self.dtype)
 
         is_s1 = peaks['rise_time'] <= self.config['s1_max_rise_time']
-        is_s1 &= peaks['range_50p_area'] <= self.config['s1_max_width']
         is_s1 &= peaks['tight_coincidence'] >= self.config['s1_min_coincidence']
         result['type'][is_s1] = 1
 
@@ -372,18 +369,18 @@ class TightCoincidence(strax.LoopPlugin):
             w = r['data'][h['left']:h['right']]
             result[i] = np.argmax(w)
         return result
-    
+
     def compute(self, records, peaks):
         r = records
         p = peaks
         hits = strax.find_hits(r)
 
         hit_max_times = np.sort(
-            hits['time'] 
+            hits['time']
             + hits['dt'] * self.hit_max_sample(records, hits))
 
         peak_max_times = (
-            peaks['time'] 
+            peaks['time']
             + np.argmax(peaks['data'], axis=1) * peaks['dt'])
 
         tight_coin = self.get_tight_coin(

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -267,7 +267,7 @@ class PeakClassification(strax.Plugin):
     depends_on = ('peak_basics','tight_coincidence')
 
     # Numpy datatype of the output
-    dtype = straxen.PeakClassification.dtype
+    dtype = [('type', np.int8, 'Classification of the peak.')]
 
     # Version of the plugin. Increment this if you change the algorithm.
     __version__ = '0.0.2'

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -243,8 +243,6 @@ class PeakPositions(strax.Plugin):
 
 @export
 @strax.takes_config(
-    strax.Option('s1_max_width', default=80,
-                 help="Maximum S1 50% area width [ns]"),
     strax.Option('s1_max_rise_time', default=70,
                  help="Maximum S1 rise time [ns]"),
     strax.Option('s1_min_coincidence', default=3,
@@ -257,14 +255,13 @@ class PeakClassification(strax.Plugin):
     provides = 'peak_classification'
     depends_on = ('peak_basics', 'tight_coincidence')
     dtype = [('type', np.int8, 'Classification of the peak.')]
-    __version__ = '0.0.3'
+    __version__ = '0.0.4'
 
     result = {}
     def compute(self, peaks):
         result = np.zeros(len(peaks), dtype=self.dtype)
 
         is_s1 = peaks['rise_time'] <= self.config['s1_max_rise_time']
-        is_s1 &= peaks['range_50p_area'] <= self.config['s1_max_width']
         is_s1 &= peaks['tight_coincidence'] >= self.config['s1_min_coincidence']
         result['type'][is_s1] = 1
 
@@ -375,18 +372,18 @@ class TightCoincidence(strax.LoopPlugin):
             w = r['data'][h['left']:h['right']]
             result[i] = np.argmax(w)
         return result
-    
+
     def compute(self, records, peaks):
         r = records
         p = peaks
         hits = strax.find_hits(r)
 
         hit_max_times = np.sort(
-            hits['time'] 
+            hits['time']
             + hits['dt'] * self.hit_max_sample(records, hits))
 
         peak_max_times = (
-            peaks['time'] 
+            peaks['time']
             + np.argmax(peaks['data'], axis=1) * peaks['dt'])
 
         tight_coin = self.get_tight_coin(


### PR DESCRIPTION
Implementation of a new Peak classification algorithm similar to the one used in pax and based on the rise time/ tight coincidence variables of the peak. I added two new variables in the "PeakBasics" plugin (rise_time and range_90p_area) and a new plugin "TightCoincidence" to compute the tight coincidence variable. Both are used in the new version of the "PeakClassification" plugin. You can see below a comparison between the current strax classification plugin and the pax-like peak classification using background data. As we can, with the current classification peaks corresponding to Single Electron (SE) are identified as S2, S1 and unknown peaks... But with the pax-like classification, they are properly tagged as S2 signal.

![pax_like_vs_default_PC_background_data](https://user-images.githubusercontent.com/47146279/70517886-a4c9dd00-1b39-11ea-820e-033932595fb7.png)

We test the validity of this new peak classification with the [Peak validation notebook using the WFsim](https://github.com/XENONnT/analysiscode/tree/master/PeakFinderTest) and we get the following S1 acceptance comparison between the current classification and my pax-like classification:

![acceptance_comparison](https://user-images.githubusercontent.com/47146279/70611897-3a32a300-1c06-11ea-9ffe-b0b0d38ece17.png)

In the end the result is pretty clear:

<img width="607" alt="Comparison_results" src="https://user-images.githubusercontent.com/47146279/70522079-b662b300-1b40-11ea-9a26-4f4a4d04f419.png">
