### PR TITLE
Matplotlib waveform plotter

### DIFF
--- a/straxen/analyses/__init__.py
+++ b/straxen/analyses/__init__.py
@@ -1,2 +1,4 @@
-from . import waveform_plots
 from . import quick_checks
+from . import records_matrix
+from . import waveform_plot
+from . import holoviews_waveform_display

--- a/straxen/analyses/holoviews_waveform_display.py
+++ b/straxen/analyses/holoviews_waveform_display.py
@@ -1,7 +1,9 @@
-import bokeh.models
-from holoviews.operation import datashader
-import holoviews as hv
-import holoviews.streams
+"""Dynamic holoviews-based waveform display
+
+Note imports are inside function, to keep 'import straxen'
+free of holoviews.
+"""
+
 import numpy as np
 import pandas as pd
 
@@ -14,16 +16,19 @@ def seconds_from(t, t_reference):
 
 # Custom wheel zoom tool that only zooms in one dimension
 def x_zoom_wheel():
+    import bokeh.models
     return bokeh.models.WheelZoomTool(dimensions='width')
 
 
 @straxen.mini_analysis(requires=['records'], hv_bokeh=True)
-def plot_pmt_pattern(*, records, to_pe, array='bottom'):
+def hvdisp_plot_pmt_pattern(*, records, to_pe, array='bottom'):
     """Plot a PMT array, with colors showing the intensity
     of light observed in the time range
 
     :param array: 'top' or 'bottom', array to show
     """
