### PR TITLE
Sort out subdetector outputs in DAQReader

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -111,7 +111,7 @@ args = parser.parse_args()
 # Configuration
 ##
 
-print(f'---\nTEST VERSION 0.2.8\n---')
+print(f'---\nTEST VERSION 0.2.9\n---')
 
 # Runs database
 run_db_username = os.environ['MONGO_RDB_USERNAME']
@@ -229,12 +229,12 @@ def new_context():
             runid_field='number',
             new_data_path=output_folder,
             mongo_dbname=dbname),
+        config=straxen.contexts.xnt_common_config,
         **context_opts)
     st.context_config['allow_multiprocess'] = True if args.cores > 1 else False
     st.context_config['allow_shm'] = True if args.cores > 1 else False
     st.context_config['max_messages'] = args.max_messages
     return st
-
 
 st = new_context()
 
@@ -626,7 +626,7 @@ def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
                                 run_start_time=run_start_time,
                                 record_length=samples_per_record,
                                 n_readout_threads=n_readout_threads,
-                                **straxen.contexts.xnt_common_config)
+                               )
             st.make(run_id, target,
                     config=strax_config,
                     max_workers=args.cores)

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -111,7 +111,7 @@ args = parser.parse_args()
 # Configuration
 ##
 
-print(f'---\nTEST VERSION 0.2.7\n---')
+print(f'---\nTEST VERSION 0.2.8\n---')
 
 # Runs database
 run_db_username = os.environ['MONGO_RDB_USERNAME']
@@ -216,8 +216,7 @@ else:
 
 
 context_opts = straxen.contexts.common_opts.copy()
-context_opts['register_all'].append(straxen.daqreader)
-
+context_opts['register'] = [straxen.DAQReader]
 
 def new_context():
     """Create strax context that can access the runs db"""

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -111,7 +111,7 @@ args = parser.parse_args()
 # Configuration
 ##
 
-print(f'---\nTEST VERSION 0.2.5\n---')
+print(f'---\nTEST VERSION 0.2.6\n---')
 
 # Runs database
 run_db_username = os.environ['MONGO_RDB_USERNAME']
@@ -184,7 +184,7 @@ assert timeouts['bootstrax_presumed_dead'] > wait_diskspace_dt, "wait_diskspace_
 # Fields in the run docs that bootstrax uses
 bootstrax_projection = f"name start end number bootstrax " \
                        f"data.host data.type data.location " \
-                       f"ini.processing_threads ini.compressor ini.strax_fragment_length".split()
+                       f"ini.processing_threads ini.compressor ini.strax_fragment_payload_bytes".split()
 
 # Filename for temporary storage of the exception
 # This is used to communicate the exception from the strax child process
@@ -619,10 +619,10 @@ def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
         def st_make():
             '''Run strax'''
             st.make(run_id, target,
-                    config=dict(input_dir=input_dir,
+                    config=dict(daq_input_dir=input_dir,
                                 compressor=compressor,
                                 run_start_time=run_start_time,
-                                rr_samples=samples_per_record,
+                                record_length=samples_per_record,
                                 n_readout_threads=n_readout_threads),
                     max_workers=args.cores)
 
@@ -708,11 +708,11 @@ def process_run(rd, send_heartbeats=True):
             fail(f"Could not find start in datetime.datetime object: {str(e)}")
 
         try:
-            samples_per_record = int(rd['ini']['strax_fragment_length'] / 2)  # note that value in rd in bytes
+            samples_per_record = int(rd['ini']['strax_fragment_payload_bytes'] / 2)  # note that value in rd in bytes
             if not samples_per_record == 110:
                 print(f'Samples_per_record = {samples_per_record}')
         except Exception as e:
-            fail(f"Could not find ini.strax_fragment_length in database: {str(e)}")
+            fail(f"Could not find ini.strax_fragment_payload_bytes in database: {str(e)}")
 
         strax_proc = multiprocessing.Process(
             target=run_strax,

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -111,7 +111,7 @@ args = parser.parse_args()
 # Configuration
 ##
 
-print(f'---\nTEST VERSION 0.2.6\n---')
+print(f'---\nTEST VERSION 0.2.7\n---')
 
 # Runs database
 run_db_username = os.environ['MONGO_RDB_USERNAME']
@@ -215,6 +215,10 @@ else:
     print(f'Not deleting live data because --delete_live = {args.delete_live}')
 
 
+context_opts = straxen.contexts.common_opts.copy()
+context_opts['register_all'].append(straxen.daqreader)
+
+
 def new_context():
     """Create strax context that can access the runs db"""
     # We use exactly the logic of straxen to access the runs DB;
@@ -226,7 +230,7 @@ def new_context():
             runid_field='number',
             new_data_path=output_folder,
             mongo_dbname=dbname),
-        **straxen.contexts.common_opts)
+        **context_opts)
     st.context_config['allow_multiprocess'] = True if args.cores > 1 else False
     st.context_config['allow_shm'] = True if args.cores > 1 else False
     st.context_config['max_messages'] = args.max_messages
