### PR TITLE
read chunk lengths from rundoc

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -749,7 +749,7 @@ def get_compressor(rd, default_compressor="blosc"):
 
 def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
               run_start_time, samples_per_record, process_mode, is_LED,
-              debug=False):
+              daq_chunk_duration, daq_overlap_chunk_duration, debug=False):
     # Clear the swap memory used by npshmmex
     npshmex.shm_clear()
     # double check by forcefully clearing shm
@@ -777,6 +777,8 @@ def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
                                 daq_compressor=compressor,
                                 run_start_time=run_start_time,
                                 record_length=samples_per_record,
+                                daq_chunk_duration = daq_chunk_duration,
+                                daq_overlap_chunk_duration = daq_overlap_chunk_duration,
                                 n_readout_threads=n_readout_threads,
                                 check_raw_record_overlaps=False,
                                 )
@@ -879,10 +881,14 @@ def process_run(rd, send_heartbeats=True):
         else:
             process_mode = dict(cores=args.cores, max_messages=args.max_messages)
 
+        daq_chunk_duration = int(rd['ini']['strax_chunk_length'] * 1e9)
+        daq_overlap_chunk_duration = int(rd['ini']['strax_chunk_overlap'] * 1e9)
+
         strax_proc = multiprocessing.Process(
             target=run_strax,
             args=(run_id, loc, target, n_readout_threads, compressor,
                   run_start_time, samples_per_record, process_mode, is_LED,
+                  daq_chunk_duration, daq_overlap_chunk_duration,
                   args.debug))
 
         t0 = now()

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -115,7 +115,7 @@ args = parser.parse_args()
 # Configuration
 ##
 
-print(f'---\nTEST VERSION 0.3.3\n---')
+print(f'---\nTEST VERSION 0.3.5\n---')
 
 # The event builders write to different directories on the respective machines.
 eb_directories = {
@@ -839,6 +839,12 @@ def process_run(rd, send_heartbeats=True):
 
         thread_info = rd.get('ini', dict()).get('processing_threads', dict())
         n_readout_threads = sum([v for v in thread_info.values()])
+        try:
+            daq_chunk_duration = int(rd['ini']['strax_chunk_length'] * 1e9)
+            daq_overlap_chunk_duration = int(rd['ini']['strax_chunk_overlap'] * 1e9)
+        except Exception as e:
+            fail(f"Could not find 'strax_chunk_length' and/or'strax_chunk_overlap' in "
+                 f"rundoc: {str(e)}")
 
         if not n_readout_threads:
             fail(f"Run doc for {run_id} has no readout thread count info")
@@ -880,9 +886,6 @@ def process_run(rd, send_heartbeats=True):
             process_mode = infer_mode(rd, loc)
         else:
             process_mode = dict(cores=args.cores, max_messages=args.max_messages)
-
-        daq_chunk_duration = int(rd['ini']['strax_chunk_length'] * 1e9)
-        daq_overlap_chunk_duration = int(rd['ini']['strax_chunk_overlap'] * 1e9)
 
         strax_proc = multiprocessing.Process(
             target=run_strax,


### PR DESCRIPTION
After recent updates in strax(en) bootstrax wasn't updated to reflect these options for the chunk length (and the overlap) as such, it was simply using the defaults in the daqreader. This PR lets bootstrax read these required uptions.

