### PR TITLE
immutabledict missing from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ git+git://github.com/AxFoundation/strax
 multihist>=0.6.3
 matplotlib
 packaging
+immutabledict


### PR DESCRIPTION
When updating straxen, I got an immutabledict not installed error.  As this is used within straxen, it should be in the requirements.txt