### PR TITLE
Move bootstrax's context into contexts.py

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -225,6 +225,7 @@ def new_context():
     return straxen.contexts.xenonnt_online(
         allow_multiprocess=args.cores > 1,
         allow_shm=args.cores > 1,
+        we_are_the_daq=True,
         max_messages=args.max_messages)
 
 st = new_context()

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -222,19 +222,10 @@ def new_context():
     """Create strax context that can access the runs db"""
     # We use exactly the logic of straxen to access the runs DB;
     # this avoids duplication, and ensures strax can access the runs DB if we can
-    st = strax.Context(
-        storage=straxen.RunDB(
-            mongo_url=mongo_url,
-            mongo_collname=run_collname,
-            runid_field='number',
-            new_data_path=output_folder,
-            mongo_dbname=dbname),
-        config=straxen.contexts.xnt_common_config,
-        **context_opts)
-    st.context_config['allow_multiprocess'] = True if args.cores > 1 else False
-    st.context_config['allow_shm'] = True if args.cores > 1 else False
-    st.context_config['max_messages'] = args.max_messages
-    return st
+    return straxen.contexts.xenonnt_online(
+        allow_multiprocess=args.cores > 1,
+        allow_shm=args.cores > 1,
+        max_messages=args.max_messages)
 
 st = new_context()
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -111,22 +111,7 @@ args = parser.parse_args()
 # Configuration
 ##
 
-print(f'---\nTEST VERSION 0.2.9\n---')
-
-# Runs database
-run_db_username = os.environ['MONGO_RDB_USERNAME']
-run_db_password = os.environ['MONGO_RDB_PASSWORD']
-# run_client = pymongo.MongoClient(f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017,old-gw:27017/admin")
-mongo_url = f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017,old-gw:27017/admin"
-dbname = 'run'
-run_collname = 'runs'
-
-# DAQ database
-daq_db_name = 'daq'
-daq_db_password = os.environ['MONGO_DAQ_PASSWORD']
-daq_db_username = os.environ['MONGO_DAQ_USERNAME']
-daq_client = pymongo.MongoClient(f"mongodb://{daq_db_username}:{daq_db_password}@xenon1t-daq:27020,old-gw:27020/daq")
-daq_db = daq_client[daq_db_name]
+print(f'---\nTEST VERSION 0.2.10\n---')
 
 # The event builders write to different directories on the respective machines.
 eb_directories = {
@@ -215,9 +200,6 @@ else:
     print(f'Not deleting live data because --delete_live = {args.delete_live}')
 
 
-context_opts = straxen.contexts.common_opts.copy()
-context_opts['register'] = [straxen.DAQReader]
-
 def new_context():
     """Create strax context that can access the runs db"""
     # We use exactly the logic of straxen to access the runs DB;
@@ -231,12 +213,22 @@ def new_context():
 
 st = new_context()
 
-run_db = st.storage[0].client[dbname]
+
+# DAQ database
+daq_db_name = 'daq'
+daq_db_password = os.environ['MONGO_DAQ_PASSWORD']
+daq_db_username = os.environ['MONGO_DAQ_USERNAME']
+daq_client = pymongo.MongoClient(f"mongodb://{daq_db_username}:{daq_db_password}@xenon1t-daq:27020,old-gw:27020/daq")
+daq_db = daq_client[daq_db_name]
+usage_coll = daq_db['eb_monitor']
+
+# Runs database
+run_dbname = 'run'
+run_collname = 'runs'
+run_db = st.storage[0].client[run_dbname]
 run_coll = run_db[run_collname]
 bs_coll = run_db['bootstrax']
 log_coll = run_db['log']
-# NB: the usage_coll is written to the DAQ database
-usage_coll = daq_db['eb_monitor']
 
 # Ping the databases to ensure the mongo connections are working
 run_db.command('ping')

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -223,9 +223,10 @@ def new_context():
     # We use exactly the logic of straxen to access the runs DB;
     # this avoids duplication, and ensures strax can access the runs DB if we can
     return straxen.contexts.xenonnt_online(
+        output_folder=output_folder,
+        we_are_the_daq=True,
         allow_multiprocess=args.cores > 1,
         allow_shm=args.cores > 1,
-        we_are_the_daq=True,
         max_messages=args.max_messages)
 
 st = new_context()

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -77,7 +77,7 @@ def xenonnt_online(output_folder='./strax_data',
     if not we_are_the_daq:
         st.context_config['forbid_creation_of'] = 'raw_records'
 
-    # Hack for https://github.com/AxFoundation/strax/pull/223
+    # Hack for https://github.com/AxFoundation/strax/issues/246
     st.context_config['check_available'] = ()
     return st
 

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 
 from frozendict import frozendict

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 
 from frozendict import frozendict
@@ -45,6 +46,41 @@ xnt_common_config = dict(
 ##
 # XENONnT
 ##
+
+
+def xenonnt_online(output_folder='./strax_data',
+                   we_are_the_daq=False,
+                   **kwargs):
+    """XENONnT online processing and analysis"""
+    run_db_username = straxen.get_secret('mongo_rdb_username')
+    run_db_password = straxen.get_secret('mongo_rdb_password')
+    run_db_dbname = 'run'
+    run_db_collname = 'runs'
+
+    mongo_url = f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017,old-gw:27017/admin"
+
+    context_options = {
+        **straxen.contexts.common_opts,
+        **kwargs}
+
+    st = strax.Context(
+        storage=straxen.RunDB(
+            mongo_url=mongo_url,
+            mongo_collname=run_db_collname,
+            runid_field='number',
+            new_data_path=output_folder,
+            mongo_dbname=run_db_dbname),
+        config=straxen.contexts.xnt_common_config,
+        **context_options)
+    st.register(straxen.DAQReader)
+
+    if not we_are_the_daq:
+        st.context_config['forbid_creation_of'] = 'raw_records'
+
+    # Hack for https://github.com/AxFoundation/strax/pull/223
+    st.context_config['check_available'] = ()
+    return st
+
 
 def nt_simulation():
     import wfsim

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -93,7 +93,7 @@ def nt_simulation():
             detector='XENONnT',
             fax_config='https://raw.githubusercontent.com/XENONnT/'
                        'strax_auxiliary_files/master/fax_files/fax_config_nt.json',
-            **x1t_common_config),
+            **xnt_common_config),
         **straxen.contexts.common_opts)
 
 

--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -131,7 +131,7 @@ class RunDB(strax.StorageFrontend):
 
         # Check if the run exists
         if self.runid_field == 'name':
-            run_query = {'name': key.run_id}
+            run_query = {'name': str(key.run_id)}
         else:
             run_query = {'number': int(key.run_id)}
         dq = self._data_query(key)
@@ -233,7 +233,13 @@ class RunDB(strax.StorageFrontend):
             yield doc
 
     def run_metadata(self, run_id, projection=None):
-        doc = self.collection.find_one({'name': run_id}, projection=projection)
+        if self.runid_field == 'name':
+            run_id = str(run_id)
+        else:
+            run_id = int(run_id)
+        doc = self.collection.find_one(
+            {self.runid_field: run_id},
+            projection=projection)
         if doc is None:
             raise strax.DataNotAvailable
         if self.reader_ini_name_is_mode:


### PR DESCRIPTION
This:
  * Moves the online processing context created in bootstrax out to the main context file. This is mainly so you can load nT data in notebooks on the eb machine after `st = straxen.contexts.xenonnt_online()`.
  * Fixes some name/number handling in rundb.py.

I tested it briefly on eb0; bootstrax still seems to work.