### PR TITLE
Update n_top_pmts for default for xenon-nt

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -117,6 +117,7 @@ x1t_common_config = dict(
     check_raw_record_overlaps=False,
     allow_sloppy_chunking=True,
     n_tpc_pmts=248,
+    n_top_pmts=127,
     channel_map=immutabledict(
         # (Minimum channel, maximum channel)
         tpc=(0, 247),

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -14,7 +14,7 @@ export, __all__ = strax.exporter()
 
 @export
 @strax.takes_config(
-    strax.Option('n_top_pmts', default=127,
+    strax.Option('n_top_pmts', default=253,
                  help="Number of top PMTs"))
 class PeakBasics(strax.Plugin):
     __version__ = "0.0.6"


### PR DESCRIPTION
Update n_top_pmts for XENONnT default. As we have PMT numbers 0-252 in the top array for nT, we have 253 top PMTs.

This was raised by Darryl in the straxferno course.