+    import holoviews as hv
+
     pmts = straxen.pmt_positions()
     areas = np.bincount(records['channel'],
                         weights=records['area'] * to_pe[records['channel']],
@@ -62,6 +67,8 @@ def plot_pmt_pattern(*, records, to_pe, array='bottom'):
 def _records_to_points(*, records, to_pe, t_reference):
     """Return (holoviews.Points, time_stream) corresponding to records
     """
+    import holoviews as hv
+
     areas_r = records['area'] * to_pe[records['channel']]
 
     # Create dataframe with record metadata
@@ -85,8 +92,8 @@ def _records_to_points(*, records, to_pe, t_reference):
 
 
 @straxen.mini_analysis(requires=['records'], hv_bokeh=True)
-def plot_records_2d(records, to_pe,
-                    t_reference, width=600, time_stream=None):
+def hvdisp_plot_records_2d(records, to_pe,
+                           t_reference, width=600, time_stream=None):
     """Plot records in a dynamic 2D histogram of (time, pmt)
 
     :param width: Plot width in pixels
@@ -94,6 +101,9 @@ def plot_records_2d(records, to_pe,
     we assume records is already converted to points (which hopefully
     is what the stream is derived from)
     """
+    import holoviews as hv
+    import holoviews.operation.datashader
+
     if time_stream is None:
         # Records are still a dataframe, convert it to points
         records, time_stream = _records_to_points(
@@ -101,8 +111,8 @@ def plot_records_2d(records, to_pe,
 
     # TODO: weigh by area?
 
-    return datashader.dynspread(
-            datashader.datashade(
+    return hv.operation.datashader.dynspread(
+            hv.operation.datashader.datashade(
                 records,
                 y_range=(0, straxen.n_tpc_pmts),
                 streams=[time_stream])).opts(
@@ -115,7 +125,7 @@ def plot_records_2d(records, to_pe,
 @straxen.mini_analysis(
     requires=['peaks', 'peak_classification', 'peak_basics'],
     hv_bokeh=True)
-def plot_peak_waveforms(
+def hvdisp_plot_peak_waveforms(
         t_reference,
         time_range,
         peaks,
@@ -128,6 +138,8 @@ def plot_peak_waveforms(
     :param time_dim: Holoviews time dimension; will create new one
     if not provided.
     """
+    import holoviews as hv
+
     if show_largest is not None and len(peaks) > show_largest:
         show_i = np.argsort(peaks['area'])[-show_largest::]
         peaks = peaks[show_i]
@@ -195,11 +207,13 @@ def waveform_display(
 
     :param width: Plot width in pixels
     """
+    import holoviews as hv
+
     records_points, time_stream = _records_to_points(records=records,
                                                      to_pe=to_pe,
                                                      t_reference=t_reference)
 
-    time_v_channel = context.plot_records_2d(
+    time_v_channel = context.hvdisp_plot_records_2d(
         run_id=run_id, to_pe=to_pe,
         records=records_points,
         width=width,
@@ -214,7 +228,7 @@ def waveform_display(
     array_plot = {
         array: hv.DynamicMap(
             _range_plot(
-                context.plot_pmt_pattern,
+                context.hvdisp_plot_pmt_pattern,
                 run_id=run_id, to_pe=to_pe,
                 records=records,
                 full_time_range=time_range,
@@ -226,7 +240,7 @@ def waveform_display(
 
     peak_wvs = hv.DynamicMap(
         _range_plot(
-            context.plot_peak_waveforms,
+            context.hvdisp_plot_peak_waveforms,
             run_id=run_id,
             width=width,
             full_time_range=time_range,

--- a/straxen/analyses/mpl_helpers.py
+++ b/straxen/analyses/mpl_helpers.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
@@ -40,3 +42,9 @@ def logticks(tmin, tmax=None, tick_at=None):
         10.**np.arange(a, b)).ravel()))
     ticks = ticks[(tmin <= ticks) & (ticks <= tmax)]
     return ticks
+
+
+def quiet_tight_layout():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        plt.tight_layout()

--- a/straxen/analyses/records_matrix.py
+++ b/straxen/analyses/records_matrix.py
@@ -1,0 +1,57 @@
+import numba
+import numpy as np
+
+import strax
+import straxen
+
+
+@straxen.mini_analysis(requires=('records',),
+                       warn_beyond_sec=5e-3,
+                       default_time_selection='touching')
+def records_matrix(records, time_range, seconds_range, to_pe):
+    """Return (wv_matrix, times, pms)
+      - wv_matrix: (n_samples, n_pmt) array with per-PMT waveform intensity in PE/ns
+      - times: time labels in seconds (corr. to rows)
+      - pmts: PMT numbers (corr. to columns)
+    Both times and pmts have one extra element.
+
+    Example:
+        wvm, ts, ys = st.records_matrix(run_id, seconds_range=(1., 1.00001))
+        plt.pcolormesh(ts, ys, wvm.T,
+                       norm=matplotlib.colors.LogNorm())
+        plt.colorbar(label='Intensity [PE / ns]')
+    """
+    if len(records):
+        dt = records[0]['dt']
+    else:
+        dt = 10  # But it doesn't matter, nothing will be plotted anyway
+
+    wvm = _records_to_matrix(
+        records,
+        t0=time_range[0],
+        window=time_range[1] - time_range[0])
+    wvm = wvm.astype(np.float32) * to_pe.reshape(1, -1) / dt
+
+    # Note + 1, so data for sample 0 will range from 0-1 in plot
+    ts = (np.arange(wvm.shape[0] + 1) * dt / int(1e9) + seconds_range[0])
+    ys = np.arange(wvm.shape[1] + 1)
+
+    return wvm, ts, ys
+
+
+@numba.njit
+def _records_to_matrix(records, t0, window, n_channels=straxen.n_tpc_pmts, dt=10):
+    n_samples = window // dt
+    y = np.zeros((n_samples, n_channels),
+                 dtype=np.int16)
+
+    for r in records:
+        if r['channel'] > n_channels:
+            continue
+        (r_start, r_end), (y_start, y_end) = strax.overlap_indices(
+            r['time'] // dt, r['length'],
+            t0 // dt, n_samples)
+        # += is paranoid, data in individual channels should not overlap
+        # but... https://github.com/AxFoundation/strax/issues/119
+        y[y_start:y_end, r['channel']] += r['data'][r_start:r_end]
+    return y

--- a/straxen/analyses/waveform_plot.py
+++ b/straxen/analyses/waveform_plot.py
@@ -9,7 +9,8 @@ from mpl_toolkits.axes_grid1 import inset_locator
 
 
 @straxen.mini_analysis()
-def plot_waveform(context, deep=False, show_largest=100, figsize=None, **kwargs):
+def plot_waveform(context, deep=False, show_largest=100, figsize=None,
+                  cbar_loc='upper right', **kwargs):
     """Plot the sum waveform and optionally per-PMT waveforms
 
     :param deep: If True, show per-PMT waveform matrix under sum waveform
@@ -17,13 +18,13 @@ def plot_waveform(context, deep=False, show_largest=100, figsize=None, **kwargs)
     :param figsize: Matplotlib figure size for the plot
     """
     if figsize is None:
-        figsize = (10, 8 if deep else 4)
+        figsize = (10, 6 if deep else 4)
 
     if not deep:
         context.plot_peaks(**kwargs, show_largest=show_largest, figsize=figsize)
 
     else:
-        f, axes = plt.subplots(2, 1, figsize=figsize)
+        f, axes = plt.subplots(2, 1, figsize=figsize, gridspec_kw={'height_ratios': [1, 2]})
 
         plt.sca(axes[0])
         context.plot_peaks(**kwargs, show_largest=show_largest,
@@ -31,7 +32,9 @@ def plot_waveform(context, deep=False, show_largest=100, figsize=None, **kwargs)
                            xaxis=False)
 
         plt.sca(axes[1])
-        context.plot_records_matrix(**kwargs, single_figure=False)
+        context.plot_records_matrix(**kwargs,
+                                    cbar_loc=cbar_loc,
+                                    single_figure=False)
 
         quiet_tight_layout()
         plt.subplots_adjust(hspace=0)
@@ -149,6 +152,7 @@ def seconds_range_xaxis(seconds_range):
 
     plt.xticks(ticks=xticks, labels=labels, rotation=90)
     plt.xlim(*seconds_range)
+    plt.xlabel("Time since run start [sec]")
 
 
 def plot_peak(p, t0=None, **kwargs):

--- a/straxen/analyses/waveform_plot.py
+++ b/straxen/analyses/waveform_plot.py
@@ -1,0 +1,180 @@
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+
+import strax
+import straxen
+from .mpl_helpers import quiet_tight_layout
+from mpl_toolkits.axes_grid1 import inset_locator
+
+
+@straxen.mini_analysis()
+def plot_waveform(context, deep=False, show_largest=100, figsize=None, **kwargs):
+    """Plot the sum waveform and optionally per-PMT waveforms
+
+    :param deep: If True, show per-PMT waveform matrix under sum waveform
+    :param show_largest: Show only the largest show_largest peaks.
+    :param figsize: Matplotlib figure size for the plot
+    """
+    if figsize is None:
+        figsize = (10, 8 if deep else 4)
+
+    if not deep:
+        context.plot_peaks(**kwargs, show_largest=show_largest, figsize=figsize)
+
+    else:
+        f, axes = plt.subplots(2, 1, figsize=figsize)
+
+        plt.sca(axes[0])
+        context.plot_peaks(**kwargs, show_largest=show_largest,
+                           single_figure=False,
+                           xaxis=False)
+
+        plt.sca(axes[1])
+        context.plot_records_matrix(**kwargs, single_figure=False)
+
+        quiet_tight_layout()
+        plt.subplots_adjust(hspace=0)
+
+
+@straxen.mini_analysis(
+    requires=('peaks', 'peak_classification'),
+    default_time_selection='touching',
+    warn_beyond_sec=60)
+def plot_peaks(peaks, seconds_range, t_reference, show_largest=100,
+               single_figure=True, figsize=(10, 4), xaxis=True):
+    if single_figure:
+        plt.figure(figsize=figsize)
+    plt.axhline(0, c='k', alpha=0.2)
+
+    peaks = peaks[np.argsort(-peaks['area'])[:show_largest]]
+    peaks = strax.sort_by_time(peaks)
+
+    for p in peaks:
+        plot_peak(p,
+                  t0=t_reference,
+                  color={0: 'gray', 1: 'b', 2: 'g'}[p['type']])
+
+    if xaxis:
+        seconds_range_xaxis(seconds_range)
+    else:
+        plt.xticks([])
+    plt.xlim(*seconds_range)
+    plt.ylabel("Intensity [PE/ns]")
+    if single_figure:
+        plt.tight_layout()
+
+
+@straxen.mini_analysis()
+def plot_records_matrix(context, run_id,
+                        seconds_range,
+                        cbar_loc='upper right',
+                        single_figure=True, figsize=(10, 4),
+                        **kwargs):
+    if seconds_range is None:
+        raise ValueError("You must pass a time selection (e.g. seconds_range) to plot_records_matrix.")
+
+    if single_figure:
+        plt.figure(figsize=figsize)
+
+    wvm, ts, ys = context.records_matrix(run_id, **kwargs)
+
+    plt.pcolormesh(
+        ts, ys, wvm.T,
+        norm=matplotlib.colors.LogNorm(), vmin=1e-3,
+        cmap=plt.cm.inferno)
+    plt.xlim(*seconds_range)
+
+    ax = plt.gca()
+    seconds_range_xaxis(seconds_range)
+    ax.invert_yaxis()
+    plt.ylabel("PMT Number")
+
+    # Create a white box to place the color bar in
+    # See https://stackoverflow.com/questions/18211967
+    bbox = inset_locator.inset_axes(ax,
+                                    width="30%", height="22%",
+                                    loc=cbar_loc)
+    [bbox.spines[k].set_visible(False) for k in bbox.spines]
+    bbox.patch.set_facecolor((1, 1, 1, 0.9))
+    bbox.set_xticks([])
+    bbox.set_yticks([])
+
+    # Create the actual color bar
+    cax = inset_locator.inset_axes(bbox,
+                                   width='90%', height='20%',
+                                   loc='upper right')
+    plt.colorbar(cax=cax,
+                 label='Intensity [PE/ns]',
+                 orientation='horizontal')
+    cax.xaxis.set_major_formatter(matplotlib.ticker.FormatStrFormatter('%g'))
+
+    plt.sca(ax)
+
+    if single_figure:
+        quiet_tight_layout()
+
+
+def seconds_range_xaxis(seconds_range):
+    """Make a pretty time axis given seconds_range"""
+    plt.xlim(*seconds_range)
+    ax = plt.gca()
+    ax.ticklabel_format(useOffset=False)
+    xticks = plt.xticks()[0]
+    if not len(xticks):
+        return
+    xticks[0] = seconds_range[0]
+    xticks[-1] = seconds_range[-1]
+
+    # Format the labels
+    # I am not very proud of this code...
+    def chop(x):
+        return np.floor(x).astype(np.int)
+    xticks_ns = np.round(xticks * int(1e9)).astype(np.int)
+    sec = chop(xticks_ns // int(1e9))
+    ms = chop((xticks_ns % int(1e9)) // int(1e6))
+    us = chop((xticks_ns % int(1e6)) // int(1e3))
+    samples = chop((xticks_ns % int(1e3)) // 10)
+
+    labels = [str(sec[i]) for i in range(len(xticks))]
+    print_samples = np.any(samples != samples[0])
+    print_us = print_samples | np.any(us != us[0])
+    print_ms = print_us | np.any(ms != ms[0])
+    if print_ms:
+        labels = [l + f'.{ms[i]:03}' for i, l in enumerate(labels)]
+        if print_us:
+            labels = [l + f' \\textbf{{{us[i]:03}}}' for i, l in enumerate(labels)]
+            if print_samples:
+                labels = [l + f' {samples[i]:02}' for i, l in enumerate(labels)]
+
+    plt.xticks(ticks=xticks, labels=labels, rotation=90)
+    plt.xlim(*seconds_range)
+
+
+def plot_peak(p, t0=None, **kwargs):
+    x, y = time_and_samples(p, t0=t0)
+    kwargs.setdefault('linewidth', 1)
+    plt.plot(x, y,
+             drawstyle='steps-pre',
+             **kwargs)
+    kwargs['alpha'] = kwargs.get('alpha', 1) * 0.2
+    if 'linewidth' in kwargs:
+        del kwargs['linewidth']
+    plt.fill_between(x, 0, y, step='pre', linewidth=0, **kwargs)
+
+
+def time_and_samples(p, t0=None):
+    """Return (x, y) numpy arrays for plotting the waveform data in p
+    using 'steps-pre'.
+
+    Where x is the time since t0 in seconds (or another time_scale),
+      and y is intensity in PE / ns.
+    :param p: Peak or other similar strax data type
+    :param t0: Zero of time in ns since unix epoch
+    """
+    n = p['length']
+    if t0 is None:
+        t0 = p['time']
+    x = ((p['time'] - t0) + np.arange(n + 1) * p['dt']) / int(1e9)
+    y = p['data'][:n] / p['dt']
+    return x, np.concatenate([[y[0]], y])

--- a/straxen/analyses/waveform_plot.py
+++ b/straxen/analyses/waveform_plot.py
@@ -146,7 +146,8 @@ def seconds_range_xaxis(seconds_range):
     if print_ms:
         labels = [l + f'.{ms[i]:03}' for i, l in enumerate(labels)]
         if print_us:
-            labels = [l + f' \\textbf{{{us[i]:03}}}' for i, l in enumerate(labels)]
+            labels = [l + r' $\bf{' + f'{us[i]:03}' + '}$'
+                      for i, l in enumerate(labels)]
             if print_samples:
                 labels = [l + f' {samples[i]:02}' for i, l in enumerate(labels)]
 

--- a/straxen/mini_analysis.py
+++ b/straxen/mini_analysis.py
@@ -25,8 +25,10 @@ The function takes the same selection arguments as context.get_array:
 _hv_bokeh_initialized = False
 
 @export
-def mini_analysis(requires=tuple(), hv_bokeh=False):
-
+def mini_analysis(requires=tuple(),
+                  hv_bokeh=False,
+                  warn_beyond_sec=None,
+                  default_time_selection='touching'):
     def decorator(f):
         parameters = inspect.signature(f).parameters
 
@@ -34,6 +36,7 @@ def mini_analysis(requires=tuple(), hv_bokeh=False):
             # Validate arguments
             known_kwargs = (
                 'time_range seconds_range time_within time_selection '
+                'ignore_time_warning '
                 'selection_str t_reference to_pe config').split()
             for k in kwargs:
                 if k not in known_kwargs and k not in parameters:
@@ -64,59 +67,86 @@ def mini_analysis(requires=tuple(), hv_bokeh=False):
                 targets=requires,
                 **{k: kwargs.get(k)
                    for k in ('time_range seconds_range time_within'.split())})
-            kwargs.setdefault('time_selection', 'fully_contained')
+            kwargs.setdefault('time_selection', default_time_selection)
             kwargs.setdefault('selection_str', None)
 
-            if ('t_reference' in parameters
-                    and kwargs.get('t_reference') is None):
-                kwargs['t_reference'] = context.estimate_run_start(
-                    run_id, requires)
+            kwargs['t_reference'] = context.estimate_run_start(
+                run_id, requires)
 
-            # Load required data
-            deps_by_kind = strax.group_by_kind(
-                requires, context=context, require_time=False)
-            for dkind, dtypes in deps_by_kind.items():
-                if dkind in kwargs:
-                    # Already have data, just apply cuts
-                    kwargs[dkind] = context.apply_selection(
-                        kwargs[dkind],
-                        selection_str=kwargs['selection_str'],
-                        time_range=kwargs['time_range'],
-                        time_selection=kwargs['time_selection'])
+            if warn_beyond_sec is not None and not kwargs.get('ignore_time_warning'):
+                tr = kwargs['time_range']
+                if tr is None:
+                    sec_requested = float('inf')
                 else:
-                    kwargs[dkind] = context.get_array(
-                        run_id,
-                        dtypes,
-                        selection_str=kwargs['selection_str'],
-                        time_range=kwargs['time_range'],
-                        time_selection=kwargs['time_selection'],
-                        # Arguments for new context, if needed
-                        config=kwargs.get('config'),
-                        register=kwargs.get('register'),
-                        storage=kwargs.get('storage', tuple()))
+                    sec_requested = (tr[1] - tr[0]) / int(1e9)
+                if sec_requested > warn_beyond_sec:
+                    tr_str = "the entire run" if tr is None else f"{sec_requested} seconds"
+                    raise ValueError(
+                        f"The author of this mini analysis recommends "
+                        f"not requesting more than {warn_beyond_sec} seconds. "
+                        f"You are requesting {tr_str}. If you wish to proceed, "
+                        "pass ignore_time_warning = True.")
 
-            # If user did not give time kwargs, but the function expects
-            # a time_range, add them based on the time range of the data
-            # (if there is no data, otherwise give (NaN, NaN))
-            if kwargs.get('time_range') is None:
+            # Load required data, if any
+            if len(requires):
+                deps_by_kind = strax.group_by_kind(
+                    requires, context=context, require_time=False)
+                for dkind, dtypes in deps_by_kind.items():
+                    if dkind in kwargs:
+                        # Already have data, just apply cuts
+                        kwargs[dkind] = context.apply_selection(
+                            kwargs[dkind],
+                            selection_str=kwargs['selection_str'],
+                            time_range=kwargs['time_range'],
+                            time_selection=kwargs['time_selection'])
+                    else:
+                        kwargs[dkind] = context.get_array(
+                            run_id,
+                            dtypes,
+                            selection_str=kwargs['selection_str'],
+                            time_range=kwargs['time_range'],
+                            time_selection=kwargs['time_selection'],
+                            # Arguments for new context, if needed
+                            config=kwargs.get('config'),
+                            register=kwargs.get('register'),
+                            storage=kwargs.get('storage', tuple()))
+
+                # If user did not give time kwargs, but the function expects
+                # a time_range, try to add one based on the time range of the data
                 base_dkind = list(deps_by_kind.keys())[0]
                 x = kwargs[base_dkind]
-                x0 = x.iloc[0] if isinstance(x, pd.DataFrame) else x[0]
-                kwargs['time_range'] = (
-                    (x0['time'], strax.endtime(x).max()) if len(x)
-                    else (float('nan'), float('nan')))
+                if len(x) and kwargs.get('time_range') is None:
+                    x0 = x.iloc[0] if isinstance(x, pd.DataFrame) else x[0]
+                    try:
+                        kwargs.setdefault('time_range', (x0['time'],
+                                                         strax.endtime(x).max()))
 
-            # Pass only the arguments the function wants
-            to_pass = dict()
-            for k in parameters:
-                if k == 'run_id':
-                    to_pass['run_id'] = run_id
-                elif k == 'context':
-                    to_pass['context'] = context
-                elif k in kwargs:
-                    to_pass[k] = kwargs[k]
-                # If we get here, let's hope the function defines a default...
+                    except AttributeError:
+                        # If x is a holoviews dataset, this will fail.
+                        pass
 
+            if 'seconds_range' in parameters:
+                if kwargs.get('time_range') is None:
+                    scr = None
+                else:
+                    scr = tuple([(t - kwargs['t_reference']) / int(1e9)
+                                 for t in kwargs['time_range']])
+                kwargs.setdefault('seconds_range', scr)
+
+            kwargs.setdefault('run_id', run_id)
+            kwargs.setdefault('context', context)
+
+            if 'kwargs' in parameters:
+                # Likely this will be passed to another mini-analysis
+                to_pass = kwargs
+                # Do not pass time_range and seconds_range both (unless explicitly requested)
+                # strax does not like that
+                if 'seconds_range' in to_pass and not 'seconds_range' in parameters:
+                    del to_pass['seconds_range']
+            else:
+                # Pass only arguments the function wants
+                to_pass = {k: v for k, v in kwargs.items()
+                           if k in parameters}
             return f(**to_pass)
 
         wrapped_f.__name__ = f.__name__


### PR DESCRIPTION
This adds the mini analysis `plot_waveform` to straxen contexts, which produces a static matplotlib waveform image. It only contains basic elements currently, there is much more we could add (peak labels, insets with hitpatterns, etc).

I hope this will be a useful alternative to the existing holoviews-based display (`st.waveform_display`), especially for generating static image plots for notes and presentations. I imagine it is also easier to customize if, like me, you are much more familiar with matplotlib than holoviews.

Example:
```python 
st.plot_waveform('180215_1029', seconds_range=(50.27050, 50.27075))
```

![example_wv](https://user-images.githubusercontent.com/4354311/71557444-9559f780-2a46-11ea-8747-810d8bff72f6.png)

This only requires the availability of `peaks`, so we should be able to run it from notebooks in the analysis facility. 

If, however, you do have `records` available for a dataset, you can pass `deep=True` to view the per-PMT waveforms:
 ```python
st.plot_waveform('180215_1029', seconds_range=(50.270450, 50.27075), deep=True)
```

![example_wv_deep](https://user-images.githubusercontent.com/4354311/71557445-97bc5180-2a46-11ea-8005-22010f9e90de.png)

You can reposition the colorbar in the lower pane using the `cbar_loc` argument.

 If you want to get the matrix in the bottom plot directly for some other use, use the new mini_analysis `records_matrix`.
