### PR TITLE
fix n_tpc_pmts option

### DIFF
--- a/bin/fake_daq
+++ b/bin/fake_daq
@@ -39,7 +39,7 @@ parser.add_argument('--sync_chunk_duration', default=0.2, type=float,
 args = parser.parse_args()
 
 n_readout_threads = 8
-n_channels = straxen.n_tpc_pmts
+n_channels = straxen.n_tpc_pmts_1T
 channels_per_reader = np.ceil(n_channels / n_readout_threads)
 
 if args.shm:

--- a/straxen/analyses/holoviews_waveform_display.py
+++ b/straxen/analyses/holoviews_waveform_display.py
@@ -84,7 +84,7 @@ def _records_to_points(*, records, to_pe, t_reference):
         kdims=[hv.Dimension('time', label='Time', unit='sec'),
                hv.Dimension('channel',
                             label='PMT number',
-                            range=(0, straxen.n_tpc_pmts))],
+                            range=(0, straxen.n_tpc_pmts_1T))],
         vdims=[hv.Dimension('area', label='Area', unit='pe')])
 
     time_stream = hv.streams.RangeX(source=rec_points)
@@ -114,7 +114,7 @@ def hvdisp_plot_records_2d(records, to_pe,
     return hv.operation.datashader.dynspread(
             hv.operation.datashader.datashade(
                 records,
-                y_range=(0, straxen.n_tpc_pmts),
+                y_range=(0, straxen.n_tpc_pmts_1T),
                 streams=[time_stream])).opts(
         plot=dict(width=width,
                   tools=[x_zoom_wheel(), 'xpan'],

--- a/straxen/analyses/records_matrix.py
+++ b/straxen/analyses/records_matrix.py
@@ -60,7 +60,7 @@ def raw_records_matrix(context, run_id, raw_records, time_range):
 
 
 @numba.njit
-def _records_to_matrix(records, t0, window, n_channels=straxen.n_tpc_pmts, dt=10):
+def _records_to_matrix(records, t0, window, n_channels=straxen.n_tpc_pmts_1T, dt=10):
     n_samples = window // dt
     y = np.zeros((n_samples, n_channels),
                  dtype=np.int32)

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -28,7 +28,7 @@ aux_repo = 'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/'
 
 first_sr1_run = 170118_1327
 tpc_r = 47.9
-n_tpc_pmts = 248
+n_tpc_pmts_1T = 248
 
 
 @export

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -19,7 +19,7 @@ import pandas as pd
 
 import strax
 export, __all__ = strax.exporter()
-__all__ += ['straxen_dir', 'first_sr1_run', 'tpc_r', 'n_tpc_pmts', 'aux_repo']
+__all__ += ['straxen_dir', 'first_sr1_run', 'tpc_r', 'n_tpc_pmts_1T', 'aux_repo']
 
 straxen_dir = os.path.dirname(os.path.abspath(
     inspect.getfile(inspect.currentframe())))

--- a/straxen/matplotlib_utils.py
+++ b/straxen/matplotlib_utils.py
@@ -69,8 +69,8 @@ def plot_on_single_pmt_array(
 
     Other arguments are passed to plt.scatter.
     """
-    assert len(c) == straxen.n_tpc_pmts, \
-        f"Need array of {straxen.n_tpc_pmts} values, got {len(c)}"
+    assert len(c) == straxen.n_tpc_pmts_1T, \
+        f"Need array of {straxen.n_tpc_pmts_1T} values, got {len(c)}"
     if vmin is None:
         vmin = c.min()
     if vmax is None:

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -48,6 +48,10 @@ export, __all__ = strax.exporter()
                  help="Time range right of peak center to call "
                       "a hit a tight coincidence (ns)"),
     strax.Option(
+        'n_tpc_pmts', type=int,
+        help='Number of TPC PMTs'),
+
+    strax.Option(
         'hit_min_amplitude',
         default=straxen.adc_thresholds(),
         help='Minimum hit amplitude in ADC counts above baseline. '
@@ -63,11 +67,14 @@ class Peaklets(strax.Plugin):
     __version__ = '0.3.0'
 
     def infer_dtype(self):
-        return dict(peaklets=strax.peak_dtype(n_channels=straxen.n_tpc_pmts),
+        return dict(peaklets=strax.peak_dtype(n_channels=self.config['n_tpc_pmts']),
                     lone_hits=strax.hit_dtype)
 
     def setup(self):
         self.to_pe = straxen.get_to_pe(self.run_id, self.config['to_pe_file'])
+        assert_str = f'Incompatible options for to_pe ({len(self.to_pe)}) and ' \
+                     f'n_tpc_pmts ({self.config["n_tpc_pmts"]}). Both should be for XENON1T OR XENONnT.'
+        assert len(self.to_pe) == self.config['n_tpc_pmts'], assert_str
 
     def compute(self, records):
         r = records

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -110,6 +110,9 @@ class PulseProcessing(strax.Plugin):
 
     def setup(self):
         self.to_pe = straxen.get_to_pe(self.run_id, self.config['to_pe_file'])
+        assert_str = f'Incompatible options for to_pe ({len(self.to_pe)}) and ' \
+                     f'n_tpc_pmts ({self.config["n_tpc_pmts"]}). Both should be for XENON1T OR XENONnT.'
+        assert len(self.to_pe) == self.config['n_tpc_pmts'], assert_str
 
     def compute(self, raw_records):
         if self.config['check_raw_record_overlaps']:


### PR DESCRIPTION
Double check that the number of PMTs in the nT-configuration match up with the to_pe file (which is currently not there).

Also the reference previously pointing to ```straxen.n_tpc_pmts``` was returning 248. Hence, I propose to rename this variable to avoid confusion.

@JelleAalbers would you say it makes sense to make a mock ```nt_to_pe``` in the aux. files and parse the reference thereto here:
https://github.com/XENONnT/straxen/blob/master/straxen/contexts.py#L32