### PR TITLE
event_scatter colorbar label fix

### DIFF
--- a/straxen/analyses/quick_checks.py
+++ b/straxen/analyses/quick_checks.py
@@ -151,10 +151,14 @@ def event_scatter(context, run_id, events,
         extend = 'neither' if color_range[1] is None else 'max'
     else:
         extend = 'min' if color_range[1] is None else 'both'
-    plt.colorbar(label="S1 area fraction top",
-                 extend=extend,
-                 ax=[ax, ax3])
-
+    if color_dim == 's1_area_fraction_top':
+        plt.colorbar(label="S1 area fraction top",
+                     extend=extend,
+                     ax=[ax, ax3])
+    else:
+        plt.colorbar(label=color_dim,
+                     extend=extend,
+                     ax=[ax, ax3])
 
 @straxen.mini_analysis(requires=('event_info',))
 def plot_energy_spectrum(


### PR DESCRIPTION
Event scatter plot does not have an override setting for when the colorbar does not indicate S1_area_fraction_top. This will return the default colorbar label, unless user specifies the colorbar to be something else (say, n_peaks.) Then the colorbar label will just be the colormap indicator used.