@@ -618,12 +622,14 @@ def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
         # This way, it can also be run inside a wrapper to profile strax
         def st_make():
             '''Run strax'''
-            st.make(run_id, target,
-                    config=dict(daq_input_dir=input_dir,
-                                compressor=compressor,
+            strax_config = dict(daq_input_dir=input_dir,
+                                daq_compressor=compressor,
                                 run_start_time=run_start_time,
                                 record_length=samples_per_record,
-                                n_readout_threads=n_readout_threads),
+                                n_readout_threads=n_readout_threads,
+                                **straxen.contexts.xnt_common_config)
+            st.make(run_id, target,
+                    config=strax_config,
                     max_workers=args.cores)
 
         if args.profile.lower() == 'false':

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -34,7 +34,7 @@ xnt_common_config = dict(
     channel_map=frozendict(
          # (Minimum channel, maximum channel)
          tpc=(0, 493),
-         tpc_lowgain=(500, 752),
+         lowgain=(500, 752),
          aqmon=(799, 807),
          mv=(1000, 1083)))
 

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -1,12 +1,12 @@
 import warnings
 
+from frozendict import frozendict
 import strax
 import straxen
 
 
 common_opts = dict(
     register_all=[
-        straxen.daqreader,
         straxen.pulse_processing,
         straxen.peaklet_processing,
         straxen.peak_processing,
@@ -20,6 +20,48 @@ common_opts = dict(
     check_available=('raw_records', 'records', 'peaklets',
                      'events', 'event_info'))
 
+x1t_common_config = dict(
+    check_raw_record_overlaps=False,
+    n_tpc_pmts=248,
+    channel_map=frozendict(
+        # (Minimum channel, maximum channel)
+        tpc=(0, 247),
+        diagnostic=(248, 253),
+        aqmon=(254, 999)))
+
+xnt_common_config = dict(
+    n_tpc_pmts=493,
+    channel_map=frozendict(
+         # (Minimum channel, maximum channel)
+         tpc=(0, 493),
+         tpc_lowgain=(500, 752),
+         aqmon=(799, 807),
+         mv=(1000, 1083)))
+
+
+##
+# XENONnT
+##
+
+def nt_simulation():
+    import wfsim
+    return strax.Context(
+        storage='./strax_data',
+        register=wfsim.RawRecordsFromFax,
+        config=dict(
+            nchunk=1,
+            event_rate=1,
+            chunk_size=10,
+            detector='XENONnT',
+            fax_config='https://raw.githubusercontent.com/XENONnT/'
+                       'strax_auxiliary_files/master/fax_files/fax_config_nt.json',
+            **x1t_common_config),
+        **straxen.contexts.common_opts)
+
+
+##
+# XENON1T
+##
 
 def demo():
     """Return strax context used in the straxen demo notebook"""
@@ -29,8 +71,26 @@ def demo():
                      strax.DataDirectory('./strax_test_data', readonly=True)],
             register=straxen.RecordsFromPax,
             forbid_creation_of=('raw_records',),
-            config=dict(check_raw_record_overlaps=False),
+            config=dict(**x1t_common_config),
             **common_opts)
+
+
+def fake_daq():
+    """Context for processing fake DAQ data in the current directory"""
+    return strax.Context(
+        storage=[strax.DataDirectory('./strax_data',
+                                     provide_run_metadata=False),
+                 # Fake DAQ puts run doc JSON in same folder:
+                 strax.DataDirectory('./from_fake_daq',
+                                     readonly=True)],
+        config=dict(daq_input_dir='./from_fake_daq',
+                    daq_chunk_duration=int(2e9),
+                    daq_compressor='lz4',
+                    n_readout_threads=8,
+                    daq_overlap_chunk_duration=int(2e8),
+                    **x1t_common_config),
+        register=straxen.Fake1TDAQReader,
+        **common_opts)
 
 
 def strax_workshop_dali():
@@ -58,23 +118,8 @@ def xenon1t_dali():
             strax.DataDirectory('./strax_data',
                                 provide_run_metadata=False)],
         register=straxen.plugins.pax_interface.RecordsFromPax,
