### PR TITLE
Gain model specification, remove 1T defaults

### DIFF
--- a/bin/fake_daq
+++ b/bin/fake_daq
@@ -5,7 +5,6 @@ from copy import copy
 import shutil
 import time
 
-import numba
 import numpy as np
 import strax
 import straxen
@@ -38,10 +37,6 @@ parser.add_argument('--sync_chunk_duration', default=0.2, type=float,
                     help='Synchronization chunk size in sec (not ns)')
 args = parser.parse_args()
 
-n_readout_threads = 8
-n_channels = straxen.n_tpc_pmts
-channels_per_reader = np.ceil(n_channels / n_readout_threads)
-
 if args.shm:
     output_dir = '/dev/shm/from_fake_daq'
 else:
@@ -56,7 +51,12 @@ def main():
     st = strax.Context(storage=strax.DataDirectory(args.input_path,
                                                    readonly=True),
                        register=straxen.plugins.pax_interface.RecordsFromPax,
+                       config=straxen.contexts.x1t_common_config,
                        **straxen.contexts.common_opts)
+
+    n_readout_threads = 8
+    n_channels = st.config['n_tpc_pmts']
+    channels_per_reader = np.ceil(n_channels / n_readout_threads)
 
     if os.path.exists(output_dir):
         shutil.rmtree(output_dir)

--- a/straxen/analyses/holoviews_waveform_display.py
+++ b/straxen/analyses/holoviews_waveform_display.py
@@ -64,7 +64,7 @@ def hvdisp_plot_pmt_pattern(*, records, to_pe, array='bottom'):
     return pmts
 
 
-def _records_to_points(*, records, to_pe, t_reference):
+def _records_to_points(*, records, to_pe, t_reference, config):
     """Return (holoviews.Points, time_stream) corresponding to records
     """
     import holoviews as hv
@@ -84,7 +84,7 @@ def _records_to_points(*, records, to_pe, t_reference):
         kdims=[hv.Dimension('time', label='Time', unit='sec'),
                hv.Dimension('channel',
                             label='PMT number',
-                            range=(0, straxen.n_tpc_pmts))],
+                            range=(0, config['n_tpc_pmts']))],
         vdims=[hv.Dimension('area', label='Area', unit='pe')])
 
     time_stream = hv.streams.RangeX(source=rec_points)
@@ -92,7 +92,7 @@ def _records_to_points(*, records, to_pe, t_reference):
 
 
 @straxen.mini_analysis(requires=['records'], hv_bokeh=True)
