### PR TITLE
Separate LED contexts, numba for get_amplitude

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -100,13 +100,16 @@ def xenonnt_online(output_folder='./strax_data',
     return st
 
 
-def xenonnt_led(**kwargs):
+def xenon1t_led(**kwargs):
     st = xenonnt_online(**kwargs)
+    st.context_config['check_available'] = ('raw_records', 'led_calibration')
+    # Return a new context with only raw_records and led_calibration registered
     return st.new_context(
+        replace=True,
         register=[straxen.DAQReader, straxen.LEDCalibration],
-        check_available=('raw_records', 'led_calibration'),
-        # To make sure other plugins are deregistered:
-        replace=True)
+        config=st.config,
+        storage=st.storage,
+        **st.context_config)
 
 
 def nt_simulation():
@@ -195,8 +198,11 @@ def xenon1t_dali(output_folder='./strax_data', build_lowlevel=False):
 
 def xenon1t_led(**kwargs):
     st = xenon1t_dali(**kwargs)
+    st.context_config['check_available'] = ('raw_records', 'led_calibration')
+    # Return a new context with only raw_records and led_calibration registered
     return st.new_context(
+        replace=True,
         register=[straxen.RecordsFromPax, straxen.LEDCalibration],
-        check_available=('raw_records', 'led_calibration'),
-        # To make sure other plugins are deregistered:
-        replace=True)
+        config=st.config,
+        storage=st.storage,
+        **st.context_config)

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -100,6 +100,15 @@ def xenonnt_online(output_folder='./strax_data',
     return st
 
 
+def xenonnt_led(**kwargs):
+    st = xenonnt_online(**kwargs)
+    return st.new_context(
+        register=[straxen.DAQReader, straxen.LEDCalibration],
+        check_available=('raw_records', 'led_calibration'),
+        # To make sure other plugins are deregistered:
+        replace=True)
+
+
 def nt_simulation():
     import wfsim
     return strax.Context(
@@ -119,22 +128,6 @@ def nt_simulation():
 ##
 # XENON1T
 ##
-
-PMT_opts = dict(
-    register_all=[
-        straxen.daqreader,
-        straxen.pulse_processing,
-        straxen.peaklet_processing,
-        straxen.peak_processing,
-        straxen.event_processing,
-        straxen.led_calibration
-        ],
-    store_run_fields=(
-        'name', 'number',
-        'reader.ini.name', 'tags.name',
-        'start', 'end', 'livetime',
-        'trigger.events_built'),
-    check_available=('raw_records', 'event_info'))
 
 def demo():
     """Return strax context used in the straxen demo notebook"""
@@ -190,7 +183,7 @@ def xenon1t_dali(output_folder='./strax_data', build_lowlevel=False):
                 provide_run_metadata=False),
             strax.DataDirectory(output_folder,
                                 provide_run_metadata=False)],
-        register=straxen.plugins.pax_interface.RecordsFromPax,
+        register=straxen.RecordsFromPax,
         config=dict(**x1t_common_config),
         # When asking for runs that don't exist, throw an error rather than
         # starting the pax converter
@@ -199,27 +192,11 @@ def xenon1t_dali(output_folder='./strax_data', build_lowlevel=False):
             else ('raw_records', 'records', 'peaklets')),
         **common_opts)
 
-def strax_SPE(output_folder='/dali/lgrandi/giovo/XENONnT/strax_data', 
-              build_lowlevel=False):
-    return strax.Context(
-        storage=[
-            strax.DataDirectory(
-                '/dali/lgrandi/xenon1t/strax_converted/raw',
-                take_only='raw_records',
-                provide_run_metadata=True,
-                deep_scan=False,
-                readonly=True),
-            strax.DataDirectory(
-                '/dali/lgrandi/xenon1t/strax_converted/processed',
-                readonly=True,
-                provide_run_metadata=False),
-            strax.DataDirectory(output_folder,
-                                provide_run_metadata=False)],
-        register=straxen.plugins.pax_interface.RecordsFromPax,
-        config=dict(**x1t_common_config),
-        # When asking for runs that don't exist, throw an error rather than
-        # starting the pax converter
-        forbid_creation_of=(
-            ('raw_records',) if build_lowlevel
-            else ('raw_records', 'records', 'peaklets')),
-        **PMT_opts)
+
+def xenon1t_led(**kwargs):
+    st = xenon1t_dali(**kwargs)
+    return st.new_context(
+        register=[straxen.RecordsFromPax, straxen.LEDCalibration],
+        check_available=('raw_records', 'led_calibration'),
+        # To make sure other plugins are deregistered:
+        replace=True)

--- a/straxen/plugins/led_calibration.py
+++ b/straxen/plugins/led_calibration.py
@@ -4,17 +4,15 @@ if you want to complain please contact: chiara@physik.uzh.ch, gvolta@physik.uzh.
 '''
 
 import strax
-import numpy as np
-import pandas as pd
-from tqdm import tqdm
 import numba
-import resource
-from numba import njit
+import numpy as np
 
-#export, __all__ = strax.exporter()
-# QUESTION: what does 'export, __all__ = strax.exporter()' do?
-# ANSWER: [fill in]
+# This makes sure shorthands for only the necessary functions
+# are made available under straxen.[...]
+export, __all__ = strax.exporter()
 
+
+@export
 @strax.takes_config(
     strax.Option('baseline_window',
                  default=(0,50),
@@ -27,20 +25,16 @@ from numba import njit
                  help="Window (samples) to analysis the noise"),
     strax.Option('channel_list',
                  default=(0,248),
-                 help="Three different light level for XENON1T: (0,36), (37,126), (127,248). Defalt value: all the PMTs")
-)
-
-
+                 help="Three different light level for XENON1T: (0,36), (37,126), (127,248). Defalt value: all the PMTs"))
 class LEDCalibration(strax.Plugin):
-    
-    '''
+    """
     Preliminary version, several parameters to set during commisioning.
     LEDCalibration returns: channel, time, dt, lenght, Area, amplitudeLED and amplitudeNOISE.
     The new variables are:
     - Area: Area computed in the given window, averaged over 6 windows that have the same starting sample and different end samples.
     - amplitudeLED: peak amplitude of the LED on run in the given window.
     - amplitudeNOISE: amplitude of the LED on run in a window far from the signal one.
-    '''
+    """
     
     __version__ = '0.1.3'
     depends_on = ('raw_records',)


### PR DESCRIPTION
This:
  * Make separate contexts `xenon1t_led` and `xenonnt_led` for LED processing and analysis. They take the same arguments as `xenon1t_dali` and `xenonnt_online`, and return versions of these parent contexts that have all plugins deregistered except the ones providing led_calibration and raw_records.
  * Changes the led plugin a little bit (it did not work when I tried it) so `get_amplitude` now uses numba. I haven't really looked at what the code does, just tried to make small changes that leave the meaning invariant.

@GiovanniVolta this PR just goes to your branch, so it would be added on top of #42 if you agree