### PR TITLE
Saturation correction from pax

### DIFF
--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -8,6 +8,11 @@ export, __all__ = strax.exporter()
 # Number of TPC PMTs. Hardcoded for now...
 n_tpc = 248
 
+# Fields added to saturation correction 
+rc_dtype = record_correction_dtype = [
+    (('Number of samples corrected', 'n_corrected'), np.uint16), \
+    (('Number of bits corrected data exceed int16 range', 'bit_shift'), np.uint16)]
+
 
 @export
 @strax.takes_config(

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -97,6 +97,8 @@ class PulseProcessing(strax.Plugin):
         for p in self.provides:
             if p.endswith('records'):
                 dtype[p] = strax.record_dtype(record_length)
+            if p == 'records':
+                dtype[p].extend(rc_dtype)
 
         dtype['veto_regions'] = strax.hit_dtype
         dtype['pulse_counts'] = pulse_count_dtype(n_tpc)


### PR DESCRIPTION
Like the correction updated at [pax 6.10.0](https://github.com/XENON1T/pax/pull/712), the same procedure can be applied to raw_records, from records onwards, `data` field is corrected from certain saturation effects.

This is still a working progress. Also, a part of the changes needs to be done in strax upon implementation.