-def hvdisp_plot_records_2d(records, to_pe,
+def hvdisp_plot_records_2d(records, to_pe, config,
                            t_reference, width=600, time_stream=None):
     """Plot records in a dynamic 2D histogram of (time, pmt)
 
@@ -114,7 +114,7 @@ def hvdisp_plot_records_2d(records, to_pe,
     return hv.operation.datashader.dynspread(
             hv.operation.datashader.datashade(
                 records,
-                y_range=(0, straxen.n_tpc_pmts),
+                y_range=(0, config['n_tpc_pmts']),
                 streams=[time_stream])).opts(
         plot=dict(width=width,
                   tools=[x_zoom_wheel(), 'xpan'],

--- a/straxen/analyses/records_matrix.py
+++ b/straxen/analyses/records_matrix.py
@@ -8,7 +8,7 @@ import straxen
 @straxen.mini_analysis(requires=('records',),
                        warn_beyond_sec=5e-3,
                        default_time_selection='touching')
-def records_matrix(records, time_range, seconds_range, to_pe):
+def records_matrix(records, time_range, seconds_range, config, to_pe):
     """Return (wv_matrix, times, pms)
       - wv_matrix: (n_samples, n_pmt) array with per-PMT waveform intensity in PE/ns
       - times: time labels in seconds (corr. to rows)
@@ -35,6 +35,7 @@ def records_matrix(records, time_range, seconds_range, to_pe):
     wvm = _records_to_matrix(
         records,
         t0=time_range[0],
+        n_channels=config['n_tpc_pmts'],
         window=time_range[1] - time_range[0])
     wvm = wvm.astype(np.float32) * to_pe.reshape(1, -1) / dt
 
@@ -60,7 +61,7 @@ def raw_records_matrix(context, run_id, raw_records, time_range):
 
 
 @numba.njit
-def _records_to_matrix(records, t0, window, n_channels=straxen.n_tpc_pmts, dt=10):
+def _records_to_matrix(records, t0, window, n_channels, dt=10):
     n_samples = window // dt
     y = np.zeros((n_samples, n_channels),
                  dtype=np.int32)

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -19,7 +19,7 @@ import pandas as pd
 
 import strax
 export, __all__ = strax.exporter()
-__all__ += ['straxen_dir', 'first_sr1_run', 'tpc_r', 'n_tpc_pmts', 'aux_repo']
+__all__ += ['straxen_dir', 'first_sr1_run', 'tpc_r', 'aux_repo']
 
 straxen_dir = os.path.dirname(os.path.abspath(
     inspect.getfile(inspect.currentframe())))
@@ -28,7 +28,6 @@ aux_repo = 'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/'
 
 first_sr1_run = 170118_1327
 tpc_r = 47.9
-n_tpc_pmts = 248
 
 
 @export

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -84,7 +84,7 @@ def get_to_pe(run_id, gain_model, n_tpc_pmts):
         # Somebody messed up
         raise RuntimeError("Attempt to use a disabled gain model")
 
-    if model_type == 'to_pe_per_run':
+    elif model_type == 'to_pe_per_run':
         # Load a npy file specifing a run_id -> to_pe array
         to_pe_file = model_conf
         x = get_resource(to_pe_file, fmt='npy')
@@ -93,13 +93,19 @@ def get_to_pe(run_id, gain_model, n_tpc_pmts):
             # Gains not known: using placeholders
             run_index = [-1]
         to_pe = x[run_index[0]]['to_pe']
-        return to_pe
 
-    if model_type == 'to_pe_constant':
+    elif model_type == 'to_pe_constant':
         # Uniform gain, specified as a to_pe factor
-        return np.ones(n_tpc_pmts, dtype=np.float32) * model_conf
+        to_pe = np.ones(n_tpc_pmts, dtype=np.float32) * model_conf
 
-    raise NotImplementedError(f"Gain model type {model_type} not implemented")
+    else:
+        raise NotImplementedError(f"Gain model type {model_type} not implemented")
+
+    if len(to_pe) != n_tpc_pmts:
+        raise ValueError(
+            f"Gain model {gain_model} resulted in a to_pe "
+            f"of length {len(to_pe)}, but n_tpc_pmts is {n_tpc_pmts}!")
+    return to_pe
 
 
 @export

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -26,10 +26,26 @@ x1t_common_config = dict(
         # (Minimum channel, maximum channel)
         tpc=(0, 247),
         diagnostic=(248, 253),
-        aqmon=(254, 999)))
+        aqmon=(254, 999)),
+    hev_gain_model=('to_pe_per_run',
+                    'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/master/to_pe.npy'),
+    gain_model=('to_pe_per_run',
+                'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/master/to_pe.npy'),
+    pmt_pulse_filter=(
+        0.012, -0.119,
+        2.435, -1.271, 0.357, -0.174, -0., -0.036,
+        -0.028, -0.019, -0.025, -0.013, -0.03, -0.039,
+        -0.005, -0.019, -0.012, -0.015, -0.029, 0.024,
+        -0.007, 0.007, -0.001, 0.005, -0.002, 0.004, -0.002),
+    tail_veto_threshold=int(1e5),
+    save_outside_hits=(3, 3),
+    hit_min_amplitude=straxen.adc_thresholds(),
+)
 
 xnt_common_config = dict(
     n_tpc_pmts=493,
+    gain_model=('to_pe_constant',
+                0.005),
     channel_map=frozendict(
          # (Minimum channel, maximum channel)
          tpc=(0, 493),
@@ -38,7 +54,8 @@ xnt_common_config = dict(
          tpc_blank=(999, 999),
          mv=(1000, 1083),
          mv_blank=(1999, 1999),
-    ))
+    )
+)
 
 
 ##

--- a/straxen/matplotlib_utils.py
+++ b/straxen/matplotlib_utils.py
@@ -17,7 +17,7 @@ def plot_on_pmt_arrays(
         **kwargs):
     """Plot the PMT arrays side-by-side, coloring the PMTS with c.
 
-    :param c: Array of colors to use. Must be len(straxen.n_tpc_pmts)
+    :param c: Array of colors to use. Must have len() n_tpc_pmts
     :param label: Label for the color bar
     :param figsize: Figure size to use.
     :param extend: same as plt.colorbar(extend=...)
@@ -50,6 +50,7 @@ def plot_on_pmt_arrays(
 def plot_on_single_pmt_array(
         c,
         array_name='top',
+        detector='xenon1t',
         r=straxen.tpc_r * 1.1,
         pmt_label_size=7,
         pmt_label_color='white',
@@ -57,7 +58,7 @@ def plot_on_single_pmt_array(
         **kwargs):
     """Plot one of the PMT arrays and color it by c.
 
