### PR TITLE
Deleting free_option in xenon1t_led

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -198,7 +198,6 @@ def xenon1t_led(**kwargs):
     return st.new_context(
         replace=True,
         register=[straxen.RecordsFromPax, straxen.LEDCalibration],
-        free_options=('channel_map',),
         config=st.config,
         storage=st.storage,
         **st.context_config)


### PR DESCRIPTION
The context is not working, it seems there is a conflict with free_option. Is it indispensable?