### PR TITLE
Natural breaks clustering

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -15,7 +15,7 @@ common_opts = dict(
         'reader.ini.name', 'tags.name',
         'start', 'end', 'livetime',
         'trigger.events_built'),
-    check_available=('raw_records', 'records', 'peaks',
+    check_available=('raw_records', 'records', 'peaklets',
                      'events', 'event_info'))
 
 

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -16,8 +16,12 @@ export, __all__ = strax.exporter()
     strax.Option('peak_right_extension', default=30,
                  help="Include this many ns right of hits in peaks"),
     strax.Option('peak_min_pmts', default=2,
-                 help="Minimum contributing PMTs needed to define a peak"),
+                 help="Minifnmum contributing PMTs needed to define a peak"),
     strax.Option('peak_split_gof_threshold',
+                 # See https://xe1t-wiki.lngs.infn.it/doku.php?id=
+                 # xenon:xenonnt:analysis:strax_clustering_classification
+                 # #natural_breaks_splitting
+                 # for more information
                  default=(
                      None,  # Reserved
                      ((0.5, 1), (3.5, 0.25)),
@@ -89,7 +93,9 @@ class Peaklets(strax.Plugin):
         strax.sum_waveform(peaklets, r, self.to_pe)
         strax.compute_widths(peaklets)
 
-        # Split peaks using natural breaks
+        # Split peaks using low-split natural breaks;
+        # see https://github.com/XENONnT/straxen/pull/45
+        # and https://github.com/AxFoundation/strax/pull/225
         peaklets = strax.split_peaks(
             peaklets, r, self.to_pe,
             algorithm='natural_breaks',


### PR DESCRIPTION
This changes the splitting algorithm for peaklets from a natural minimum finder to low-split natural breaks, described in https://github.com/AxFoundation/strax/pull/225.

This should lead to a better separation of the Kr S1 peaks, while Joey's peak merging (https://github.com/XENONnT/straxen/pull/36) should prevent the splitting of low-energy S2s.

The goodness of split threshold is a function of area and rise time. Basically there are two thresholds: one for S1s (low rise time) and another for S2s (high rise time), which we interpolate between using a sigmoid function.

The thresholds were chosen by this procedure:
  * Simulating 'bare' S1 and S2 peaks, without PMT afterpulses or single electrons.
  * Disabling essentially all peak splitting
  * Find out how the natural breaks goodness of split is distributed vs area. Choose by hand a curve that lies comfortably above the distribution.

More details and tests will follow in a note.