### PR TITLE
Restore checks on DAQ data

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1088,10 +1088,8 @@ def process_run(rd, send_heartbeats=args.production):
                 if not (timedelta(seconds=-30)
                         < (run_duration - t_covered)
                         < timedelta(seconds=30)):
-                    # Todo
-                    #  revert statement to fail(...) if daq timestamp issues are resolved
-                    log_warning(f"Processing covered {t_covered.seconds}, "
-                                f"but run lasted {run_duration.seconds}!")
+                    fail(f"Processing covered {t_covered.seconds}, "
+                         f"but run lasted {run_duration.seconds}!")
 
                 log.info(f"Run {run_id} processed successfully")
                 if args.production:

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -21,7 +21,6 @@ common_opts = dict(
 xnt_common_config = dict(
     n_tpc_pmts=494,
     gain_model=('to_pe_constant', 0.005),
-    check_raw_record_overlaps=False,  # Tempory hack until DAQ timestamps fixed
     channel_map=immutabledict(
          # (Minimum channel, maximum channel)
          tpc=(0, 493),


### PR DESCRIPTION
This restores some checks bootstrax straxen does on the DAQ data (disabled in 5d73ee9dc0ceb13a4042873f923e5fdec1261ed6, https://github.com/XENONnT/straxen/pull/96). Now that the timestamp and overwriting issues seem to be fixed, normal data should pass these checks.