-        config=dict(check_raw_record_overlaps=False),
+        config=dict(**x1t_common_config),
         # When asking for runs that don't exist, throw an error rather than
         # starting the pax converter
         forbid_creation_of=('raw_records',),
-        **common_opts)
-
-
-def fake_daq():
-    """Context for processing fake DAQ data in the current directory"""
-    return strax.Context(
-        storage=[strax.DataDirectory('./strax_data',
-                                     provide_run_metadata=False),
-                 # Fake DAQ puts run doc JSON in same folder:
-                 strax.DataDirectory('./from_fake_daq',
-                                     readonly=True)],
-        config=dict(daq_input_dir='./from_fake_daq',
-                    daq_chunk_duration=int(2e9),
-                    n_readout_threads=8,
-                    daq_overlap_chunk_duration=int(2e8)),
         **common_opts)

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -36,7 +36,10 @@ xnt_common_config = dict(
          tpc=(0, 493),
          lowgain=(500, 752),
          aqmon=(799, 807),
-         mv=(1000, 1083)))
+         tpc_blank=(999, 999),
+         mv=(1000, 1083),
+         mv_blank=(1999, 1999),
+    ))
 
 
 ##

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -67,7 +67,6 @@ class DAQReader(strax.Plugin):
         'raw_records',
         'raw_records_lowgain',
         'raw_records_aqmon',
-        'raw_records_aqmon_nv',
         'raw_records_mv')
 
     data_kind = frozendict(zip(provides, provides))

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -288,6 +288,12 @@ class DAQReader(strax.Plugin):
         # Convert to strax chunks
         result = dict()
         for i, subd in enumerate(self.config['channel_map']):
+
+            # Ignore data from the 'blank' channels, corresponding to
+            # channels that have nothing connected
+            if subd.endswith('blank'):
+                continue
+
             result_name = 'raw_records'
             if subd != 'tpc':
                 result_name += '_' + subd

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -3,7 +3,9 @@ import os
 import shutil
 import warnings
 
+from frozendict import frozendict
 import numpy as np
+import numba
 
 import strax
 
@@ -22,45 +24,63 @@ class ArtificialDeadtimeInserted(UserWarning):
 
 @export
 @strax.takes_config(
-    strax.Option('daq_chunk_duration', track=False,
-                 default=int(5e9), type=int,
-                 help="Duration of regular chunks in ns"),
-    strax.Option('daq_overlap_chunk_duration', track=False,
-                 default=int(5e8), type=int,
-                 help="Duration of intermediate/overlap chunks in ns"),
-    strax.Option('daq_input_dir', type=str, track=False,
-                 help="Directory where readers put data"),
-    strax.Option('n_readout_threads', type=int, track=False,
-                 help="Number of readout threads producing strax data files"),
-    strax.Option('safe_break_in_pulses', default=1000, track=False,
-                 help="Time (ns) between pulses indicating a safe break "
-                      "in the datastream -- gaps of this size cannot be "
-                      "interior to peaklets."),
-    strax.Option('erase', default=False, track=False,
-                 help="Delete reader data after processing"),
-    strax.Option('compressor', default="blosc", track=False,
-                 help="Algorithm used for (de)compressing the live data"),
+
+    # All these must have track=False, so the raw_records hash never changes!
+
+    # DAQ settings -- should match settings given to redax
     strax.Option('record_length', default=110, track=False, type=int,
                  help="Number of samples per raw_record"),
     strax.Option('digitizer_sampling_resolution',
                  default=10, track=False, type=int,
                  help="Digitizer sampling resolution"),
     strax.Option('run_start_time', type=float, track=False, default=0,
-                 help="time of start run (s since unix epoch)"))
+                 help="time of start run (s since unix epoch)"),
+    strax.Option('daq_chunk_duration', track=False,
+                 default=int(5e9), type=int,
+                 help="Duration of regular chunks in ns"),
+    strax.Option('daq_overlap_chunk_duration', track=False,
+                 default=int(5e8), type=int,
+                 help="Duration of intermediate/overlap chunks in ns"),
+    strax.Option('daq_compressor', default="blosc", track=False,
+                 help="Algorithm used for (de)compressing the live data"),
+    strax.Option('n_readout_threads', type=int, track=False,
+                 help="Number of readout threads producing strax data files"),
+    strax.Option('daq_input_dir', type=str, track=False,
+                 help="Directory where readers put data"),
+
+    # DAQReader settings
+    strax.Option('safe_break_in_pulses', default=1000, track=False,
+                 help="Time (ns) between pulses indicating a safe break "
+                      "in the datastream -- gaps of this size cannot be "
+                      "interior to peaklets."),
+    strax.Option('erase', default=False, track=False,
+                 help="Delete reader data after processing"),
+    strax.Option('channel_map', track=False, type=frozendict,
+                 help="frozendict mapping subdetector to (min, max) "
+                      "channel number."))
 class DAQReader(strax.Plugin):
     """Read the XENONnT DAQ
 
     Does nothing whatsoever to the pulse data; not even baselining.
     """
