### PR TITLE
Store proximity to nearby peaks

### DIFF
--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -23,7 +23,7 @@ export, __all__ = strax.exporter()
                       'triggering peak'),
 )
 class Events(strax.OverlapWindowPlugin):
-    depends_on = ['peak_basics', 'n_competing']
+    depends_on = ['peak_basics', 'peak_proximity']
     data_kind = 'events'
     dtype = [
         ('event_number', np.int64, 'Event number in this dataset'),
@@ -72,7 +72,7 @@ class EventBasics(strax.LoopPlugin):
     depends_on = ('events',
                   'peak_basics',
                   'peak_positions',
-                  'n_competing')
+                  'peak_proximity')
 
     def infer_dtype(self):
         dtype = [(('Number of peaks in the event',


### PR DESCRIPTION
This renames NCompeting to PeakProximity, and adds fields for the time to the nearest, previous, and next peak.

This would make selecting isolated peaks a lot easier (e.g. for single electron studies @Jianyu010):
```python
df = st.get_df(run_id, ['peaks_basics', 'peak_proximity'],
               selection_str='t_to_nearest_peak > 10e3')
```

The `t_to_nearest_peak` etc. fields have a (configurable) maximum value of 1 second. So if a peak has no other peaks within 5 minutes, `t_to_nearest_peak` will still be 1 second. This limits the amount of lookback/lookahead we need to do, which is good for online processing.