### PR TITLE
aq mon starts at 800

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -50,7 +50,7 @@ xnt_common_config = dict(
          # (Minimum channel, maximum channel)
          tpc=(0, 493),
          he=(500, 752),  # high energy
-         aqmon=(799, 807),
+         aqmon=(800, 807),
          tpc_blank=(999, 999),
          mv=(1000, 1083),
          mv_blank=(1999, 1999),


### PR DESCRIPTION
@JelleAalbers , I think the aqmon starts at 800:
https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:channel_groups