-    :param c: Array of colors to use. Must be len(straxen.n_tpc_pmts)
+    :param c: Array of colors to use. Must be len() of the number of TPC PMTs
     :param label: Label for the color bar
     :param pmt_label_size: Fontsize for the PMT number labels.
     Set to 0 to disable.
@@ -69,8 +70,6 @@ def plot_on_single_pmt_array(
 
     Other arguments are passed to plt.scatter.
     """
-    assert len(c) == straxen.n_tpc_pmts, \
-        f"Need array of {straxen.n_tpc_pmts} values, got {len(c)}"
     if vmin is None:
         vmin = c.min()
     if vmax is None:

--- a/straxen/mini_analysis.py
+++ b/straxen/mini_analysis.py
@@ -23,6 +23,7 @@ The function takes the same selection arguments as context.get_array:
 
 _hv_bokeh_initialized = False
 
+
 @export
 def mini_analysis(requires=tuple(),
                   hv_bokeh=False,
@@ -44,6 +45,8 @@ def mini_analysis(requires=tuple(),
 
             if 'config' in kwargs:
                 context = context.new_context(config=kwargs['config'])
+            if 'config' in parameters:
+                kwargs['config'] = context.config
 
             # Say magic words to enable holoviews
             if hv_bokeh:

--- a/straxen/mini_analysis.py
+++ b/straxen/mini_analysis.py
@@ -61,8 +61,8 @@ def mini_analysis(requires=tuple(),
             if 'to_pe' in parameters and 'to_pe' not in kwargs:
                 kwargs['to_pe'] = straxen.get_to_pe(
                     run_id,
-                    'https://raw.githubusercontent.com/XENONnT/'
-                    'strax_auxiliary_files/master/to_pe.npy')
+                    context.config['gain_model'],
+                    context.config['n_tpc_pmts'])
 
             # Prepare selection arguments
             kwargs['time_range'] = context.to_absolute_time_range(

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -51,7 +51,11 @@ export, __all__ = strax.exporter()
         'hit_min_amplitude',
         default=straxen.adc_thresholds(),
         help='Minimum hit amplitude in ADC counts above baseline. '
-             'Specify as a tuple of length n_tpc_pmts, or a number.'))
+             'Specify as a tuple of length n_tpc_pmts, or a number.'),
+    strax.Option(
+        'n_tpc_pmts', type=int,
+        help='Number of TPC PMTs'),
+)
 class Peaklets(strax.Plugin):
     depends_on = ('records',)
     provides = ('peaklets', 'lone_hits')
@@ -63,7 +67,8 @@ class Peaklets(strax.Plugin):
     __version__ = '0.3.0'
 
     def infer_dtype(self):
-        return dict(peaklets=strax.peak_dtype(n_channels=straxen.n_tpc_pmts),
+        return dict(peaklets=strax.peak_dtype(
+                        n_channels=self.config['n_tpc_pmts']),
                     lone_hits=strax.hit_dtype)
 
     def setup(self):

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -38,9 +38,8 @@ export, __all__ = strax.exporter()
                  help='Maximum number of recursive peak splits to do.'),
     strax.Option('diagnose_sorting', track=False, default=False,
                  help="Enable runtime checks for sorting and disjointness"),
-    strax.Option('to_pe_file',
-                 default='https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/master/to_pe.npy',
-                 help='Link to the to_pe conversion factors'),
+    strax.Option('gain_model',
+                 help='PMT gain model. Specify as (model_type, model_config)'),
     strax.Option('tight_coincidence_window_left', default=50,
                  help="Time range left of peak center to call "
                       "a hit a tight coincidence (ns)"),
@@ -72,7 +71,9 @@ class Peaklets(strax.Plugin):
                     lone_hits=strax.hit_dtype)
 
     def setup(self):
-        self.to_pe = straxen.get_to_pe(self.run_id, self.config['to_pe_file'])
+        self.to_pe = straxen.get_to_pe(self.run_id,
+                                       self.config['gain_model'],
+                                       n_tpc_pmts=self.config['n_tpc_pmts'])
 
     def compute(self, records):
         r = records

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -139,7 +139,7 @@ class PulseProcessing(strax.Plugin):
 
         pulse_counts = count_pulses(r, self.config['n_tpc_pmts'])
 
-        if (len(r) and self.hev_enabled):
+        if len(r) and self.hev_enabled:
             r, r_vetoed, veto_regions = software_he_veto(
                 r, self.to_pe,
                 area_threshold=self.config['tail_veto_threshold'],
@@ -188,7 +188,8 @@ class PulseProcessing(strax.Plugin):
 def software_he_veto(records, to_pe,
                      area_threshold=int(1e5),
                      veto_length=int(3e6),
-                     veto_res=int(1e3), pass_veto_fraction=0.01,
+                     veto_res=int(1e3),
+                     pass_veto_fraction=0.01,
                      pass_veto_extend=3):
     """Veto veto_length (time in ns) after peaks larger than
     area_threshold (in PE).

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -8,20 +8,19 @@ export, __all__ = strax.exporter()
 
 @export
 @strax.takes_config(
-    strax.Option(
-        'to_pe_file',
-        default='https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/master/to_pe.npy',    # noqa
-        help='URL of the to_pe conversion factors'),
+    strax.Option('hev_gain_model',
+                 default=('disabled', None),
+                 help='PMT gain model used in the software high-energy veto.'
+                      'Specify as (model_type, model_config)'),
     strax.Option(
         'baseline_samples',
         default=40,
         help='Number of samples to use at the start of the pulse to determine '
              'the baseline'),
-
     # Tail veto options
     strax.Option(
         'tail_veto_threshold',
-        default=int(1e5),
+        default=0,
         help=("Minimum peakarea in PE to trigger tail veto."
               "Set to None, 0 or False to disable veto.")),
     strax.Option(
@@ -44,20 +43,16 @@ export, __all__ = strax.exporter()
     # PMT pulse processing options
     strax.Option(
         'pmt_pulse_filter',
-        default=(0.012, -0.119,
-                 2.435, -1.271, 0.357, -0.174, -0., -0.036,
-                 -0.028, -0.019, -0.025, -0.013, -0.03, -0.039,
-                 -0.005, -0.019, -0.012, -0.015, -0.029, 0.024,
-                 -0.007, 0.007, -0.001, 0.005, -0.002, 0.004, -0.002),
+        default=None,
         help='Linear filter to apply to pulses, will be normalized.'),
     strax.Option(
         'save_outside_hits',
-        default=(3, 3),
+        default=(3, 20),
         help='Save (left, right) samples besides hits; cut the rest'),
 
     strax.Option(
         'hit_min_amplitude',
-        default=straxen.adc_thresholds(),
+        default=15,
         help='Minimum hit amplitude in ADC counts above baseline. '
              'Specify as a tuple of length n_tpc_pmts, or a number.'),
 
@@ -109,7 +104,14 @@ class PulseProcessing(strax.Plugin):
         return dtype
 
     def setup(self):
-        self.to_pe = straxen.get_to_pe(self.run_id, self.config['to_pe_file'])
+        self.hev_enabled = (
+            (self.config['hev_gain_model'][0] != 'disabled')
+            and self.config['tail_veto_threshold'])
+        if self.hev_enabled:
+            self.to_pe = straxen.get_to_pe(
+                self.run_id,
+                self.config['hev_gain_model'],
+                n_tpc_pmts=self.config['n_tpc_pmts'])
 
     def compute(self, raw_records):
         if self.config['check_raw_record_overlaps']:
@@ -137,7 +139,7 @@ class PulseProcessing(strax.Plugin):
 
         pulse_counts = count_pulses(r, self.config['n_tpc_pmts'])
 
-        if self.config['tail_veto_threshold'] and len(r):
+        if (len(r) and self.hev_enabled):
             r, r_vetoed, veto_regions = software_he_veto(
                 r, self.to_pe,
                 area_threshold=self.config['tail_veto_threshold'],


### PR DESCRIPTION
This:
  * Adds the `gain_model` and `hev_gain_model` options to describe PMT gain models (and replace the old `to_pe_file` option). These must be set to a tuple: (a model type string, a configuration or version specific to that model). The software high-energy veto has a separate option, because we may want to set this during online processing and never change it. Currently we only support a few basic model types; in the future time- or voltage-dependent models could be added:
    * `to_pe_constant`: configuration is a single number, the ADC -> PE conversion factor to use for all channels.
    * `to_pe_file`: configuration is a URL (or filename) pointing to a .npy file mapping run_id's to to_pe arrays.
    * `disabled`: configuration should be None. This is a placeholder for hev_gain_model to denote that the software-HEV should be disabled. (You can also disable the software-HEV by setting its threshold to a False value, but then it would be odd to still have to specify a gain model.)
  * Replace the XENON1T-like defaults in PulseProcessing by values more sensible for XENONnT first data (no pulse filter, no high-energy veto, generous hit extension, uniform hitfinder threshold and gain). The XENON1T settings are moved to `straxen.common.x1t_common_config`, which is auto-applied for 1T contexts. I hope we can move all 1T-specific defaults here eventually so it doesn't clutter straxen later on.
  * Removes `straxen.n_tpc_pmts`. The number of PMTs has for some time now been specified as part of the config.
  * Lets mini-analyses takes `config` as an argument. They could already get it through `context.config`, but this seems more convenient.

These changes are inspired by Joran's #69.