### PR TITLE
Keeps the live data entry in the rundoc

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -696,13 +696,9 @@ def _delete_live_data(rd, live_data_path):
     # Remove the /live_data location from the rundoc
     if not os.path.exists(live_data_path):
         log.info('updating data field in rundoc')
-        locs = []
-        for dd in rd.get('data'):
-            if dd.get('type') != 'live':
-                locs.append(dd)
-        run_coll.find_one_and_update(
-            {'_id': rd['_id']},
-            {'$set': {'data': locs}})
+        run_coll.update_one(
+                {'_id' : rd['_id'], 'data.type' : 'live'}
+                {'$set' : {'data.$.location' : 'deleted'}})
     else:
         raise ValueError(f"Something went wrong we wanted to delete {live_data_path}!")
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -697,7 +697,7 @@ def _delete_live_data(rd, live_data_path):
     if not os.path.exists(live_data_path):
         log.info('updating data field in rundoc')
         run_coll.update_one(
-                {'_id' : rd['_id'], 'data.type' : 'live'}
+                {'_id' : rd['_id'], 'data.type' : 'live'},
                 {'$set' : {'data.$.location' : 'deleted'}})
     else:
         raise ValueError(f"Something went wrong we wanted to delete {live_data_path}!")

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1227,8 +1227,8 @@ def clean_run(*, mongo_id=None, number=None, force=False):
                 log.info(f'prevent {loc} from being deleted. The live_data has already'
                          f' been removed')
             elif os.path.exists(loc):
+                ddoc['location'] = 'deleted'
                 shutil.rmtree(loc)
-        else:
             new_data.append(ddoc)
     run_coll.find_one_and_update(
         {'_id': rd['_id']},


### PR DESCRIPTION
Rather than removing all trace of the live data existing once live processing concludes and the data on disk is deleted, its entry in the rundoc is kept, but its location is changed to "deleted".