### PR TITLE
Add functionality to change rr_length and max-mailboxes

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -86,10 +86,14 @@ parser.add_argument('--cores', type=int, default=25,
                          "Set to -1 for all available cores")
 parser.add_argument('--target', default='event_info',
                     help="Strax data type name that should be produced")
+# TODO change to action
 parser.add_argument('--delete_live', type=str,
                     # TODO -> set this to yes after testing
                     default='no',
                     help="Delete live_data after succesful processing of the run [yes/no]")
+parser.add_argument('--max_messages', type=int,
+                    default=4,
+                    help="number of max mailbox messages")
 
 actions = parser.add_mutually_exclusive_group()
 actions.add_argument('--process', type=int, metavar='NUMBER',
@@ -107,7 +111,7 @@ args = parser.parse_args()
 # Configuration
 ##
 
-print(f'---\nTEST VERSION 0.2.3\n---')
+print(f'---\nTEST VERSION 0.2.5\n---')
 
 # Runs database
 run_db_username = os.environ['MONGO_RDB_USERNAME']
@@ -180,7 +184,7 @@ assert timeouts['bootstrax_presumed_dead'] > wait_diskspace_dt, "wait_diskspace_
 # Fields in the run docs that bootstrax uses
 bootstrax_projection = f"name start end number bootstrax " \
                        f"data.host data.type data.location " \
-                       f"ini.processing_threads ini.compressor".split()
+                       f"ini.processing_threads ini.compressor ini.strax_fragment_length".split()
 
 # Filename for temporary storage of the exception
 # This is used to communicate the exception from the strax child process
@@ -225,6 +229,7 @@ def new_context():
         **straxen.contexts.common_opts)
     st.context_config['allow_multiprocess'] = True if args.cores > 1 else False
     st.context_config['allow_shm'] = True if args.cores > 1 else False
+    st.context_config['max_messages'] = args.max_messages
     return st
 
 
@@ -365,7 +370,7 @@ def update_usage(pid_process, run_number):
     mem_tot = virtual_memory()
     disk = disk_usage(output_folder)
     terabyte_to_byte = 1024.0 ** 4
-#   current_process =  multiprocessing.current_process()
+    #   current_process =  multiprocessing.current_process()
     usage = {'run': int(run_number),
              'host': hostname,
              'time': now(),
@@ -436,7 +441,7 @@ def sufficient_diskspace():
                   f'on {hostname}. Waiting {wait_diskspace_dt} s ({i}th iteration')
             time.sleep(wait_diskspace_dt)
             send_heartbeat()
-    assert False, "No diskspace to write to"
+    raise RuntimeError("No diskspace to write to")
 
 
 ##
@@ -599,7 +604,7 @@ def delete_live_data(live_data_path):
 ##
 
 def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
-              run_start_time, debug=False):
+              run_start_time, samples_per_record, debug=False):
     if args.cores > 1:
         # Clear the swap memory used by npshmmex
         npshmex.shm_clear()
@@ -617,9 +622,8 @@ def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
                     config=dict(input_dir=input_dir,
                                 compressor=compressor,
                                 run_start_time=run_start_time,
-                                n_readout_threads=n_readout_threads,
-                                rr_max_messages=args.max_messages_raw_records,
-                                r_max_messages=args.max_messages_records),
+                                rr_samples=samples_per_record,
+                                n_readout_threads=n_readout_threads),
                     max_workers=args.cores)
 
         if args.profile.lower() == 'false':
@@ -703,10 +707,17 @@ def process_run(rd, send_heartbeats=True):
         except Exception as e:
             fail(f"Could not find start in datetime.datetime object: {str(e)}")
 
+        try:
+            samples_per_record = int(rd['ini']['strax_fragment_length'] / 2)  # note that value in rd in bytes
+            if not samples_per_record == 110:
+                print(f'Samples_per_record = {samples_per_record}')
+        except Exception as e:
+            fail(f"Could not find ini.strax_fragment_length in database: {str(e)}")
+
         strax_proc = multiprocessing.Process(
             target=run_strax,
             args=(run_id, loc, target, n_readout_threads, compressor,
-                  run_start_time, args.debug))
+                  run_start_time, samples_per_record, args.debug))
 
         t0 = now()
         info = dict(started_processing=t0)
@@ -718,7 +729,7 @@ def process_run(rd, send_heartbeats=True):
 
         while True:
             if send_heartbeats:
-                update_usage(pid_process = pid_process, run_number = run_id)
+                update_usage(pid_process=pid_process, run_number=run_id)
                 send_heartbeat()
 
             ec = strax_proc.exitcode
@@ -753,11 +764,9 @@ def process_run(rd, send_heartbeats=True):
                 # (at least up to some fudge factor)
                 # Since chunks can be empty, and we don't want to crash,
                 # this has to be done with some care...
-                t_covered = timedelta(seconds=(
-                    max([x.get('last_endtime', 0)
-                         for x in md['chunks']])
-                    - min([x.get('first_time', float('inf'))
-                           for x in md['chunks']]))/1e9)
+                t_covered = timedelta(
+                    seconds=(max([x.get('last_endtime', 0) for x in md['chunks']]) -
+                             min([x.get('first_time', float('inf')) for x in md['chunks']])) / 1e9)
                 run_duration = rd['end'] - rd['start']
                 if not (0 < t_covered.seconds < float('inf')):
                     fail(f"Processed data covers {t_covered} sec")
@@ -778,12 +787,12 @@ def process_run(rd, send_heartbeats=True):
                 # exception retrieval. The actual error comes later.
                 log.info(f"Failure while procesing run {run_id}")
                 if osp.exists(exception_tempfile):
-                   with open(exception_tempfile, mode='r') as f:
-                       exc_info = f.read()
-                   if not exc_info:
-                       exc_info = '[No exception info known, exception file was empty?!]'
+                    with open(exception_tempfile, mode='r') as f:
+                        exc_info = f.read()
+                    if not exc_info:
+                        exc_info = '[No exception info known, exception file was empty?!]'
                 else:
-                   exc_info = "[No exception info known, exception file not found?!]"
+                    exc_info = "[No exception info known, exception file not found?!]"
                 fail(f"Strax exited with exit code {ec}. Exception info: {exc_info}")
 
             # TODO: Strax should update run db with metadata
@@ -835,15 +844,15 @@ def cleanup_db():
         send_heartbeat()
         bd = bs_coll.find_one_and_delete(
             {'time':
-             {'$lt': now(-timeouts['bootstrax_presumed_dead'])}})
+                 {'$lt': now(-timeouts['bootstrax_presumed_dead'])}})
         if bd is None:
             break
         log_warning(f"Bootstrax on host {bd['host']} presumed dead. Rest in peace")
 
     # Runs that say they are 'considering' or 'busy' but nothing happened for a while
     for state, timeout in [
-            ('considering', timeouts['max_considering_time']),
-            ('busy', timeouts['max_busy_time'])]:
+        ('considering', timeouts['max_considering_time']),
+        ('busy', timeouts['max_busy_time'])]:
         while True:
             send_heartbeat()
             rd = consider_run(


### PR DESCRIPTION
fix issue https://github.com/XENONnT/straxen/issues/58

In some run modes (such as LED runs) one might want to have other lengths of raw records than the 110 set as default by strax (https://github.com/AxFoundation/strax/blob/master/strax/dtypes.py#L13).

Hence, we need to read this from the runs database where it was set for redax. It was tested on runs 7010 and 7011 on eb1.

Additionally there are some minor features in bootstrax that are also added in this PR. (My appologies for all the automatic pycharm edits that are all over the place.)

The version number is something that will be removed soon when the testing is finished. 