-    provides = 'raw_records'
+    provides = (
+        'raw_records',
+        'raw_records_lowgain',
+        'raw_records_aqmon',
+        'raw_records_aqmon_nv',
+        'raw_records_mv')
+
+    data_kind = frozendict(zip(provides, provides))
     depends_on = tuple()
     parallel = 'process'
     rechunk_on_save = False
     compressor = 'lz4'
 
     def infer_dtype(self):
-        return strax.raw_record_dtype(
-            samples_per_record=self.config["record_length"])
+        return {
+            d: strax.raw_record_dtype(
+                samples_per_record=self.config["record_length"])
+            for d in self.provides}
 
     def setup(self):
         self.t0 = int(self.config['run_start_time']) * int(1e9)
@@ -128,7 +148,7 @@ class DAQReader(strax.Plugin):
         records = [
             strax.load_file(
                 fn,
-                compressor=self.config["compressor"],
+                compressor=self.config["daq_compressor"],
                 dtype=self.dtype_for('raw_records'))
             for fn in sorted(glob.glob(f'{path}/*'))]
         records = np.concatenate(records)
@@ -259,9 +279,78 @@ class DAQReader(strax.Plugin):
             # Ensure the offset is a whole digitizer sample
             records["time"] += self.dt * (self.t0 // self.dt)
 
-        result = self.chunk(
-            start=self.t0 + break_pre,
-            end=self.t0 + break_post,
-            data=records)
-        print(f"Read chunk {chunk_i:04d}, {result} from DAQ")
+        # Split records by channel
+        result_arrays = _channel_split(
+            records,
+            np.asarray(list(self.config['channel_map'].values())))
+        del records
+
+        # Convert to strax chunks
+        result = dict()
+        for i, subd in enumerate(self.config['channel_map']):
+            result_name = 'raw_records'
+            if subd != 'tpc':
+                result_name += '_' + subd
+            result[result_name] = self.chunk(
+                start=self.t0 + break_pre,
+                end=self.t0 + break_post,
+                data=result_arrays[i],
+                data_type=result_name)
+
+        print(f"Read chunk {chunk_i:06d} from DAQ")
+        for r in result.values():
+            print(f"\t{r}")
         return result
+
+
+@export
+class Fake1TDAQReader(DAQReader):
+    provides = (
+        'raw_records',
+        'raw_records_diagnostic',
+        'raw_records_aqmon')
+
+    data_kind = frozendict(zip(provides, provides))
+
+
+@export
+@numba.njit(nogil=True, cache=True)
+def split_channel_ranges(records, channel_ranges):
+    """Return numba.List of record arrays in channel_ranges.
+
+    ~2.5x as fast as a naive implementation with np.in1d
+    """
+    n_subdetectors = len(channel_ranges)
+    which_detector = np.zeros(len(records), dtype=np.int8)
+    n_in_detector = np.zeros(n_subdetectors, dtype=np.int64)
+
+    # First loop to count number of records per detector
+    for r_i, r in enumerate(records):
+        for d_i in range(n_subdetectors):
+            left, right = channel_ranges[d_i]
+            if r['channel'] > right:
+                continue
+            elif r['channel'] >= left:
+                which_detector[r_i] = d_i
+                n_in_detector[d_i] += 1
+                break
+            else:
+                print(r['time'], r['channel'])
+                raise ValueError(
+                    "Bad data from DAQ: data in unknown channel!")
+
+    # Allocate memory
+    results = numba.typed.List()
+    for d_i in range(n_subdetectors):
+        results.append(np.empty(n_in_detector[d_i], dtype=records.dtype))
+
+    # Second loop to fill results
+    # This is slightly faster than using which_detector == d_i masks,
+    # since it only needs one loop over the data.
+    n_placed = np.zeros(n_subdetectors, dtype=np.int64)
+    for r_i, r in enumerate(records):
+        d_i = which_detector[r_i]
+        results[d_i][n_placed[d_i]] = r
+        n_placed[d_i] += 1
+
+    return results

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -41,7 +41,7 @@ class ArtificialDeadtimeInserted(UserWarning):
     strax.Option('daq_overlap_chunk_duration', track=False,
                  default=int(5e8), type=int,
                  help="Duration of intermediate/overlap chunks in ns"),
-    strax.Option('daq_compressor', default="blosc", track=False,
+    strax.Option('daq_compressor', default="lz4", track=False,
                  help="Algorithm used for (de)compressing the live data"),
     strax.Option('n_readout_threads', type=int, track=False,
                  help="Number of readout threads producing strax data files"),
@@ -280,7 +280,7 @@ class DAQReader(strax.Plugin):
             records["time"] += self.dt * (self.t0 // self.dt)
 
         # Split records by channel
-        result_arrays = _channel_split(
+        result_arrays = split_channel_ranges(
             records,
             np.asarray(list(self.config['channel_map'].values())))
         del records

--- a/tests/test_channel_split.py
+++ b/tests/test_channel_split.py
@@ -1,0 +1,28 @@
+import numpy as np
+import hypothesis
+
+import strax.testutils
+import straxen
+
+
+def channel_split_naive(r, channel_ranges):
+    """Slower but simpler implementation of straxen.split_channel_ranges"""
+    results = []
+    for left, right in channel_ranges:
+        results.append(r[np.in1d(r['channel'], np.arange(left, right + 1))])
+    return results
+
+
+@hypothesis.settings(deadline=None)
+@hypothesis.given(strax.testutils.several_fake_records)
+def test_channel_split(records):
+    channel_range = np.asarray([[0, 0], [1, 2], [3, 3], [4, 999]])
+    result = list(straxen.split_channel_ranges(records, channel_range))
+    result_2 = channel_split_naive(records, channel_range)
+
+    assert len(result) == len(result_2)
+    for i in range(len(result)):
+        np.testing.assert_array_equal(
+            np.unique(result[i]['channel']),
+            np.unique(result_2[i]['channel']))
+        np.testing.assert_array_equal(result[i], result_2[i])


### PR DESCRIPTION
This:
 * Lets DAQReader sort/split raw records data from different subdetectors into different data types.
 * Makes a start with splitting off XENON1T and XENONnT contexts explicitly.

After this, DAQReader will be a multi-output plugin, producing `raw_records`, `raw_records_lowgain`, `raw_records_mv`, and `raw_records_aqmon`. If any of them has no entries (e.g. MV for a non-linked TPC run) the data types will still exist, but all chunks will be empty. On disk, they get a folder with only a metadata.json file (no empty files).

Sorting out the different subdetectors in DAQReader seems preferable over several alternatives (to me -- happy to hear other perspectives!):
  * **Having multiple DAQReaders** (what I had initially in mind) would put the burden on redax to sort things in different (sub)folders on ceph. Strax would also have a big headache trying to piece together the many independent source plugins producing data with not-perfectly aligned chunks (because final chunk breaks are set by where the data shows gaps).
  * **Sorting in PulseProcessing** is what we currently do. This means PulseProcessing shows up in the muon veto and acquisition monitor dependency chain, so when we e.g. change the TPC hitfinder threshold all muon veto processing would have to be redone from scratch. That can't be right.
  * **Let the first plugin of each subsystem select a channel range** would still mean you still have to (download and) go through the full raw_records, even to reprocess very light data such as the acquisition monitor or muon veto.
  * **Having separate channel-selector plugins** that do no processing for each subsystem would be almost equivalent to this PR does -- except that you would save the intermediate unsorted raw_records unnecessarily. Having many plugins depend on a big monolithic raw_records could also increase strax's memory usage, depending on under what conditions numpy arrays get copied internally.

This does not consider the neutron veto yet. I'm starting to agree with @darrylmasson that the most elegant solution would be a single DAQReader plugin that can handle everything. We would have to make a few modifications to deal with the different digitizer time resolution, and (if I understood correctly) the fact that the data will appear in a different folder. We'd also have to consider if the data is still sparse enough to look for simultaneous chunk breaks.