### PR TITLE
make '--production' mode explicit; prevent tests from messing up data/runDB

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -2,6 +2,12 @@
 """
 Bootstrax: XENONnT online processing manager
 =============================================
+How to use
+----------------
+    <activate conda environment>
+    bootstrax --production
+----------------
+
 First draft: Jelle Aalbers, 2018
 With additional input from: Joran Angevaare, 2020
 
@@ -11,7 +17,7 @@ You can run more than one bootstrax instance, but only one per machine. If you s
 
 
 Philosophy
--------------
+----------------
 Bootstrax has a crash-only / recovery first philosophy. Any error in the core code causes a crash; there is no nice exit or mandatory cleanup. Boostrax focuses on recovery after restarts: before starting work, we look for and fix any mess left by crashes.
 
 This ensures that hangs and hard crashes do not require expert tinkering to repair databases. Plus, you can just stop the program with ctrl-c (or, in principle, pulling the machine's power plug) at any time.
@@ -23,7 +29,7 @@ Mongo documents
 ----------------
 Bootstrax records its status in a document in the 'bootstrax' collection in the runs db. These documents contain:
   - **host**: socket.getfqdn()
-  - **time**: last time this bootstrax showed lifesigns
+  - **time**: last time this bootstrax showed life signs
   - **state**: one of the following:
     - **busy**: doing something
     - **idle**: NOT doing something; available for processing new runs
@@ -49,7 +55,7 @@ Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is
   - **disk_size**: size of the disk whereto this bootstrax instance is writing to (in TB),
   - **disk_used**: used part of the disk whereto this bootstrax instance is writing to (in percent)
 """
-__version__ = '0.4.3'
+__version__ = '0.4.5'
 
 import argparse
 from collections import Counter
@@ -65,7 +71,7 @@ import shutil
 import time
 import traceback
 from tqdm import tqdm
-from warnings import warn as warning
+
 import numpy as np
 import pymongo
 from psutil import pid_exists, Process, virtual_memory, cpu_percent, disk_usage
