### PR TITLE
Temporarily discard mis-assigned data on chunk boundary

### DIFF
--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -156,6 +156,18 @@ class DAQReader(strax.Plugin):
         first_start, last_start, last_end = None, None, None
         if len(records):
             first_start, last_start = records[0]['time'], records[-1]['time']
+
+            if last_start == end:
+                # TEMPORARY HACK: Discard data assigned to wrong chunk due to
+                # https://github.com/coderdj/redax/pull/82
+                print(
+                    f"Bad data from DAQ: chunk {path} should contain data "
+                    f"that starts in [{start}, {end}), but we see start times "
+                    f"ranging from {first_start} to {last_start}.")
+                print('-> discarding offending data for now!!')
+                records = records[records['time'] < end]
+                last_start = records[-1]['time']
+
             # Records are fixed length, so we also know the last end:
             last_end = strax.endtime(records[-1])
 


### PR DESCRIPTION
This is a temporary fix to be able to build data affected by https://github.com/coderdj/redax/pull/82. After that is deployed and the data is built, we should reverse this hack.