### PR TITLE
Patch nhits peaklets

### DIFF
--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -61,7 +61,7 @@ class Peaklets(strax.Plugin):
     parallel = 'process'
     compressor = 'zstd'
 
-    __version__ = '0.3.2'
+    __version__ = '0.3.3'
 
     def infer_dtype(self):
         return dict(peaklets=strax.peak_dtype(

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -150,7 +150,12 @@ class Peaklets(strax.Plugin):
             assert np.diff(hits['time']).min(initial=1) >= 0, "Hits not sorted"
             assert np.all(peaklets['time'][1:]
                           >= strax.endtime(peaklets)[:-1]), "Peaks not disjoint"
-
+        
+        # Update nhits of peaklets:
+        counts = strax.touching_windows(hits, peaklets)
+        counts = np.diff(counts, axis=1).flatten()
+        peaklets['n_hits'] = counts
+        
         return dict(peaklets=peaklets,
                     lone_hits=lone_hits)
 


### PR DESCRIPTION
Fixed issue, that n_hits of split peaklets is zero. If accepted, one should also update the docstring in the strax dtype.