@@ -97,8 +103,9 @@ parser.add_argument('--infer_mode', action='store_true',
 parser.add_argument('--delete_live', action='store_true',
                     help="Do not delete live_data after successful processing of the run. "
                          "Delete the live_data if this flag is not added.")
-parser.add_argument('--test_mode', action='store_true',
-                    help="Prevent bootstrax form interacting with the runs-database")
+parser.add_argument('--production', action='store_true',
+                    help="Run bootstrax in production mode. Assuming test mode otherwise to prevent "
+                         "interactions with the runs-database")
 parser.add_argument('--max_messages', type=int,
                     default=4,
                     help="number of max mailbox messages")
@@ -130,6 +137,8 @@ eb_directories = {
     'eb4.xenon.local': '/data/xenonnt_processed/',
     'eb5.xenon.local': '/data/xenonnt_processed/',
 }
+# The folder that can be used for testing bootstrax (i.e. non production mode). It will be written to:
+test_data_folder = './bootstrax/'
 
 # Timeouts in seconds
 timeouts = {
@@ -138,7 +147,7 @@ timeouts = {
     'signal_escalate': 3,
     # Minimum waiting time to retry a failed run
     # Escalates exponentially on repeated failures: 1x, 5x, 25x, 125x, 125x, 125x, ...
-    # Some jitter is applied: actual delays willrandomly be 0.5 - 1.5x as long
+    # Some jitter is applied: actual delays will randomly be 0.5 - 1.5x as long
     'retry_run': 60,
     # Maximum time for strax to complete a processing
     # if exceeded, strax will be killed by bootstrax
@@ -188,8 +197,7 @@ bootstrax_projection = f"name start end number bootstrax status mode " \
 exception_tempfile = 'last_bootstrax_exception.txt'
 
 # The name of the thread that is opened to delete live_data
-delete_thread_name =  'DeleteThread'
-
+delete_thread_name = 'DeleteThread'
 
 ##
 # Initialize globals (e.g. rundb connection)
@@ -208,18 +216,42 @@ output_folder = eb_directories[hostname]
 if os.access(output_folder, os.W_OK) is not True:
     raise IOError(f'No writing access to {output_folder}')
 
+if not args.production:
+    # This means we are in some test mode
+    wait_diskspace_min_space = 850  # GB
+    output_folder = test_data_folder
+    if not os.path.exists(output_folder):
+        log.warning(f'Creating {output_folder}')
+        os.mkdir(output_folder)
+
+    log.warning(
+        f'\n---------------'
+        f'\nBe aware, bootstrax not running in production_mode. Specify with --production_mode.'
+        f'\nWriting new data to {output_folder}. Not saving this location in the runsDB.'
+        f'\nNot writing to the runs-database.'
+        f'\n---------------')
+    time.sleep(5)
+else:
+    if not args.delete_live:
+        log.warning("Production mode is designed to run with '--delete_live'\nplease restart bootstrax")
+    if not args.infer_mode:
+        log.warning("Better performance is expected in production mode with '--infer_mode'\nplease restart bootstrax")
+
 
 def new_context(cores=args.cores, max_messages=args.max_messages, timeout=300):
     """Create strax context that can access the runs db"""
-    # We use exactly the logic of straxen to access the runs DB;
+    # We use exactly the same logic of straxen to access the runs DB;
     # this avoids duplication, and ensures strax can access the runs DB if we can
-    return straxen.contexts.xenonnt_online(
+    context = straxen.contexts.xenonnt_online(
         output_folder=output_folder,
         we_are_the_daq=True,
         allow_multiprocess=cores > 1,
         allow_shm=cores > 1,
         max_messages=max_messages,
         timeout=timeout)
+    if not args.production:
+        context.storage = [strax.DataDirectory(output_folder)]
+    return context
 
 
 st = new_context()
@@ -235,7 +267,15 @@ usage_coll = daq_db['eb_monitor']
 # Runs database
 run_dbname = 'run'
 run_collname = 'runs'
-run_db = st.storage[0].client[run_dbname]
+if args.production:
+    run_db = st.storage[0].client[run_dbname]
+else:
+    # TODO to get a read only mode we could refer to one of the secondaries since those are readonly by default
+    run_db_username = os.environ['MONGO_RDB_USERNAME']
+    run_db_password = os.environ['MONGO_RDB_PASSWORD']
+    run_client = pymongo.MongoClient(
+        f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017,old-gw:27017/admin")
+    run_db = run_client[run_dbname]
 run_coll = run_db[run_collname]
 bs_coll = run_db['bootstrax']
 log_coll = run_db['log']
@@ -301,6 +341,8 @@ def main_loop():
     t_start = now()
 
     next_cleanup_time = now()
+    # keep track of the ith run that we have seen when we are not in production mode
+    new_runs_seen, failed_runs_seen = 0, 1
     while True:
         log.info(f'bootstrax running for {(now() - t_start).seconds} seconds')
         sufficient_diskspace()
@@ -312,8 +354,9 @@ def main_loop():
         # Check resources are still OK, otherwise crash / reboot program
 
         # Process new runs
-        rd = consider_run({"bootstrax": {"$exists": False}})
+        rd = consider_run({"bootstrax": {"$exists": False}}, test_counter=new_runs_seen)
         if rd is not None:
+            new_runs_seen += 1
             process_run(rd)
             continue
 
@@ -324,14 +367,19 @@ def main_loop():
 
         # Any failed runs to retry?
         # Only try one run, we want to be back for new runs quickly
-        rd = consider_run({
-            "bootstrax.state": 'failed',
-            "bootstrax.next_retry": {
-                '$lt': now()}})
+        rd = consider_run({"bootstrax.state": 'failed',
+                           "bootstrax.next_retry": {'$lt': now()}
+                           }, test_counter=failed_runs_seen)
         if rd is not None:
+            failed_runs_seen += 1
             process_run(rd)
             continue
 
+        if not args.production:
+            log.info(f'We have gone through the rundDB in a readonly mode there are no '
+                     f'runs left. We looked at {new_runs_seen} new runs and '
+                     f'{failed_runs_seen} previously failed runs.')
+            break
         log.info("No work to do, waiting for new runs or retry timers")
         set_state('idle')
         time.sleep(timeouts['idle_nap'])
@@ -445,6 +493,8 @@ def log_warning(message, priority='warning'):
         warning: 2,
         <any other valid python logging level, e.g. error or fatal>: 3
     """
+    if not args.production:
+        return
     getattr(log, priority)(message)
     log_coll.insert_one({
         'message': message,
@@ -463,12 +513,16 @@ def eb_can_process():
     if hostname in ['eb3.xenon.local', 'eb4.xenon.local', 'eb5.xenon.local']:
         return True
 
+    # In test mode we can always process
+    if not args.production:
+        return True
+
     # Check that there are runs that are waiting to be processed. If there are few, this
     # eb should not process.
     max_queue_new_runs = 2
     n_untouched_runs = 0
     # Count number of runs untouched by bootstrax. Sorry for the sloppy pymongo syntax.
-    for x in run_coll.find({'bootstrax': {'$exists': False}}):
+    for _ in run_coll.find({'bootstrax': {'$exists': False}}):
         n_untouched_runs += 1
     if n_untouched_runs < max_queue_new_runs:
         log.info(f'eb_can_process::\tDo not process on {hostname} as there are few new runs')
@@ -486,7 +540,7 @@ def eb_can_process():
             if eb_query['time'] < now(-timeout):
                 n_ebs_busy += 1
 
-    if (n_ebs_running == n_ebs_busy):
+    if n_ebs_running == n_ebs_busy:
         # There is a need for this eb to also process data (for now).
         log.info(f'eb_can_process::\tThere is a need for {hostname} to process data')
         return True
@@ -571,15 +625,12 @@ def sufficient_diskspace():
             # Good we can write, lets continue
             return
         else:
-            log.info(f'Insufficient free disk space ({disk.disk_free} GB)'
-                     f'on {hostname}. Waiting {wait_diskspace_dt} s ({i}th iteration')
+            log.info(f'Insufficient free disk space ({int(disk_free)} GB) '
+                     f'on {hostname}. Waiting {wait_diskspace_dt} s ({i}th iteration)')
             time.sleep(wait_diskspace_dt)
             send_heartbeat()
-            return
-
-    if args.test_mode:
-        warning("Ignoring insufficient disk space")
-        return
+            disk = disk_usage(output_folder)
+            disk_free = disk.free / gigabyte_to_byte
     raise RuntimeError("No disk space to write to")
 
 
@@ -587,42 +638,38 @@ def delete_live_data(rd, live_data_path):
     """
     Open thread to delete the live_data
     """
-    delete_thread = threading.Thread(name=delete_thread_name,
-                                     target=_delete_live_data,
-                                     args=(rd, live_data_path))
-    log.info(f'Starting thread to delete {live_data_path} at {now()}')
-    # We rather not stop deleting the live_data if something else fails. Set the thread to daemon.
-    delete_thread.setDaemon(True)
-    delete_thread.start()
-    log.info(f'DeleteThread {live_data_path} should be running in parallel, continue MainThread now: {now()}')
+    if args.production and os.path.exists(live_data_path) and args.delete_live:
+        delete_thread = threading.Thread(name=delete_thread_name,
+                                         target=_delete_live_data,
+                                         args=(rd, live_data_path))
+        log.info(f'Starting thread to delete {live_data_path} at {now()}')
+        # We rather not stop deleting the live_data if something else fails. Set the thread to daemon.
+        delete_thread.setDaemon(True)
+        delete_thread.start()
+        log.info(f'DeleteThread {live_data_path} should be running in parallel, '
+                 f'continue MainThread now: {now()}')
 
 
 def _delete_live_data(rd, live_data_path):
     """After completing the processing and updating the runsDB, remove the
     live_data"""
-
-    if os.path.exists(live_data_path) and args.delete_live:
-        log.info(f'Deleting data at {live_data_path}')
-        os.system(f'du -h -d0 {live_data_path}')
-        del_start = time.time()
-        shutil.rmtree(live_data_path)
-        log.info(f'deleting {live_data_path} took {int(time.time() - del_start)} s')
-    else:
-        raise FileNotFoundError(f'Something is off, no folder found '
-                                f'at {live_data_path} but there was '
-                                f'an attempt to delete data here')
+    log.info(f'Deleting data at {live_data_path}')
+    os.system(f'du -h -d0 {live_data_path}')
+    del_start = time.time()
+    shutil.rmtree(live_data_path)
+    log.info(f'deleting {live_data_path} took {int(time.time() - del_start)} s')
     # Remove the /live_data location from the rundoc
     if not os.path.exists(live_data_path):
-        if not args.test_mode:
-            locs = []
-            for dd in rd.get('data'):
-                if dd.get('type') != 'live':
-                    locs.append(dd)
-            run_coll.find_one_and_update(
-                {'_id': rd['_id']},
-                {'$set': {'data': locs}})
+        log.info('updating data field in rundoc')
+        locs = []
+        for dd in rd.get('data'):
+            if dd.get('type') != 'live':
+                locs.append(dd)
+        run_coll.find_one_and_update(
+            {'_id': rd['_id']},
+            {'$set': {'data': locs}})
     else:
-        raise ValueError("Something went wrong we wanted to delete this path!")
+        raise ValueError(f"Something went wrong we wanted to delete {live_data_path}!")
 
 
 def wait_on_delete_thread():
@@ -691,6 +738,9 @@ def set_run_state(rd, state, return_new_doc=True, **kwargs):
 
     Any additional kwargs will be added to the bootstrax field.
     """
+    if not args.production:
+        return run_coll.find_one({'_id': rd['_id']})
+
     bd = rd['bootstrax']
     bd.update({
         'state': state,
@@ -710,11 +760,11 @@ def set_run_state(rd, state, return_new_doc=True, **kwargs):
 
 def set_status_finished(rd):
     """Set the status to ready to upload for datamanager and admix"""
-    # Only update the status if it does not exist or if it needs to be uploaded
-    if args.test_mode:
-        log.info("Not changing the status because test_mode is enabled")
+    if not args.production:
+        # Don't update the status if we are not in production mode
         return
 
+    # Only update the status if it does not exist or if it needs to be uploaded
     ready_to_upload = {'status': 'eb_ready_to_upload'}
     if rd.get('status') in [None, 'needs_upload']:
         run_coll.find_one_and_update(
@@ -736,23 +786,33 @@ def abandon(*, mongo_id=None, number=None):
         'abandoned')
 
 
-def consider_run(query, return_new_doc=True):
+def consider_run(query, return_new_doc=True, test_counter=0):
     """Return one run doc matching query, and simultaneously set its bootstraxstate to 'considering'"""
     # We must first do an atomic find-and-update to set the run's state
     # to "considering", to ensure the run doesn't get picked up by a
     # bootstrax on another host.
-    rd = run_coll.find_one_and_update(
-        query,
-        {"$set": {'bootstrax.state': 'considering'}},
-        projection=bootstrax_projection,
-        return_document=True,
-        sort=[('start', pymongo.DESCENDING)])
-
-    # Next, we can update the bootstrax entry properly with set_run_state
-    # (adding hostname, time, etc.)
-    if rd is None:
-        return None
-    return set_run_state(rd, 'considering', return_new_doc=return_new_doc)
+    if args.production:
+        rd = run_coll.find_one_and_update(
+            query,
+            {"$set": {'bootstrax.state': 'considering'}},
+            projection=bootstrax_projection,
+            return_document=True,
+            sort=[('start', pymongo.DESCENDING)])
+        # Next, we can update the bootstrax entry properly with set_run_state
+        # (adding hostname, time, etc.)
+        if rd is None:
+            return None
+        return set_run_state(rd, 'considering', return_new_doc=return_new_doc)
+    else:
+        # Don't change the runs-database for test modes
+        try:
+            rds = run_coll.find(
+                query,
+                projection=bootstrax_projection,
+                sort=[('start', pymongo.DESCENDING)])
+            return rds[test_counter]
+        except IndexError:
+            return None
 
 
 def fail_run(rd, reason):
@@ -763,7 +823,7 @@ def fail_run(rd, reason):
         long_run_id = f"run {rd['number']}:{rd['_id']}"
 
     # No bootstrax info is present when manually failing a run with args.fail
-    if not 'bootstrax' in rd.keys():
+    if 'bootstrax' not in rd.keys():
         rd['bootstrax'] = {}
         rd['bootstrax']['n_failures'] = 0
 
@@ -878,7 +938,7 @@ def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
         raise
 
 
-def process_run(rd, send_heartbeats=True):
+def process_run(rd, send_heartbeats=args.production):
     log.info(f"Starting processing of run {rd['number']}")
     if rd is None:
         raise RuntimeError("Pass a valid rundoc, not None!")
@@ -888,7 +948,10 @@ def process_run(rd, send_heartbeats=True):
         pass
 
     def fail(reason):
-        fail_run(rd, reason)
+        if args.production:
+            fail_run(rd, reason)
+        else:
+            log.warning(reason)
         raise RunFailed
 
     try:
@@ -930,7 +993,10 @@ def process_run(rd, send_heartbeats=True):
         # Remove any previous processed data
         # If we do not do this, strax will just load this instead of
         # starting a new processing
-        clean_run(mongo_id=rd['_id'])
+        if args.production:
+            clean_run(mongo_id=rd['_id'])
+        else:
+            clean_run_test_data(run_id)
 
         # Remove any temporary exception info from previous runs
         if osp.exists(exception_tempfile):
@@ -985,11 +1051,12 @@ def process_run(rd, send_heartbeats=True):
                 if t0 < now(-timeouts['max_processing_time']):
                     fail(f"Processing took longer than {timeouts['max_processing_time']} sec")
                     kill_process(strax_proc.pid)
-
                 # Still working, check in later
                 # TODO: is there a good way to detect hangs, before max_processing_time expires?
+
                 log.info(f"Still processing run {run_id}")
-                set_run_state(rd, 'busy', **info)
+                if args.production:
+                    set_run_state(rd, 'busy', **info)
                 time.sleep(timeouts['check_on_strax'])
                 continue
 
@@ -1005,7 +1072,7 @@ def process_run(rd, send_heartbeats=True):
                     fail("Processing succeeded, but no chunks were written!")
 
                 rd = get_run(mongo_id=rd['_id'])
-                if not 'end' in rd:
+                if 'end' not in rd:
                     fail("Processing succeeded, but run hasn't yet ended!")
 
                 # Check that the data written covers the run
@@ -1026,18 +1093,19 @@ def process_run(rd, send_heartbeats=True):
                     log_warning(f"Processing covered {t_covered.seconds}, "
                                 f"but run lasted {run_duration.seconds}!")
 
-                log.info(f"Run {run_id} processed succesfully")
-                set_run_state(rd, 'done', **info)
-                set_status_finished(rd)
+                log.info(f"Run {run_id} processed successfully")
+                if args.production:
+                    set_run_state(rd, 'done', **info)
+                    set_status_finished(rd)
 
-                if args.delete_live:
-                    delete_live_data(rd, loc)
+                    if args.delete_live:
+                        delete_live_data(rd, loc)
                 break
 
             else:
                 # This is just the info that we're starting
                 # exception retrieval. The actual error comes later.
-                log.info(f"Failure while procesing run {run_id}")
+                log.info(f"Failure while processing run {run_id}")
                 if osp.exists(exception_tempfile):
                     with open(exception_tempfile, mode='r') as f:
                         exc_info = f.read()
@@ -1059,7 +1127,7 @@ def process_run(rd, send_heartbeats=True):
 ##
 
 
-def clean_run(*, mongo_id=None, number=None):
+def clean_run(*, mongo_id=None, number=None, force=False):
     """Removes all data on this host associated with a run
     that was previously registered in the run db.
 
@@ -1070,10 +1138,14 @@ def clean_run(*, mongo_id=None, number=None):
     # a surgical update below
     rd = get_run(mongo_id=mongo_id, number=number, full_doc=True)
     new_data = []
+    have_live_data = np.any(['live' in dd['type'] for dd in rd['data']])
     for ddoc in rd['data']:
         if 'host' in ddoc and ddoc['host'] == hostname:
             loc = ddoc['location']
-            if os.path.exists(loc):
+            if not force and not have_live_data and 'raw_records' in ddoc['type']:
+                log.info(f'prevent {loc} from being deleted. The live_data has already'
+                         f' been removed')
+            elif os.path.exists(loc):
                 shutil.rmtree(loc)
         else:
             new_data.append(ddoc)
@@ -1081,6 +1153,16 @@ def clean_run(*, mongo_id=None, number=None):
         {'_id': rd['_id']},
         {'$set': {
             'data': new_data}})
+
+
+def clean_run_test_data(run_id):
+    """
+    Clean the data in the test_data_folder associated with this run_id
+    """
+    for folder in os.listdir(test_data_folder):
+        if run_id in folder:
+            log.info(f'Cleaning {test_data_folder + folder}')
+            shutil.rmtree(test_data_folder + folder)
 
 
 def cleanup_db():

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -226,7 +226,7 @@ if not args.production:
 
     log.warning(
         f'\n---------------'
-        f'\nBe aware, bootstrax not running in production_mode. Specify with --production_mode.'
+        f'\nBe aware, bootstrax not running in production mode. Specify with --production.'
         f'\nWriting new data to {output_folder}. Not saving this location in the runsDB.'
         f'\nNot writing to the runs-database.'
         f'\n---------------')


### PR DESCRIPTION
**Explicit production mode**
This pull request builds on #96. With this pull request we make it absolutely explicit that you are running the production mode of bootstrax. Run this by e.g.:
```
bootstrax --production
```
**Testing mode: ommit ```'--production'```**
If one does not specify that the bootstrax is used for ```--production``` some features are disabled that might be hard/impossible/annoying to fix.

This prevents bootstrax from interacting with the runDB to:
- Register new data
- Update the status of bootstrax
- Delete `live_data`
- Write data to any of the xenonnt-processed data directories on the eventbuilders

To this end we have to overwrite the mongo frontend in the strax.DataDirectory and point it to a folder in the directory where strax is called from. This might not be ideal but allows sufficient flexibility. As it is checked each run that there is sufficient storage, I deem it save enough. Of course this means that the DAQ people have the responsibility to clean up this folder themselves.

Furthermore, as we don't keep track of the processing using the runsDB for these ```test mode``` bootstrax instances I've added a simple counter in the main() loop that checks how many runs it has processed (or tried to) such that we still loop over the events. This is not a infinite loop (as one shouldn't want to build for testing). This could in principle give funny edge cases of the testing mode, what if another 'production bootstrax' is processing the same run and deletes the live_data before a 'test bootstrax' finishes processing? However, such a scenario doesn't seem sufficiently likely/important that I think it is required to have this handled differently: the test will fail and production will continue unaffected.

The DAQ database is still used to register the bootstrax instance such that it can be killed in the ```main()``` loop.

Additionally, I've added another safeguard that prevents us from accidently deleting 'raw_records' from a disk if 'live_data' is no longer available.

**How to run bootstrax production**
After this PR bootstrax should be better protected from accidently removing/overwriting important data. The best mode to operate bootstrax during production after this PR will be:
```
(base) xedaq@eb1:~$ conda activate py37
(py37) xedaq@eb1:~$ python bootstrax --infer_mode --production --delete_live
```
**How to run bootstrax for testing**
Testing is assumed one can simply do single runs by:
```
(base) xedaq@eb1:~$ conda activate py37
(py37) xedaq@eb1:~$ python bootstrax --process <run_id>
```