### PR TITLE
fried contexts

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -194,6 +194,20 @@ def xenon1t_dali(output_folder='./strax_data', build_lowlevel=False):
             else ('raw_records', 'records', 'peaklets')),
         **x1t_context_config)
 
+def xenon1t_fried(output_folder='./strax_data', build_lowlevel=False):
+    # For use on fried.rice.edu
+    st = xenon1t_dali(output_folder, build_lowlevel)
+    st.storage=[
+            strax.DataDirectory(
+                '/data/xenon1t/strax_data_raw',
+                take_only='raw_records',
+                provide_run_metadata=True,
+                readonly=True),
+            strax.DataDirectory(
+                '/data/xenon1t/strax_data',
+                readonly=True),
+            strax.DataDirectory(output_folder)]
+    return st
 
 def xenon1t_led(**kwargs):
     st = xenon1t_dali(**kwargs)

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -69,6 +69,16 @@ def xenonnt_online(output_folder='./strax_data',
         st.context_config['forbid_creation_of'] = 'raw_records'
 
     return st
+    
+def xenonnt_fried(**kwargs):
+    """XENONnT online processing and analysis for fried.rice.edu"""
+    st = xenonnt_online(**kwargs)
+    for backend in st.storage:
+        if isinstance(backend, strax.DataDirectory):
+            backend.path = backend.path.replace('/dali/lgrandi/xenonnt/',
+                                                '/data/xenonnt/')
+    
+    return st
 
 
 def xenonnt_led(**kwargs):


### PR DESCRIPTION
Adding a context for fried accessing xenon1t and xenonnt data.  Since this is JupyterHub, it might be useful for demos.