### PR TITLE
switch naming to high energy

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -49,7 +49,7 @@ xnt_common_config = dict(
     channel_map=frozendict(
          # (Minimum channel, maximum channel)
          tpc=(0, 493),
-         high_e=(500, 752),
+         high_energy=(500, 752),
          aqmon=(799, 807),
          tpc_blank=(999, 999),
          mv=(1000, 1083),

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -49,7 +49,7 @@ xnt_common_config = dict(
     channel_map=frozendict(
          # (Minimum channel, maximum channel)
          tpc=(0, 493),
-         high_energy=(500, 752),
+         he=(500, 752),  # high energy
          aqmon=(799, 807),
          tpc_blank=(999, 999),
          mv=(1000, 1083),

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -49,7 +49,7 @@ xnt_common_config = dict(
     channel_map=frozendict(
          # (Minimum channel, maximum channel)
          tpc=(0, 493),
-         lowgain=(500, 752),
+         high_e=(500, 752),
          aqmon=(799, 807),
          tpc_blank=(999, 999),
          mv=(1000, 1083),

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -65,7 +65,7 @@ class DAQReader(strax.Plugin):
     """
     provides = (
         'raw_records',
-        'raw_records_high_energy',
+        'raw_records_he',  # high energy
         'raw_records_aqmon',
         'raw_records_mv')
 

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -65,7 +65,7 @@ class DAQReader(strax.Plugin):
     """
     provides = (
         'raw_records',
-        'raw_records_high_e',
+        'raw_records_high_energy',
         'raw_records_aqmon',
         'raw_records_mv')
 

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -65,7 +65,7 @@ class DAQReader(strax.Plugin):
     """
     provides = (
         'raw_records',
-        'raw_records_lowgain',
+        'raw_records_high_e',
         'raw_records_aqmon',
         'raw_records_mv')
 


### PR DESCRIPTION
The DAQ-group would prefer a consistent naming convention. As such it might be better to change this naming to be compliant with naming it:
 * high energy (for 0vbb search, the low gain channels that is)
 * low energy (for dark matter search, the high gain channels that is)