### PR TITLE
Placeholder InterpolatingMap

### DIFF
--- a/straxen/itp_map.py
+++ b/straxen/itp_map.py
@@ -139,11 +139,12 @@ class InterpolatingMap:
                 # and always return a single value
                 def itp_fun(positions):
                     return map_data * np.ones_like(positions)
-            if array_valued:
-                map_data = map_data.reshape((-1, map_data.shape[-1]))
-            itp_fun = InterpolateAndExtrapolate(points=np.array(cs),
-                                                values=np.array(map_data),
-                                                array_valued=array_valued)
+            else:
+                if array_valued:
+                    map_data = map_data.reshape((-1, map_data.shape[-1]))
+                itp_fun = InterpolateAndExtrapolate(points=np.array(cs),
+                                                    values=np.array(map_data),
+                                                    array_valued=array_valued)
 
             self.interpolators[map_name] = itp_fun
 

--- a/straxen/itp_map.py
+++ b/straxen/itp_map.py
@@ -138,7 +138,7 @@ class InterpolatingMap:
                 # 0 D -- placeholder maps which take no arguments
                 # and always return a single value
                 def itp_fun(positions):
-                    return map_data * np.ones_like(positions)
+                    return np.array([map_data])
             else:
                 if array_valued:
                     map_data = map_data.reshape((-1, map_data.shape[-1]))


### PR DESCRIPTION
This fixed a bug(?) in InterpolatingMap to allow it to accept 0d single-valued placeholder maps.

  1. Skip "InterpolateAndExtrapolate" when the input is a placeholder.
  2. Output of placeholder function should be single-valued, though the input is multi-dimensional (position)