### PR TITLE
Infer bootstrax process mode

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -425,26 +425,28 @@ def infer_run_mode(rd, input_dir):
     Estimating save parameters for running bootstrax from:
       # TODO update with new strax version
       https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:eb_speed_tests
+    returns: dictionary of how many cores and max_messages should be used based on an
+    estimated data rate.
     '''
-    naptime, i = 10, 0
+    nap_time, i = 10, 0
     while len(os.listdir(input_dir)) < 3 * 3:
         if i > 10:
             # To few files to be sure the first chunk is completely written
             return dict(cores=args.cores, max_messages=args.max_messages)
-        time.sleep(naptime)
-    # esitmate datarate on the bases of the size of the first chunk
+        time.sleep(nap_time)
+    # Estimate data rate on the bases of the size of the first chunk
     first_chunk = input_dir + '/000000/'
     chunk_size = np.sum([os.path.getsize(first_chunk + f) for f in os.listdir(first_chunk)])
     chunk_time = rd['ini']['strax_chunk_length'] + rd['ini']['strax_chunk_overlap']
-    compresson_factor = 3  # this is an estimate
-    data_rate = compresson_factor * (chunk_size / 1e6) / (chunk_time)  # in MB/s
+    compression_factor = 3  # this is an estimate
+    data_rate = compression_factor * (chunk_size / 1e6) / chunk_time  # in MB/s
 
     # Find out if eb is new (eb3-eb5):
     is_new_eb = int(hostname.strip('eb.xenon.local')) >= 3
     print(f"infer_run_mode::\teb number {int(hostname.strip('eb.xenon.local'))}")
 
     # Return a run-mode that is empirically found to provide stable processing.
-    print(f'infer_run_mode::\tWorking with an approx. datarate of {data_rate} MB/s')
+    print(f'infer_run_mode::\tWorking with an estimated data rate of {data_rate} MB/s')
     if data_rate < 50:
         result = dict(cores=12 if is_new_eb else 8,
                       max_messages=8 if is_new_eb else 6)
@@ -499,6 +501,18 @@ def delete_live_data(live_data_path):
         raise FileNotFoundError(f'Something is off, no folder found '
                                 f'at {live_data_path} but there was '
                                 f'an attempt to delete data here')
+
+
+def clear_shm():
+    '''Manually delete files in /dev/shm/ created by npshmex on starup.'''
+    shm_dir = '/dev/shm/'
+    shm_files = [f for f in os.listdir(shm_dir) if 'npshmex' in f]
+
+    if not len(shm_files):
+        return
+    print(f'clear_shm:: clearing {len(shm_files)} files')
+    for f in tqdm(shm_files):
+        os.remove(shm_dir + f)
 
 
 ##
@@ -647,9 +661,11 @@ def get_compressor(rd, default_compressor="blosc"):
 
 def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
               run_start_time, samples_per_record, process_mode, debug=False):
-    if args.cores > 1:
-        # Clear the swap memory used by npshmmex
-        npshmex.shm_clear()
+    # Clear the swap memory used by npshmmex
+    npshmex.shm_clear()
+    # double check by forcefully clearing shm
+    clear_shm()
+
     if debug:
         log.setLevel(logging.DEBUG)
     try:

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -63,6 +63,7 @@ import socket
 import shutil
 import time
 import traceback
+from tqdm import tqdm
 
 import numpy as np
 import pymongo
@@ -86,6 +87,9 @@ parser.add_argument('--cores', type=int, default=25,
                          "Set to -1 for all available cores")
 parser.add_argument('--target', default='event_info',
                     help="Strax data type name that should be produced")
+parser.add_argument('--infer_run_mode', action='store_true',
+                    help="Determine best number max-messages and cores for each run automatically. "
+                         "Overrides --cores and --max_messages")
 # TODO change to action
 parser.add_argument('--delete_live', type=str,
                     # TODO -> set this to yes after testing
@@ -111,7 +115,7 @@ args = parser.parse_args()
 # Configuration
 ##
 
-print(f'---\nTEST VERSION 0.2.10\n---')
+print(f'---\nTEST VERSION 0.3.0\n---')
 
 # The event builders write to different directories on the respective machines.
 eb_directories = {
@@ -169,7 +173,8 @@ assert timeouts['bootstrax_presumed_dead'] > wait_diskspace_dt, "wait_diskspace_
 # Fields in the run docs that bootstrax uses
 bootstrax_projection = f"name start end number bootstrax " \
                        f"data.host data.type data.location " \
-                       f"ini.processing_threads ini.compressor ini.strax_fragment_payload_bytes".split()
+                       f"ini.processing_threads ini.compressor ini.strax_fragment_payload_bytes " \
+                       f"ini.strax_chunk_length ini.strax_chunk_overlap".split()
 
 # Filename for temporary storage of the exception
 # This is used to communicate the exception from the strax child process
@@ -200,19 +205,19 @@ else:
     print(f'Not deleting live data because --delete_live = {args.delete_live}')
 
 
-def new_context():
+def new_context(cores=args.cores, max_messages=args.max_messages):
     """Create strax context that can access the runs db"""
     # We use exactly the logic of straxen to access the runs DB;
     # this avoids duplication, and ensures strax can access the runs DB if we can
     return straxen.contexts.xenonnt_online(
         output_folder=output_folder,
         we_are_the_daq=True,
-        allow_multiprocess=args.cores > 1,
-        allow_shm=args.cores > 1,
-        max_messages=args.max_messages)
+        allow_multiprocess=cores > 1,
+        allow_shm=cores > 1,
+        max_messages=max_messages)
+
 
 st = new_context()
-
 
 # DAQ database
 daq_db_name = 'daq'
@@ -414,6 +419,55 @@ def log_warning(message, priority='warning'):
         'priority': dict(warning=2, info=1).get(priority, 3)})
 
 
+def infer_run_mode(rd, input_dir):
+    '''
+    Infer a safe operating mode of running bootstrax based on the size of the first chunk.
+    Estimating save parameters for running bootstrax from:
+      # TODO update with new strax version
+      https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:eb_speed_tests
+    '''
+    naptime, i = 10, 0
+    while len(os.listdir(input_dir)) < 3 * 3:
+        if i > 10:
+            # To few files to be sure the first chunk is completely written
+            return dict(cores=args.cores, max_messages=args.max_messages)
+        time.sleep(naptime)
+    # esitmate datarate on the bases of the size of the first chunk
+    first_chunk = input_dir + '/000000/'
+    chunk_size = np.sum([os.path.getsize(first_chunk + f) for f in os.listdir(first_chunk)])
+    chunk_time = rd['ini']['strax_chunk_length'] + rd['ini']['strax_chunk_overlap']
+    compresson_factor = 3  # this is an estimate
+    data_rate = compresson_factor * (chunk_size / 1e6) / (chunk_time)  # in MB/s
+
+    # Find out if eb is new (eb3-eb5):
+    is_new_eb = int(hostname.strip('eb.xenon.local')) >= 3
+    print(f"infer_run_mode::\teb number {int(hostname.strip('eb.xenon.local'))}")
+
+    # Return a run-mode that is empirically found to provide stable processing.
+    print(f'infer_run_mode::\tWorking with an approx. datarate of {data_rate} MB/s')
+    if data_rate < 50:
+        result = dict(cores=12 if is_new_eb else 8,
+                      max_messages=8 if is_new_eb else 6)
+    elif data_rate < 100:
+        result = dict(cores=10 if is_new_eb else 6,
+                      max_messages=8 if is_new_eb else 6)
+    elif data_rate < 300:
+        result = dict(cores=8 if is_new_eb else 5,
+                      max_messages=6 if is_new_eb else 4)
+    elif data_rate < 700:
+        result = dict(cores=6 if is_new_eb else 4,
+                      max_messages=4 if is_new_eb else 4)
+    else:
+        result = dict(cores=1,
+                      max_messages=4)
+    print(f'Override processing mode for run {rd["number"]} changing to:\t {result}')
+    return result
+
+
+##
+# Host interactions
+##
+
 def sufficient_diskspace():
     '''Check if there is sufficient space available on the local disk to write to'''
     disk = disk_usage(output_folder)
@@ -430,6 +484,21 @@ def sufficient_diskspace():
             time.sleep(wait_diskspace_dt)
             send_heartbeat()
     raise RuntimeError("No diskspace to write to")
+
+
+def delete_live_data(live_data_path):
+    '''After completing the processing and updating the runsDB, remove the
+    live_data'''
+
+    if os.path.exists(live_data_path) and delete_live:
+        print(f'Deleteing data at {live_data_path}')
+        shutil.rmtree(live_data_path)
+        if os.path.exists(live_data_path):
+            assert False, "we wanted to delete this path!"
+    else:
+        raise FileNotFoundError(f'Something is off, no folder found '
+                                f'at {live_data_path} but there was '
+                                f'an attempt to delete data here')
 
 
 ##
@@ -519,7 +588,7 @@ def fail_run(rd, reason):
     else:
         long_run_id = f"run {rd['number']}:{rd['_id']}"
 
-    # No bootstrax info is present when manually failing a run with arg.fail
+    # No bootstrax info is present when manually failing a run with args.fail
     if not 'bootstrax' in rd.keys():
         rd['bootstrax'] = {}
         rd['bootstrax']['n_failures'] = 0
@@ -547,7 +616,7 @@ def fail_run(rd, reason):
                       now(plus=(timeouts['retry_run']
                                 * np.random.uniform(0.5, 1.5)
                                 # Exponential backoff with jitter
-                                * 5**min(rd['bootstrax'].get('n_failures', 0), 3)
+                                * 5 ** min(rd['bootstrax'].get('n_failures', 0), 3)
                                 ))))
 
     # Report to DAQ log and screen
@@ -572,27 +641,12 @@ def get_compressor(rd, default_compressor="blosc"):
         return default_compressor
 
 
-def delete_live_data(live_data_path):
-    '''After completing the processing and updating the runsDB, remove the
-    live_data'''
-
-    if os.path.exists(live_data_path) and delete_live:
-        print(f'Deleteing data at {live_data_path}')
-        shutil.rmtree(live_data_path)
-        if os.path.exists(live_data_path):
-            assert False, "we wanted to delete this path!"
-    else:
-        raise FileNotFoundError(f'Something is off, no folder found '
-                                f'at {live_data_path} but there was '
-                                f'an attempt to delete data here')
-
-
 ##
 # Processing
 ##
 
 def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
-              run_start_time, samples_per_record, debug=False):
+              run_start_time, samples_per_record, process_mode, debug=False):
     if args.cores > 1:
         # Clear the swap memory used by npshmmex
         npshmex.shm_clear()
@@ -600,7 +654,8 @@ def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
         log.setLevel(logging.DEBUG)
     try:
         log.info(f"Starting strax to make {run_id} with input dir {input_dir}")
-        st = new_context()
+
+        st = new_context(**process_mode)
 
         # Make a function for running strax, call the function to process the run
         # This way, it can also be run inside a wrapper to profile strax
@@ -611,10 +666,10 @@ def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
                                 run_start_time=run_start_time,
                                 record_length=samples_per_record,
                                 n_readout_threads=n_readout_threads,
-                               )
+                                )
             st.make(run_id, target,
                     config=strax_config,
-                    max_workers=args.cores)
+                    max_workers=process_mode['cores'])
 
         if args.profile.lower() == 'false':
             st_make()
@@ -704,10 +759,15 @@ def process_run(rd, send_heartbeats=True):
         except Exception as e:
             fail(f"Could not find ini.strax_fragment_payload_bytes in database: {str(e)}")
 
+        if args.infer_run_mode:
+            process_mode = infer_run_mode(rd, loc)
+        else:
+            process_mode = dict(cores=args.cores, max_messages=args.max_messages)
+
         strax_proc = multiprocessing.Process(
             target=run_strax,
             args=(run_id, loc, target, n_readout_threads, compressor,
-                  run_start_time, samples_per_record, args.debug))
+                  run_start_time, samples_per_record, process_mode, args.debug))
 
         t0 = now()
         info = dict(started_processing=t0)


### PR DESCRIPTION
This PR does two things:

- Add a feature to run bootstrax in a lazy mode: determine the number of cores and max number of mailbox messages. As such, one does not have to worry to finetune these numbers or have them the same for each and every run. The numbers are estimated based on [this note ](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:eb_speed_tests) and are preferably updated once harmonious DAQ-strax processing is resumed.
- Add some redundancy to double check that the shm is really cleared each time a run is processed.
