### PR TITLE
Bootstrax  updates and removing data from ebs

### DIFF
--- a/bin/ajax
+++ b/bin/ajax
@@ -18,6 +18,15 @@ import shutil
 import pymongo
 import pytz
 
+# TODO
+#  Ajax is aimed at making bootstrax simpler and more devoted to the processing while Ajax
+#  is clearing the data behind it.
+#  To this purpose I want to add:
+#  Delete the failed runs from the /live_data partition
+#  Delete old high level plugins
+#  Move/Delete old raw_records_nv
+#  Delete live_data if the run has been successfully processed and uploaded
+
 
 def now(plus=0):
     return datetime.now(pytz.utc) + timedelta(seconds=plus)

--- a/bin/ajax
+++ b/bin/ajax
@@ -8,7 +8,7 @@ Joran Angevaare, 2020
 
 This tool keeps the event builders clean by:
  A) deleting data associated to a run if it has been abandoned (delete live_data and data from eb)
- B) there is old high level data on the machine
+ B) deleting data if there is old high level data on the machine
  C) (re)moving old raw_records_nv as we do not plan to store this data long term
  D) check that the live_data is deleted if a run has been successfully processed and uploaded
 

--- a/bin/ajax
+++ b/bin/ajax
@@ -277,7 +277,8 @@ def _rmtree(path):
     :return:
     """
     if args.execute:
-        shutil.rmtree(path)
+        if confirm(f'delete {path}?'):
+            shutil.rmtree(path)
     else:
         log.info(f'TESTING:\tshutil.rmtree({path})')
         if not os.path.exists(path):
@@ -323,11 +324,12 @@ def delete_data(rd, path, data_type, test=True):
         ddoc.update({'at': now(), 'by': hostname + '.ajax'})
         log.info(f'update with {ddoc}')
         if args.execute and not args.test:
-            run_coll.update_one({'_id': rd['_id']},
-                                {"$addToSet": {'deleted_data': ddoc},
-                                 "$pull": {"data":
-                                               {"type": data_type,
-                                                "host": {'$in': ['daq', hostname]}}}})
+            if confirm('update rundoc?'):
+                run_coll.update_one({'_id': rd['_id']},
+                                    {"$addToSet": {'deleted_data': ddoc},
+                                     "$pull": {"data":
+                                                   {"type": data_type,
+                                                    "host": {'$in': ['daq', hostname]}}}})
         else:
             log.info(f'Update ddoc with : {ddoc}')
     elif not test:
@@ -395,6 +397,7 @@ def remove_if_unregistered(number, delete_live=False):
             # runDB)
             _remove_unregistered_run(ceph_folder, run_id, checked_db=True)
 
+
 def _remove_unregistered_run(base_folder, run_id, checked_db=False):
     """
     NB: The check that this run is not registered should be performed first!
@@ -428,6 +431,22 @@ def _remove_unregistered_run(base_folder, run_id, checked_db=False):
 def now(plus=0):
     """UTC timestamp"""
     return datetime.now(pytz.utc) + timedelta(seconds=plus)
+
+
+def confirm(question):
+    """
+    If --ask_confirm is specified, ask user to confirm to proceed.
+    :return: bool
+    """
+    if not args.ask_confirm:
+        return True
+    answer = str(input(question+' (y/n): ')).lower().strip()
+    if answer is 'y':
+        return True
+    elif answer is 'no':
+        return False
+    else:
+        confirm('please input (y/n)\n')
 
 
 def wait_on_delete_thread():
@@ -464,6 +483,9 @@ if __name__ == '__main__':
         description="XENONnT cleaning manager")
     parser.add_argument('--force', action='store_true',
                         help="Forcefully remove stuff from this host")
+    parser.add_argument('--ask_confirm', action='store_true',
+                        help="Always ask for confirmation before deleting data/updating"
+                             " the rundoc")
     parser.add_argument('--delete_live', action='store_true',
                         help="delete live data for this run")
     parser.add_argument('--execute', action='store_true',

--- a/bin/ajax
+++ b/bin/ajax
@@ -2,12 +2,24 @@
 """
 AJAX: XENONnT
 Aggregate Junking Ancient Xenondata
-cleaning tool to remove old data from eventbuilders
+cleaning tool to remove old data from eventbuilders.
 =============================================
 Joran Angevaare, 2020
 
+This tool keeps the event builders clean by:
+ A) deleting data associated to a run if it has been abandoned (delete live_data and data from eb)
+ B) there is old high level data on the machine
+ C) (re)moving old raw_records_nv as we do not plan to store this data long term
+ D) check that the live_data is deleted if a run has been successfully processed and uploaded
+
+Whereas A-C can be performed on autopilot D is a rather delicate task as it can become somewhat complicated if multiple
+ajax instances are running on different machines.
+This could be solved by registering ajax like bootstrax but this seems overkill at the moment.
+Therefore D) can only be performed on one of the eventbuiders (see eb_can_clean_ceph).
+
 """
-__version__ = '0.0.1'
+
+__version__ = '0.0.2'
 
 import argparse
 from datetime import datetime, timedelta
@@ -17,31 +29,287 @@ import socket
 import shutil
 import pymongo
 import pytz
+import threading
+import time
+import re
+import numpy as np
+import sys
 
-# TODO
-#  Ajax is aimed at making bootstrax simpler and more devoted to the processing while Ajax
-#  is clearing the data behind it.
-#  To this purpose I want to add:
-#  Delete the failed runs from the /live_data partition
-#  Delete old high level plugins
-#  Move/Delete old raw_records_nv
-#  Delete live_data if the run has been successfully processed and uploaded
+##
+# Parameters
+##
+ajax_thresholds = {
+    # Remove the live data only if this many seconds old
+    'remove_live_after': 24 * 3600,  # s
+    # Remove do not remove successfully processed runs if they have finished less than
+    # this many seconds ago
+    'wait_after_processing': 2 * 3600,  # s
+    # Remove the raw records of the neutron veto after this many seconds
+    # TODO
+    #  make sure that ajax breaks if we get a SN trigger
+    'remove_raw_records_nv': 24 * 3600,  # s
+    # Remove high level plugins if the run is this old
+    # TODO
+    #  change the value to a different one
+    'remove_high_level_data': 365 * 24 * 3600,  # s
+    # Minimum time for restarting ajax to check for new stuff to clean (essentially the
+    # timeout)
+    'nap_time': 3600,  # s
+    # Short nap time
+    'short_nap': 1,  # s
+
+}
+
+# The low level data is taken care of by admix so we don't have to delete this. All other
+# data-types are deleted in the clean_high_level_data routine
+low_level_data = ['records*', 'raw_records*',
+                  'lone_hits', 'veto_regions', 'pulse_counts', 'led_calibration'
+                                                               'peaklets', ]
+
+# Open deletion threads with this prefix (and also look for these before quiting ajax)
+thread_prefix = 'ajax_delete'
+
+# To prevent multiple ebs from cleaning ceph only this one can actually do it
+eb_can_clean_ceph = 'eb0.xenon.local'
 
 
-def now(plus=0):
-    return datetime.now(pytz.utc) + timedelta(seconds=plus)
+##
+# Main functions
+##
+
+
+def main_ajax():
+    """Main function"""
+    if args.number:
+        remove_run_from_host(args.number)
+    if args.delete_live:
+        remove_run_from_host(args.number, delete_live=True)
+
+    if args.mode:
+        if args.mode == 'clean_ceph':
+            clean_cehp()
+        elif args.mode == 'clean_high_level_data':
+            clean_high_level_data()
+        elif args.mode == 'clean_unregistered':
+            clean_unregistered()
+        elif args.mode == 'clean_raw_records_nv':
+            clean_raw_records_nv()
+        elif args.mode == 'clean_abandoned':
+            clean_abandoned()
+        elif args.mode == 'clean_all':
+            while True:
+                if hostname == eb_can_clean_ceph:
+                    clean_cehp()
+                clean_high_level_data()
+                clean_unregistered()
+                clean_raw_records_nv()
+                if not args.execute:
+                    break
+                log.info(f'Loop finished, take a {ajax_thresholds["nap_time"]} s nap')
+                time.sleep(ajax_thresholds['nap_time'])
+        else:
+            raise ValueError(f'Unknown mode {args.mode}')
+
+
+def clean_cehp():
+    """
+    Look for old data on ceph. If found, delete it. Recursively iterate until no old data
+    is found. This function only works on the the host that is eb_can_clean_ceph.
+    """
+    if not hostname == eb_can_clean_ceph:
+        log.info(f'clean_cehp::\tfor cleaning ceph, go to {eb_can_clean_ceph}')
+        return
+
+    rd = run_coll.find_one({'bootstrax.state': 'done',
+                            'status': 'transferred',
+                            'start':
+                                {'$lt': now(-ajax_thresholds['remove_live_after'])},
+                            'bootstrax.time':
+                                {"$lt": now(-ajax_thresholds['wait_after_processing'])},
+                            'data.type': 'live'})
+    if rd is None:
+        return
+    else:
+        run_number = rd['number']
+        log.info(f'clean_cehp::\tremove data associated to run {run_number}')
+        remove_run_from_host(run_number, delete_live=True)
+        log.info(f'clean_cehp::\tfinished for {run_number}, take a'
+                 f' {ajax_thresholds["short_nap"]} s nap')
+        time.sleep(ajax_thresholds['short_nap'])
+
+        # Repeat.
+        if args.execute:
+            clean_cehp()
+
+    # Finally, check that there is no old data on ceph that is also not in the rundoc.
+    clean_unregistered(delete_live=True)
+
+
+def clean_high_level_data():
+    """
+    Check the runs database for old data on this host and clean all non-low-level
+    data-types from this host.
+    """
+    # We need to grep all the rundocs at once as simply doing one at the time (find_one)
+    # might get stuck as the query may yield the same result the next time it is called.
+    rds = run_coll.find({'bootstrax.state': 'done',
+                         'status': 'transferred',
+                         'start':
+                             {"$lt": now(-ajax_thresholds['remove_high_level_data'])},
+                         'data.host': hostname})
+    if not rds:
+        # Great, we are clean
+        return
+
+    for rd in rds:
+        # First check that we actually have raw_records stored somewhere
+        have_raw_records = False
+        for dd in rd['data']:
+            if dd['type'] == 'raw_records' and dd['location'] != 'deleted':
+                have_raw_records = True
+                break
+        if not have_raw_records:
+            break
+
+        # Okay, good to go let's see if it is high level data and if so, delete it
+        for ddoc in rd['data']:
+            # Only delete data on this host
+            if 'host' in ddoc and ddoc['host'] == hostname:
+                is_low_level = re.findall('|'.join(low_level_data), ddoc['type'])
+                if is_low_level:
+                    continue
+                loc = ddoc['location']
+                if 'raw_records' in ddoc['type']:
+                    raise ValueError('clean_high_level_data::\tyour regex syntax fails!')
+                elif os.path.exists(loc):
+                    log.info(f'clean_high_level_data::\tdelete data at {loc}')
+                    delete_data(rd, loc, ddoc['type'], test=not args.execute)
+                else:
+                    loc = loc + '_temp'
+                    log.info(f'clean_high_level_data::\tdelete data at {loc}')
+                    delete_data(rd, loc, ddoc['type'], test=not args.execute)
+
+
+def check_sn_trigger():
+    """
+    Get the information of a supernova trigger from some place. If occurred we should
+    crash immediately to prevent data loss
+    """
+    # Check some database for supernova triggers
+    super_nova = False
+    # super_nova = True if run_db['sn_trigger'].find_one({'time':{'$exists':True}}) else False
+    if super_nova:
+        # Just brute force quit, no exception catching nonsense
+        sys.exit(-1)
+
+
+def clean_raw_records_nv():
+    """
+    Based on the runsDB, remove the raw_records_nv if they are old
+    """
+    check_sn_trigger()
+    rd = run_coll.find_one({'data.type': 'raw_records_nv',
+                            'start':
+                                {'$lt': now(-ajax_thresholds["remove_raw_records_nv"])}})
+    if not rd:
+        return
+    for ddoc in rd['data']:
+        if ddoc.get('type', '') == 'raw_records_nv':
+            break
+    if ddoc.get('type', '') == 'raw_records_nv':
+        log.info(f'clean_raw_records_nv::\tNOT implemented but could have done something '
+                 f'with {ddoc["location"]}')
+
+    pass
+
+
+def clean_unregistered(delete_live=False):
+    """
+    Clean data that is not in the database. To do this check the output folder and remove
+    files if there is no corresponding entry in the rundoc
+    :param delete_live: bool, if true delete unregistered live data.
+    """
+    folder_to_check = output_folder if delete_live is False else ceph_folder
+    all_data = os.listdir(folder_to_check)
+    run_ids = []
+    for f in all_data:
+        run_ids.append(f.split('-')[0])
+    run_ids = np.unique(run_ids)
+    log.info(f'clean_unregistered::\tfound {len(run_ids)} runs stored on'
+             f'{folder_to_check}. Checking that each is in the runs-database')
+    for run_id in run_ids:
+        remove_if_unregistered(int(run_id), delete_live=delete_live)
+
+
+def clean_abandoned(delete_live=False):
+    """
+    Recursively delete data associated to abandoned runs.
+    :param delete_live: bool, if true also delete the live_data of these runs.
+    """
+    if not delete_live:
+        rd = run_coll.find_one({'bootstrax.state': 'abandoned',
+                                'data.host': hostname})
+    else:
+        rd = run_coll.find_one({'bootstrax.state': 'abandoned',
+                                'data.host': 'daq'})
+    if rd is None:
+        return
+
+    run_number = rd['number']
+    log.info(f'clean_abandoned::\tremove data associated to run {run_number}')
+    remove_run_from_host(run_number, delete_live=delete_live)
+
+    # Repeat
+    if args.execute:
+        clean_abandoned()
+
+
+##
+# Core functions
+##
+
+def _rmtree(path):
+    """
+    Wrapper for shutil.rmtree. All deletion statements in this script go through this
+    function in order to make sure that the args.execute statement is always double
+    (tripple) checked before deleting data.
+    :param path: path to delete
+    :return:
+    """
+    if args.execute:
+        pass
+        # shutil.rmtree(path)
+    else:
+        log.info(f'TESTING:\tshutil.rmtree({path})')
+        if not os.path.exists(path):
+            raise ValueError(f'{path} does not exist')
+
+
+def threaded_delete_data(rd, path, data_type, test=True):
+    """
+    Wrapper for delete_data to run in separate threads.
+    """
+    thread_name = thread_prefix + path.split('/')[-1]
+    delete_thread = threading.Thread(name=thread_name,
+                                     target=delete_data,
+                                     args=(rd, path, data_type, test))
+    log.info(f'Starting thread to delete {path} at {now()}')
+    # We rather not stop deleting the live_data if something else fails. Set the thread
+    # to daemon.
+    delete_thread.setDaemon(True)
+    delete_thread.start()
+    log.info(f'DeleteThread {path} should be running in parallel, continue MainThread '
+             f'now: {now()}')
 
 
 def delete_data(rd, path, data_type, test=True):
-    """After completing the processing and updating the runsDB, remove the
-    live_data"""
-
-    if data_type == 'live' and not args.delete_live:
-        raise ValueError('Unsafe operation. Trying to delete live data!')
+    """Delete data and update the rundoc"""
+    # if data_type == 'live' and not args.delete_live:
+    #     raise ValueError('Unsafe operation. Trying to delete live data!')
     if os.path.exists(path):
         log.info(f'Deleting data at {path}')
         if not test:
-            shutil.rmtree(path)
+            _rmtree(path)
     log.info(f'deleting {path} finished')
     # Remove the data location from the rundoc and append it to the 'deleted_data' entries
     if not os.path.exists(path):
@@ -53,17 +321,137 @@ def delete_data(rd, path, data_type, test=True):
             if k in ['location', 'meta', 'protocol']:
                 ddoc.pop(k)
 
-        ddoc.update({'at': now(), 'by': hostname})
+        ddoc.update({'at': now(), 'by': hostname + '.ajax'})
         log.info(f'update with {ddoc}')
-        if not test:
-            log.info('update test')
+        if args.execute and not args.test:
             run_coll.update_one({'_id': rd['_id']},
                                 {"$addToSet": {'deleted_data': ddoc},
                                  "$pull": {"data":
                                                {"type": data_type,
-                                                "host": {'$in':['daq', hostname]}}}})
+                                                "host": {'$in': ['daq', hostname]}}}})
+        else:
+            log.info(f'Update ddoc with : {ddoc}')
     elif not test:
         raise ValueError(f"Something went wrong we wanted to delete {path}!")
+
+
+def remove_run_from_host(number, delete_live=False):
+    # Query the database to remove data
+    rd = run_coll.find_one({'number': number,
+                            'data.host': hostname if not delete_live else 'daq'})
+    if not rd:
+        log.info(f'No registered data for {number} on {hostname}')
+        return
+
+    have_live_data, have_raw_records = False, False
+    for dd in rd['data']:
+        if dd['type'] == 'live' and dd['location'] != 'deleted':
+            have_live_data = True
+        if dd['type'] == 'raw_records' and dd['location'] != 'deleted':
+            have_raw_records = True
+    for ddoc in rd['data']:
+        if 'host' in ddoc and ddoc['host'] == hostname:
+            if delete_live:
+                continue
+            loc = ddoc['location']
+            if not args.force and not have_live_data and 'raw_records' in ddoc['type']:
+                log.info(f'prevent {loc} from being deleted. The live_data has already'
+                         f' been removed')
+            elif os.path.exists(loc):
+                log.info(f'delete data at {loc}')
+                delete_data(rd, loc, ddoc['type'], test=not args.execute)
+            else:
+                loc = loc + '_temp'
+                log.info(f'delete data at {loc}')
+                delete_data(rd, loc, ddoc['type'], test=not args.execute)
+        elif 'host' in ddoc and ddoc['host'] == 'daq':
+            run_id = '%06d' % number
+            loc = os.path.join(ddoc['location'], run_id)
+            if not delete_live:
+                log.info(f'prevent {loc} from being deleted. Do so with --delete_live')
+            elif not args.force and not have_raw_records:
+                log.info(f'Unsafe to delete {loc}, no raw_records registered. Force with '
+                         f'--force')
+            else:
+                if args.force and not have_raw_records:
+                    log.info(f'Forcefully delete {loc}, but no raw_records registered!')
+                else:
+                    log.info(f'Deleting data at {loc}')
+                threaded_delete_data(rd, loc, ddoc['type'], test=not args.execute)
+
+
+def remove_if_unregistered(number, delete_live=False):
+    # Query the database to remove data
+    rd = run_coll.find_one({'number': number,
+                            'data.host': hostname if not delete_live else 'daq'})
+    run_id = '%06d' % number
+
+    if not rd:
+        log.info(f'remove_if_unregistered::\trun {number} is NOT registered in the runDB')
+        if not delete_live:
+            # Check the local ebs disk for data.
+            _remove_unregistered_run(output_folder, run_id, checked_db=True)
+        else:
+            # Check ceph for data associated to this run (which is apparently not in the
+            # runDB)
+            _remove_unregistered_run(ceph_folder, run_id, checked_db=True)
+
+def _remove_unregistered_run(base_folder, run_id, checked_db=False):
+    """
+    NB: The check that this run is not registered should be performed first!
+    Deletes any folder from base_folder that matches run_id.
+    :param base_folder: folder to check
+    :param run_id: run_id to remove from folder
+    :param checked_db: Bool if it is checked that this run in not in the database.
+    """
+    if not checked_db:
+        raise ValueError("Only insert runs where for it is checked that it is "
+                         "not registered in the runs database ")
+    log.warning(f'No data for {run_id} found! Double checking {base_folder}!')
+    deleted_data = False
+    for folder in os.listdir(base_folder):
+        if run_id in folder:
+            log.info(f'Cleaning {base_folder + folder}')
+            if args.execute:
+                _rmtree(base_folder + folder)
+            else:
+                log.info(f'TEST\tdeleting {base_folder + folder}')
+            deleted_data = True
+    if not deleted_data:
+        raise FileNotFoundError(f'No data registered on {hostname} for {run_id}')
+
+
+##
+# Helper functions
+##
+
+
+def now(plus=0):
+    """UTC timestamp"""
+    return datetime.now(pytz.utc) + timedelta(seconds=plus)
+
+
+def wait_on_delete_thread():
+    """
+    Check that the threads with the thread_prefix are finished before continuing.
+    """
+    threads = threading.enumerate()
+    for thread in threads:
+        if thread_prefix in thread.name:
+            wait = True
+            while wait:
+                wait = False
+                if thread.isAlive():
+                    log.info(f'{thread.name} still running take a '
+                             f'{ajax_thresholds["short_nap"]} s nap')
+                    time.sleep(ajax_thresholds['short_nap'])
+                    wait = True
+    log.info(f'wait_on_delete_thread::\tChecked that all {thread_prefix}* finished')
+
+
+##
+# Main
+##
 
 
 if __name__ == '__main__':
@@ -71,6 +459,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO,
                         format='%(relativeCreated)6d %(threadName)s %(name)s %(message)s')
     log = logging.getLogger()
+    hostname = socket.getfqdn()
 
     parser = argparse.ArgumentParser(
         description="XENONnT cleaning manager")
@@ -78,23 +467,43 @@ if __name__ == '__main__':
                         help="Forcefully remove stuff from this host")
     parser.add_argument('--delete_live', action='store_true',
                         help="delete live data for this run")
-    parser.add_argument('--test', action='store_true',
-                        help="Never remove data nor update databases")
+    parser.add_argument('--execute', action='store_true',
+                        help="Execute the deletion commands. If not specified, ajax "
+                             "assumes you want to test")
 
     actions = parser.add_mutually_exclusive_group()
     actions.add_argument('--number', type=int, metavar='NUMBER',
                          help="Process a single run, regardless of its status.")
+    actions.add_argument('--mode', type=str,
+                         help=
+                         'Run ajax in any of the following modes: [clean_ceph, clean_raw_records_nv, '
+                         'clean_unregistered, clean_abandoned, clean_high_level_data, clean_all]\n'
+                         '"clean_ceph": Remove successfully processed runs and abandoned runs from /live_data\n'
+                         '"clean_raw_records_nv": (re)move raw_records_nv if older than threshold\n'
+                         '"clean_unregistered": remove all data from this host that is not registered in the rundb\n'
+                         '"clean_abandoned": remove all the data associated to abandoned runs\n'
+                         '"clean_high_level_data": remove all the data on host that is not registered in the rundb\n'
+                         '"clean_all": Clean everything that AJAX can get its hands on: unregistered data, high level '
+                         'data, old raw_records_nv')
 
     args = parser.parse_args()
-    run_id = '%06d' % args.number
-    if args.force:
-        log.warning(f'DANGERZONE you are forcefully deleting data that may result in an irrecoverable loss of data.')
-        log.info(f'Please note that tests argument is {args.test} which means you are {"" if args.test else "!NOT!"} safe')
-        if not input('Want to proceed willingly? [y]').lower() == 'y':
-            log.info(f'Alright no unsafe operations, bye bye')
-            exit(-1)
 
-    hostname = socket.getfqdn()
+    if args.mode == 'clean_raw_records_nv':
+        log.info(f'main::\tDelete neutron veto data from {hostname} older than '
+                 f'{ajax_thresholds["remove_raw_records_nv"]} s')
+        raise NotImplementedError("I don't know what to do with the raw_records of the NV")
+    if args.delete_live:
+        if not args.number:
+            raise ValueError("Specify which number with --number")
+    if args.force:
+        log.warning(f'main::\tDANGER ZONE you are forcefully deleting data that may '
+                    f'result in an irrecoverable loss of data.')
+        log.info(f'main::\tPlease note that execute argument is {args.execute} which '
+                 f'means you are {"" if not args.execute else "!NOT!"} safe')
+        if not input('Want to proceed willingly? [y]').lower() == 'y':
+            log.info(f'main::\tAlright no unsafe operations, bye bye')
+            exit(-1)
+        raise NotImplementedError('main::\tI dont want to have this option enabled yet.')
 
     # The event builders write to different directories on the respective machines.
     eb_directories = {
@@ -106,16 +515,16 @@ if __name__ == '__main__':
         'eb5.xenon.local': '/data/xenonnt_processed/',
     }
 
-    # Set the output folder
+    # Set the folders
+    ceph_folder = '/live_data/xenonnt/'
     output_folder = eb_directories[hostname]
     if os.access(output_folder, os.W_OK) is not True:
-        raise IOError(f'No writing access to {output_folder}')
+        raise IOError(f'main::\tNo writing access to {output_folder}')
 
     # Runs database
     run_dbname = 'xenonnt'
     run_collname = 'runs'
 
-    # Please note, this is a read only account on the rundb
     run_db_username = os.environ['MONGO_RDB_USERNAME']
     run_db_password = os.environ['MONGO_RDB_PASSWORD']
     run_client = pymongo.MongoClient(
@@ -123,52 +532,6 @@ if __name__ == '__main__':
     run_db = run_client[run_dbname]
     run_coll = run_db[run_collname]
 
-    # Query the database to remove data
-    rd = run_coll.find_one({
-        'number': args.number,
-        'data.host': hostname}
-        )
-    if not rd:
-        log.warning(f'No data for {run_id} found! Double checking on the disk!')
-        deleted_data = False
-        for folder in os.listdir(output_folder):
-            if run_id in folder:
-                log.info(f'Cleaning {output_folder + folder}')
-                if not args.test:
-                     shutil.rmtree(output_folder + folder)
-                deleted_data = True
-        if not deleted_data:
-            raise FileNotFoundError(f'No data registered on {hostname} for {args.number}')
-    else:
-        have_live_data, have_raw_records = False, False
-        for dd in rd['data']:
-            if dd['type'] == 'live' and dd['location'] != 'deleted':
-                have_live_data = True
-            if dd['type'] == 'raw_records' and dd['location'] != 'deleted':
-                have_raw_records = True
-        for ddoc in rd['data']:
-            if 'host' in ddoc and ddoc['host'] == hostname:
-                loc = ddoc['location']
-                if not args.force and not have_live_data and 'raw_records' in ddoc['type']:
-                    log.info(f'prevent {loc} from being deleted. The live_data has already'
-                             f' been removed')
-                elif os.path.exists(loc):
-                    log.info(f'delete data at {loc}')
-                    delete_data(rd, loc, ddoc['type'], test=args.test)
-                else:
-                    loc = loc + '_temp'
-                    log.info(f'delete data at {loc}')
-                    delete_data(rd, loc, ddoc['type'], test=args.test)
-            elif 'host' in ddoc and ddoc['host'] == 'daq':
-                loc = ddoc['location']
-                if not args.delete_live:
-                    log.info(f'prevent {loc} from being deleted. Do so with --delete_live')
-                elif not args.force and not have_raw_records:
-                    log.info(f'Unsafe to delete {loc}, no raw_records registered. Force with --force')
-                elif args.force and not have_raw_records:
-                    log.info(f'Forcefully delete {loc}, but no raw_records registered!')
-                    delete_data(rd, loc, ddoc['type'], test=args.test)
-                else:
-                    log.info(f'Deleting data at {loc}')
-                    delete_data(rd, loc, ddoc['type'], test=args.test)
-    log.info(f'Ajax did {run_id}, bye bye')
+    main_ajax()
+    wait_on_delete_thread()
+    log.info(f'main::\tAjax finished, bye bye')

--- a/bin/ajax
+++ b/bin/ajax
@@ -19,7 +19,7 @@ Therefore D) can only be performed on one of the eventbuiders (see eb_can_clean_
 
 """
 
-__version__ = '0.0.3'
+__version__ = '0.1.0'
 
 import argparse
 from datetime import datetime, timedelta
@@ -79,7 +79,7 @@ eb_can_clean_ceph = 'eb0.xenon.local'
 def main_ajax():
     """Main function"""
     if args.number:
-        remove_run_from_host(args.number, delete_live=args.delete_live)
+        remove_run_from_host(args.number, delete_live=args.delete_live, force=args.force)
 
     if args.mode:
         if args.mode == 'clean_ceph':
@@ -136,7 +136,7 @@ def clean_cehp():
     else:
         run_number = rd['number']
         log.info(f'clean_cehp::\tremove data associated to run {run_number}')
-        remove_run_from_host(run_number, delete_live=True)
+        remove_run_from_host(run_number, delete_live=True, force=args.force)
         log.info(f'clean_cehp::\tfinished for {run_number}, take a'
                  f' {ajax_thresholds["short_nap"]} s nap')
         time.sleep(ajax_thresholds['short_nap'])
@@ -250,16 +250,13 @@ def clean_abandoned(delete_live=False):
     multiple threads at the same time.
     :param delete_live: bool, if true also delete the live_data of these runs.
     """
-    if not args.force:
-        log.warning("Cannot delete abandoned data without --force. Please restart with "
-                    "--mode clean_abandoned --force --ask_confirm")
-
     # Notice that we thread the deletion of live_data. As such we need to allow multiple
     # runs to be deleted simultaneously.
     if not delete_live:
         rd = run_coll.find_one({'bootstrax.state': 'abandoned',
                                 'data.host': hostname})
         if rd is None:
+            log.info('clean_abandoned::\tNo more matches in rundoc')
             return
         else:
             # Make it iterable for the loop below
@@ -277,9 +274,12 @@ def clean_abandoned(delete_live=False):
             break
         run_number = rd['number']
         log.info(f'clean_abandoned::\tremove data associated to run {run_number}')
-        remove_run_from_host(run_number, delete_live=delete_live)
+        # Please note that we have to force these runs always since they should not be
+        # stored elsewhere. They are abandoned for a reason!
+        remove_run_from_host(run_number, delete_live=delete_live, force=True)
         i += 1
-    else:
+    if not i:
+        log.info('clean_abandoned::\tNo more live_data matches in rundoc')
         # Apparently there is no rd in rds
         return
 
@@ -287,7 +287,7 @@ def clean_abandoned(delete_live=False):
     if args.execute:
         if delete_live:
             wait_on_delete_thread()
-        clean_abandoned(delete_live=delete_live)
+        return clean_abandoned(delete_live=delete_live)
 
 
 ##
@@ -340,7 +340,7 @@ def delete_data(rd, path, data_type, test=True):
     if not os.path.exists(path):
         log.info('changing data field in rundoc')
         for ddoc in rd['data']:
-            if ddoc['type'] == data_type:
+            if ddoc['type'] == data_type and ddoc['host'] in ('daq', hostname):
                 break
         for k in ddoc.copy().keys():
             if k in ['location', 'meta', 'protocol']:
@@ -361,11 +361,14 @@ def delete_data(rd, path, data_type, test=True):
         raise ValueError(f"Something went wrong we wanted to delete {path}!")
 
 
-def remove_run_from_host(number, delete_live=False):
+def remove_run_from_host(number, delete_live=False, force=False):
     """
-    Save way of removing data from host if data registerred elsewhere
+    Save way of removing data from host if data registered elsewhere
     :param number: run number (not ID!)
     :param delete_live: bool, if true delete the live_data else the processed data
+    :param force: forcefully remove the data even if we don't have the right copies (e.g.
+    deleting /live_data when the raw_records are not stored. Be careful with this option!
+    Should only be used for the deletion of abandoned runs.
     """
     # Query the database to remove data
     rd = run_coll.find_one({'number': number,
@@ -387,7 +390,7 @@ def remove_run_from_host(number, delete_live=False):
                 # If you want to delete the live data you shouldn't consider this ddoc
                 continue
             loc = ddoc['location']
-            if not args.force and not have_live_data and 'raw_records' in ddoc['type']:
+            if not force and not have_live_data and 'raw_records' in ddoc['type']:
                 # If we do not have live_data, don't delete raw_records. However, if we
                 # --force deletion, do go to the next else statement
                 log.info(f'prevent {loc} from being deleted. The live_data has already'
@@ -409,13 +412,13 @@ def remove_run_from_host(number, delete_live=False):
             loc = os.path.join(ddoc['location'], run_id)
             if not delete_live:
                 log.info(f'prevent {loc} from being deleted. Do so with --delete_live')
-            elif not args.force and not have_raw_records:
+            elif not force and not have_raw_records:
                 # If we do not have raw records, don't delete this data. However, if we
                 # --force deletion, do go to the next else statement
                 log.info(f'Unsafe to delete {loc}, no raw_records registered. Force with '
                          f'--force')
             else:
-                if args.force and not have_raw_records:
+                if force and not have_raw_records:
                     log.info(f'Forcefully delete {loc}, but no raw_records registered!')
                 else:
                     log.info(f'Deleting data at {loc}')

--- a/bin/ajax
+++ b/bin/ajax
@@ -7,7 +7,7 @@ cleaning tool to remove old data from eventbuilders
 Joran Angevaare, 2020
 
 """
-__version__ = '0.0.0'
+__version__ = '0.0.1'
 
 import argparse
 from datetime import datetime, timedelta
@@ -23,11 +23,11 @@ def now(plus=0):
     return datetime.now(pytz.utc) + timedelta(seconds=plus)
 
 
-def _delete_data(rd, path, data_type, test= True):
+def delete_data(rd, path, data_type, test=True):
     """After completing the processing and updating the runsDB, remove the
     live_data"""
 
-    if data_type == 'live' and not args.delete_live and args.production:
+    if data_type == 'live' and not args.delete_live:
         raise ValueError('Unsafe operation. Trying to delete live data!')
     if os.path.exists(path):
         log.info(f'Deleting data at {path}')
@@ -67,17 +67,23 @@ if __name__ == '__main__':
         description="XENONnT cleaning manager")
     parser.add_argument('--force', action='store_true',
                         help="Forcefully remove stuff from this host")
+    parser.add_argument('--delete_live', action='store_true',
+                        help="delete live data for this run")
     parser.add_argument('--test', action='store_true',
-                        help="Forcefully remove stuff from this host")
+                        help="Never remove data nor update databases")
 
     actions = parser.add_mutually_exclusive_group()
     actions.add_argument('--number', type=int, metavar='NUMBER',
                          help="Process a single run, regardless of its status.")
-    actions.add_argument('--all', action='store_true',
-                         help="remove all runs from this eb that are transferred")
 
     args = parser.parse_args()
     run_id = '%06d' % args.number
+    if args.force:
+        log.warning(f'DANGERZONE you are forcefully deleting data that may result in an irrecoverable loss of data.')
+        log.info(f'Please note that tests argument is {args.test} which means you are {"" if args.test else "!NOT!"} safe')
+        if not input('Want to proceed willingly? [y]').lower() == 'y':
+            log.info(f'Alright no unsafe operations, bye bye')
+            exit(-1)
 
     hostname = socket.getfqdn()
 
@@ -125,11 +131,12 @@ if __name__ == '__main__':
         if not deleted_data:
             raise FileNotFoundError(f'No data registered on {hostname} for {args.number}')
     else:
-        have_live_data = False
+        have_live_data, have_raw_records = False, False
         for dd in rd['data']:
             if dd['type'] == 'live' and dd['location'] != 'deleted':
                 have_live_data = True
-                break
+            if dd['type'] == 'raw_records' and dd['location'] != 'deleted':
+                have_raw_records = True
         for ddoc in rd['data']:
             if 'host' in ddoc and ddoc['host'] == hostname:
                 loc = ddoc['location']
@@ -138,9 +145,21 @@ if __name__ == '__main__':
                              f' been removed')
                 elif os.path.exists(loc):
                     log.info(f'delete data at {loc}')
-                    _delete_data(rd, loc, ddoc['type'], test= args.test)
+                    delete_data(rd, loc, ddoc['type'], test=args.test)
                 else:
                     loc = loc + '_temp'
                     log.info(f'delete data at {loc}')
-                    _delete_data(rd, loc, ddoc['type'], test= args.test)
+                    delete_data(rd, loc, ddoc['type'], test=args.test)
+            elif 'host' in ddoc and ddoc['host'] == 'daq':
+                loc = ddoc['location']
+                if not args.delete_live:
+                    log.info(f'prevent {loc} from being deleted. Do so with --delete_live')
+                elif not args.force and not have_raw_records:
+                    log.info(f'Unsafe to delete {loc}, no raw_records registered. Force with --force')
+                elif args.force and not have_raw_records:
+                    log.info(f'Forcefully delete {loc}, but no raw_records registered!')
+                    delete_data(rd, loc, ddoc['type'], test=args.test)
+                else:
+                    log.info(f'Deleting data at {loc}')
+                    delete_data(rd, loc, ddoc['type'], test=args.test)
     log.info(f'Ajax did {run_id}, bye bye')

--- a/bin/ajax
+++ b/bin/ajax
@@ -56,7 +56,7 @@ ajax_thresholds = {
     # timeout)
     'nap_time': 3600,  # s
     # Short nap time
-    'short_nap': 1,  # s
+    'short_nap': 60,  # s
 
 }
 
@@ -96,6 +96,8 @@ def main_ajax():
             clean_raw_records_nv()
         elif args.mode == 'clean_abandoned':
             clean_abandoned()
+            if hostname == eb_can_clean_ceph:
+                clean_abandoned(delete_live=True)
         elif args.mode == 'clean_all':
             while True:
                 if hostname == eb_can_clean_ceph:
@@ -139,6 +141,7 @@ def clean_cehp():
 
         # Repeat.
         if args.execute:
+            wait_on_delete_thread()
             clean_cehp()
 
     # Finally, check that there is no old data on ceph that is also not in the rundoc.
@@ -323,7 +326,7 @@ def delete_data(rd, path, data_type, test=True):
 
         ddoc.update({'at': now(), 'by': hostname + '.ajax'})
         log.info(f'update with {ddoc}')
-        if args.execute and not args.test:
+        if args.execute and not test:
             if confirm('update rundoc?'):
                 run_coll.update_one({'_id': rd['_id']},
                                     {"$addToSet": {'deleted_data': ddoc},
@@ -332,7 +335,7 @@ def delete_data(rd, path, data_type, test=True):
                                                     "host": {'$in': ['daq', hostname]}}}})
         else:
             log.info(f'Update ddoc with : {ddoc}')
-    elif not test:
+    elif not test and not args.ask_confirm:
         raise ValueError(f"Something went wrong we wanted to delete {path}!")
 
 
@@ -358,14 +361,17 @@ def remove_run_from_host(number, delete_live=False):
             if not args.force and not have_live_data and 'raw_records' in ddoc['type']:
                 log.info(f'prevent {loc} from being deleted. The live_data has already'
                          f' been removed')
-            elif os.path.exists(loc):
-                log.info(f'delete data at {loc}')
-                delete_data(rd, loc, ddoc['type'], test=not args.execute)
             else:
-                loc = loc + '_temp'
                 log.info(f'delete data at {loc}')
                 delete_data(rd, loc, ddoc['type'], test=not args.execute)
+
+                loc = loc + '_temp'
+                if os.path.exists(loc):
+                    log.info(f'delete data at {loc}')
+                    delete_data(rd, loc, ddoc['type'], test=not args.execute)
         elif 'host' in ddoc and ddoc['host'] == 'daq':
+            if not delete_live:
+                continue
             run_id = '%06d' % number
             loc = os.path.join(ddoc['location'], run_id)
             if not delete_live:
@@ -440,11 +446,9 @@ def confirm(question):
     """
     if not args.ask_confirm:
         return True
-    answer = str(input(question+' (y/n): ')).lower().strip()
-    if answer is 'y':
-        return True
-    elif answer is 'no':
-        return False
+    answer = str(input(question + ' (y/n): ')).lower().strip()
+    if answer in ('y', 'n'):
+        return answer == 'y'
     else:
         confirm('please input (y/n)\n')
 
@@ -553,6 +557,11 @@ if __name__ == '__main__':
     run_db = run_client[run_dbname]
     run_coll = run_db[run_collname]
 
-    main_ajax()
+    try:
+        main_ajax()
+    except KeyboardInterrupt as e:
+        log.info('\nStopping, wait a second for the delete threads\n')
+        wait_on_delete_thread()
+        raise e
     wait_on_delete_thread()
     log.info(f'main::\tAjax finished, bye bye')

--- a/bin/ajax
+++ b/bin/ajax
@@ -252,10 +252,10 @@ def clean_abandoned(delete_live=False):
     """
     if not args.force:
         log.warning("Cannot delete abandoned data without --force. Please restart with "
-                    "--force and --ask_confirm")
+                    "--mode clean_abandoned --force --ask_confirm")
 
     # Notice that we thread the deletion of live_data. As such we need to allow multiple
-    # runs to be deleted simultenously.
+    # runs to be deleted simultaneously.
     if not delete_live:
         rd = run_coll.find_one({'bootstrax.state': 'abandoned',
                                 'data.host': hostname})

--- a/bin/ajax
+++ b/bin/ajax
@@ -62,9 +62,9 @@ ajax_thresholds = {
 
 # The low level data is taken care of by admix so we don't have to delete this. All other
 # data-types are deleted in the clean_high_level_data routine
-low_level_data = ['records*', 'raw_records*',
-                  'lone_hits', 'veto_regions', 'pulse_counts', 'led_calibration'
-                                                               'peaklets', ]
+low_level_data = ['raw_records*',
+                  'records*', 'lone_hits', 'veto_regions', 'pulse_counts', 'led_calibration',
+                  'peaklets']
 
 # Open deletion threads with this prefix (and also look for these before quiting ajax)
 thread_prefix = 'ajax_delete'

--- a/bin/ajax
+++ b/bin/ajax
@@ -277,8 +277,7 @@ def _rmtree(path):
     :return:
     """
     if args.execute:
-        pass
-        # shutil.rmtree(path)
+        shutil.rmtree(path)
     else:
         log.info(f'TESTING:\tshutil.rmtree({path})')
         if not os.path.exists(path):

--- a/bin/ajax
+++ b/bin/ajax
@@ -19,7 +19,7 @@ Therefore D) can only be performed on one of the eventbuiders (see eb_can_clean_
 
 """
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 import argparse
 from datetime import datetime, timedelta
@@ -45,8 +45,6 @@ ajax_thresholds = {
     # this many seconds ago
     'wait_after_processing': 2 * 3600,  # s
     # Remove the raw records of the neutron veto after this many seconds
-    # TODO
-    #  make sure that ajax breaks if we get a SN trigger
     'remove_raw_records_nv': 24 * 3600,  # s
     # Remove high level plugins if the run is this old
     # TODO
@@ -56,14 +54,14 @@ ajax_thresholds = {
     # timeout)
     'nap_time': 3600,  # s
     # Short nap time
-    'short_nap': 60,  # s
+    'short_nap': 5,  # s
 
 }
 
 # The low level data is taken care of by admix so we don't have to delete this. All other
 # data-types are deleted in the clean_high_level_data routine
-low_level_data = ['raw_records*',
-                  'records*', 'lone_hits', 'veto_regions', 'pulse_counts', 'led_calibration',
+low_level_data = ['raw_records*', 'records*',
+                  'lone_hits', 'veto_regions', 'pulse_counts', 'led_calibration',
                   'peaklets']
 
 # Open deletion threads with this prefix (and also look for these before quiting ajax)
@@ -81,9 +79,7 @@ eb_can_clean_ceph = 'eb0.xenon.local'
 def main_ajax():
     """Main function"""
     if args.number:
-        remove_run_from_host(args.number)
-    if args.delete_live:
-        remove_run_from_host(args.number, delete_live=True)
+        remove_run_from_host(args.number, delete_live=args.delete_live)
 
     if args.mode:
         if args.mode == 'clean_ceph':
@@ -92,6 +88,8 @@ def main_ajax():
             clean_high_level_data()
         elif args.mode == 'clean_unregistered':
             clean_unregistered()
+            if hostname == eb_can_clean_ceph:
+                clean_unregistered(delete_live=True)
         elif args.mode == 'clean_raw_records_nv':
             clean_raw_records_nv()
         elif args.mode == 'clean_abandoned':
@@ -102,9 +100,13 @@ def main_ajax():
             while True:
                 if hostname == eb_can_clean_ceph:
                     clean_cehp()
+                    clean_abandoned(delete_live=True)
+                    clean_unregistered(delete_live=True)
+
                 clean_high_level_data()
                 clean_unregistered()
                 clean_raw_records_nv()
+                clean_abandoned()
                 if not args.execute:
                     break
                 log.info(f'Loop finished, take a {ajax_thresholds["nap_time"]} s nap')
@@ -207,9 +209,7 @@ def check_sn_trigger():
 
 
 def clean_raw_records_nv():
-    """
-    Based on the runsDB, remove the raw_records_nv if they are old
-    """
+    """Based on the runsDB, remove the raw_records_nv if they are old"""
     check_sn_trigger()
     rd = run_coll.find_one({'data.type': 'raw_records_nv',
                             'start':
@@ -246,30 +246,54 @@ def clean_unregistered(delete_live=False):
 
 def clean_abandoned(delete_live=False):
     """
-    Recursively delete data associated to abandoned runs.
+    Recursively delete data associated to abandoned runs. If deleting live data, submit
+    multiple threads at the same time.
     :param delete_live: bool, if true also delete the live_data of these runs.
     """
+    if not args.force:
+        log.warning("Cannot delete abandoned data without --force. Please restart with "
+                    "--force and --ask_confirm")
+
+    # Notice that we thread the deletion of live_data. As such we need to allow multiple
+    # runs to be deleted simultenously.
     if not delete_live:
         rd = run_coll.find_one({'bootstrax.state': 'abandoned',
                                 'data.host': hostname})
+        if rd is None:
+            return
+        else:
+            # Make it iterable for the loop below
+            rds = [rd]
     else:
-        rd = run_coll.find_one({'bootstrax.state': 'abandoned',
-                                'data.host': 'daq'})
-    if rd is None:
-        return
+        rds = run_coll.find({'bootstrax.state': 'abandoned',
+                             'data.location': '/live_data/xenonnt',
+                             'data.host': 'daq'})
 
-    run_number = rd['number']
-    log.info(f'clean_abandoned::\tremove data associated to run {run_number}')
-    remove_run_from_host(run_number, delete_live=delete_live)
+    # Count the number of threads. Only allow one if we aks for user input.
+    i = 0
+    i_max = 1 if args.ask_confirm else 5
+    for rd in rds:
+        if i >= i_max:
+            break
+        run_number = rd['number']
+        log.info(f'clean_abandoned::\tremove data associated to run {run_number}')
+        remove_run_from_host(run_number, delete_live=delete_live)
+        i += 1
+    else:
+        # Apparently there is no rd in rds
+        return
 
     # Repeat
     if args.execute:
-        clean_abandoned()
+        if delete_live:
+            wait_on_delete_thread()
+        clean_abandoned(delete_live=delete_live)
 
 
 ##
 # Core functions
 ##
+
 
 def _rmtree(path):
     """
@@ -289,9 +313,7 @@ def _rmtree(path):
 
 
 def threaded_delete_data(rd, path, data_type, test=True):
-    """
-    Wrapper for delete_data to run in separate threads.
-    """
+    """Wrapper for delete_data to run in separate threads."""
     thread_name = thread_prefix + path.split('/')[-1]
     delete_thread = threading.Thread(name=thread_name,
                                      target=delete_data,
@@ -340,6 +362,11 @@ def delete_data(rd, path, data_type, test=True):
 
 
 def remove_run_from_host(number, delete_live=False):
+    """
+    Save way of removing data from host if data registerred elsewhere
+    :param number: run number (not ID!)
+    :param delete_live: bool, if true delete the live_data else the processed data
+    """
     # Query the database to remove data
     rd = run_coll.find_one({'number': number,
                             'data.host': hostname if not delete_live else 'daq'})
@@ -354,11 +381,15 @@ def remove_run_from_host(number, delete_live=False):
         if dd['type'] == 'raw_records' and dd['location'] != 'deleted':
             have_raw_records = True
     for ddoc in rd['data']:
+        # This is processed data on the eventbuilders
         if 'host' in ddoc and ddoc['host'] == hostname:
             if delete_live:
+                # If you want to delete the live data you shouldn't consider this ddoc
                 continue
             loc = ddoc['location']
             if not args.force and not have_live_data and 'raw_records' in ddoc['type']:
+                # If we do not have live_data, don't delete raw_records. However, if we
+                # --force deletion, do go to the next else statement
                 log.info(f'prevent {loc} from being deleted. The live_data has already'
                          f' been removed')
             else:
@@ -370,13 +401,17 @@ def remove_run_from_host(number, delete_live=False):
                     log.info(f'delete data at {loc}')
                     delete_data(rd, loc, ddoc['type'], test=not args.execute)
         elif 'host' in ddoc and ddoc['host'] == 'daq':
+            # This is the live_data
             if not delete_live:
+                # If you want to delete processed data you shouldn't consider this ddoc
                 continue
             run_id = '%06d' % number
             loc = os.path.join(ddoc['location'], run_id)
             if not delete_live:
                 log.info(f'prevent {loc} from being deleted. Do so with --delete_live')
             elif not args.force and not have_raw_records:
+                # If we do not have raw records, don't delete this data. However, if we
+                # --force deletion, do go to the next else statement
                 log.info(f'Unsafe to delete {loc}, no raw_records registered. Force with '
                          f'--force')
             else:
@@ -388,6 +423,11 @@ def remove_run_from_host(number, delete_live=False):
 
 
 def remove_if_unregistered(number, delete_live=False):
+    """
+    Given a run number delete data on this machine that matches that number
+    :param number: int! the run_number (not run_id)
+    :param delete_live: Bool, if True: Remove the live_data. Else remove processed data
+    """
     # Query the database to remove data
     rd = run_coll.find_one({'number': number,
                             'data.host': hostname if not delete_live else 'daq'})
@@ -446,7 +486,7 @@ def confirm(question):
     """
     if not args.ask_confirm:
         return True
-    answer = str(input(question + ' (y/n): ')).lower().strip()
+    answer = str(input(question + ' (y/n): \n')).lower().strip()
     if answer in ('y', 'n'):
         return answer == 'y'
     else:
@@ -454,9 +494,7 @@ def confirm(question):
 
 
 def wait_on_delete_thread():
-    """
-    Check that the threads with the thread_prefix are finished before continuing.
-    """
+    """Check that the threads with the thread_prefix are finished before continuing."""
     threads = threading.enumerate()
     for thread in threads:
         if thread_prefix in thread.name:
@@ -516,7 +554,7 @@ if __name__ == '__main__':
     if args.mode == 'clean_raw_records_nv':
         log.info(f'main::\tDelete neutron veto data from {hostname} older than '
                  f'{ajax_thresholds["remove_raw_records_nv"]} s')
-        raise NotImplementedError("I don't know what to do with the raw_records of the NV")
+        raise NotImplementedError("I dont know what to do with the raw_records of the NV")
     if args.delete_live:
         if not args.number:
             raise ValueError("Specify which number with --number")
@@ -528,7 +566,9 @@ if __name__ == '__main__':
         if not input('Want to proceed willingly? [y]').lower() == 'y':
             log.info(f'main::\tAlright no unsafe operations, bye bye')
             exit(-1)
-        raise NotImplementedError('main::\tI dont want to have this option enabled yet.')
+        if args.mode != 'clean_abandoned':
+            raise NotImplementedError('main::\tI dont want to have this option enabled '
+                                      'yet.')
 
     # The event builders write to different directories on the respective machines.
     eb_directories = {

--- a/bin/ajax.py
+++ b/bin/ajax.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+"""
+AJAX: XENONnT
+Aggregate Junking Ancient Xenondata
+cleaning tool to remove old data from eventbuilders
+=============================================
+Joran Angevaare, 2020
+
+"""
+__version__ = '0.0.0'
+
+import argparse
+from datetime import datetime, timedelta
+import logging
+import os
+import socket
+import shutil
+import pymongo
+import pytz
+
+
+def now(plus=0):
+    return datetime.now(pytz.utc) + timedelta(seconds=plus)
+
+
+def _delete_data(rd, path, data_type, test= True):
+    """After completing the processing and updating the runsDB, remove the
+    live_data"""
+
+    if data_type == 'live' and not args.delete_live and args.production:
+        raise ValueError('Unsafe operation. Trying to delete live data!')
+    if os.path.exists(path):
+        log.info(f'Deleting data at {path}')
+        if not test:
+            shutil.rmtree(path)
+    log.info(f'deleting {path} finished')
+    # Remove the data location from the rundoc and append it to the 'deleted_data' entries
+    if not os.path.exists(path):
+        log.info('changing data field in rundoc')
+        for ddoc in rd['data']:
+            if ddoc['type'] == data_type:
+                break
+        for k in ddoc.copy().keys():
+            if k in ['location', 'meta', 'protocol']:
+                ddoc.pop(k)
+
+        ddoc.update({'at': now(), 'by': hostname})
+        log.info(f'update with {ddoc}')
+        if not test:
+            log.info('update test')
+            run_coll.update_one({'_id': rd['_id']},
+                                {"$addToSet": {'deleted_data': ddoc},
+                                 "$pull": {"data":
+                                               {"type": data_type,
+                                                "host": {'$in':['daq', hostname]}}}})
+    elif not test:
+        raise ValueError(f"Something went wrong we wanted to delete {path}!")
+
+
+if __name__ == '__main__':
+    print(f'---\n ajax version {__version__}\n---')
+    logging.basicConfig(level=logging.INFO,
+                        format='%(relativeCreated)6d %(threadName)s %(name)s %(message)s')
+    log = logging.getLogger()
+
+    parser = argparse.ArgumentParser(
+        description="XENONnT cleaning manager")
+    parser.add_argument('--force', action='store_true',
+                        help="Forcefully remove stuff from this host")
+    parser.add_argument('--test', action='store_true',
+                        help="Forcefully remove stuff from this host")
+
+    actions = parser.add_mutually_exclusive_group()
+    actions.add_argument('--number', type=int, metavar='NUMBER',
+                         help="Process a single run, regardless of its status.")
+    actions.add_argument('--all', action='store_true',
+                         help="remove all runs from this eb that are transferred")
+
+    args = parser.parse_args()
+    run_id = '%06d' % args.number
+
+    hostname = socket.getfqdn()
+
+    # The event builders write to different directories on the respective machines.
+    eb_directories = {
+        'eb0.xenon.local': '/data2/xenonnt_processed/',
+        'eb1.xenon.local': '/data1/xenonnt_processed/',
+        'eb2.xenon.local': '/nfs/eb0_data1/xenonnt_processed/',
+        'eb3.xenon.local': '/data/xenonnt_processed/',
+        'eb4.xenon.local': '/data/xenonnt_processed/',
+        'eb5.xenon.local': '/data/xenonnt_processed/',
+    }
+
+    # Set the output folder
+    output_folder = eb_directories[hostname]
+    if os.access(output_folder, os.W_OK) is not True:
+        raise IOError(f'No writing access to {output_folder}')
+
+    # Runs database
+    run_dbname = 'xenonnt'
+    run_collname = 'runs'
+
+    # Please note, this is a read only account on the rundb
+    run_db_username = os.environ['MONGO_RDB_USERNAME']
+    run_db_password = os.environ['MONGO_RDB_PASSWORD']
+    run_client = pymongo.MongoClient(
+        f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017,old-gw:27017/admin")
+    run_db = run_client[run_dbname]
+    run_coll = run_db[run_collname]
+
+    # Query the database to remove data
+    rd = run_coll.find_one({
+        'number': args.number,
+        'data.host': hostname}
+        )
+    if not rd:
+        log.warning(f'No data for {run_id} found! Double checking on the disk!')
+        deleted_data = False
+        for folder in os.listdir(output_folder):
+            if run_id in folder:
+                log.info(f'Cleaning {output_folder + folder}')
+                if not args.test:
+                     shutil.rmtree(output_folder + folder)
+                deleted_data = True
+        if not deleted_data:
+            raise FileNotFoundError(f'No data registered on {hostname} for {args.number}')
+    else:
+        have_live_data = False
+        for dd in rd['data']:
+            if dd['type'] == 'live' and dd['location'] != 'deleted':
+                have_live_data = True
+                break
+        for ddoc in rd['data']:
+            if 'host' in ddoc and ddoc['host'] == hostname:
+                loc = ddoc['location']
+                if not args.force and not have_live_data and 'raw_records' in ddoc['type']:
+                    log.info(f'prevent {loc} from being deleted. The live_data has already'
+                             f' been removed')
+                elif os.path.exists(loc):
+                    log.info(f'delete data at {loc}')
+                    _delete_data(rd, loc, ddoc['type'], test= args.test)
+                else:
+                    loc = loc + '_temp'
+                    log.info(f'delete data at {loc}')
+                    _delete_data(rd, loc, ddoc['type'], test= args.test)
+    log.info(f'Ajax did {run_id}, bye bye')

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -580,11 +580,14 @@ def infer_mode(rd, input_dir):
 
     # Get data rate from dispatcher
     data_rate = 0
-    for det in rd['detectors']:
-        try:
-            data_rate += ag_stat_coll.find_one({'detector' : det}, sort=(['_id', -1]))['rate']
-        except:
-            pass
+    try:
+        docs = ag_stat_coll.aggregate([
+                    {'$match': {'number': rd['number']}},
+                    {'$group': {'_id': '$detector', 'rate': {'$max': '$rate'}}}
+                ])
+        data_rate = sum(docs.values())
+    except:
+        pass
 
     # Find out if eb is new (eb3-eb5):
     is_new_eb = int(hostname[2]) >= 3  # ebX.xenon.local

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -49,7 +49,6 @@ Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is
 __version__ = '0.5.1'
 
 import argparse
-from collections import Counter
 from datetime import datetime, timedelta, timezone
 import logging
 import multiprocessing
@@ -271,7 +270,7 @@ daq_db_username = os.environ['MONGO_DAQ_USERNAME']
 daq_client = pymongo.MongoClient(f"mongodb://{daq_db_username}:{daq_db_password}@xenon1t-daq:27017/admin")
 daq_db = daq_client[daq_db_name]
 bs_coll = daq_db['eb_monitor']
-ag_stat_col = daq_db['aggregate_status']
+ag_stat_coll = daq_db['aggregate_status']
 
 # Runs database
 run_dbname = 'xenonnt'
@@ -530,7 +529,7 @@ def eb_can_process():
     max_queue_new_runs = 2
 
     # Count number of runs untouched by bootstrax.
-    n_untouched_runs = run_coll.count_documents({'bootstrax' : {'$exists' : 0}})
+    n_untouched_runs = run_coll.count_documents({'bootstrax': {'$exists': 0}})
 
     # Check that eb3-5 are all busy for at least some time.
     n_ebs_running = 0
@@ -545,7 +544,7 @@ def eb_can_process():
             running_eb = run_coll.find_one({'bootstrax.state': 'busy',
                                             'bootstrax.host': f'eb{eb_i}.xenon.local'})
             if (running_eb and
-                running_eb.get('bootstrax',{}).get('started_processing',now()).replace(tzinfo=pytz.utc) <
+                running_eb.get('bootstrax', {}).get('started_processing', now()).replace(tzinfo=pytz.utc) <
                     now(-timeouts['eb3-5_max_busy_time'])):
                 n_ebs_busy += 1
                 log.info(f'eb_can_process::\t eb{eb_i} is busy')
@@ -571,29 +570,29 @@ def infer_mode(rd, input_dir):
     estimated data rate.
     """
     nap_time, i = 10, 0
+    default_opt = result = dict(cores=args.cores, max_messages=args.max_messages, timeout=300)
 
     # min. of 3 chunks with each pre_, chunk and post_
     min_chunks = 3
     while len(os.listdir(input_dir)) < min_chunks * 3:
         if i >= 10:
             # Too few files to be sure the first chunk is completely written
-            result = dict(cores=args.cores, max_messages=args.max_messages)
             log.info(f'Waited {i * nap_time} s but less than {min_chunks} were written. '
                      f'Could not infer run mode. Using default: {result}.')
-            return result
+            return default_opt
         i += 1
         time.sleep(nap_time)
 
     # Get data rate from dispatcher
-    data_rate = 0
     try:
         docs = ag_stat_coll.aggregate([
                     {'$match': {'number': rd['number']}},
                     {'$group': {'_id': '$detector', 'rate': {'$max': '$rate'}}}
                 ])
         data_rate = sum([d['rate'] for d in docs])
-    except:
-        pass
+    except Exception as e:
+        log_warning(f'infer_mode ran into {e}. Cannot infer mode, using default mode.')
+        return default_opt
 
     # Find out if eb is new (eb3-eb5):
     is_new_eb = int(hostname[2]) >= 3  # ebX.xenon.local
@@ -646,7 +645,6 @@ def sufficient_diskspace():
                      f'on {hostname}. Waiting {wait_diskspace_dt} s ({i}th iteration)')
             time.sleep(wait_diskspace_dt)
             send_heartbeat(dict(state='disk full'))
-            disk_pct = disk_usage(output_folder).percent
     set_state(dead_state)
     message = f"No disk space to write to. Kill bootstrax on {hostname}"
     log_warning(message, priority='warning')
@@ -666,7 +664,7 @@ def delete_temp_files():
         if run_coll.find_one(
                 {'bootstrax.state': 'done',
                  'number': run_id},
-                {'_id' : 1}):
+                {'_id': 1}):
             log.info(f'removing {output_folder}/{f}')
             shutil.rmtree(f'{output_folder}/{f}')
 
@@ -714,7 +712,7 @@ def _delete_data(rd, path, data_type):
                             {"$addToSet": {'deleted_data': ddoc},
                              "$pull": {"data":
                                            {"type": data_type,
-                                            "host": {'$in':['daq', hostname]}}}})
+                                            "host": {'$in': ['daq', hostname]}}}})
     else:
         raise ValueError(f"Something went wrong we wanted to delete {path}!")
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -46,7 +46,7 @@ Additionally, bootstrax tracks information with each run in the 'bootstrax' fiel
 Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is running to a collection in the DAQ database into the capped collection 'eb_monitor'. This collection contains information on what bootstrax is thinking of at the moment
   - **disk_used**: used part of the disk whereto this bootstrax instance is writing to (in percent)
 """
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 import argparse
 from collections import Counter
@@ -176,7 +176,7 @@ timeouts = {
 # be written to datamanager at some point. This may clean up data on the disk,
 # hence, we can check if there is sufficient diskspace and if not, wait a while.
 # Below are the max number of times and number of seconds bootstrax will wait.
-wait_diskspace_min_space = 500  # GB
+wait_diskspace_max_space_percent = 90
 wait_diskspace_n_max = 100  # times
 wait_diskspace_dt = 60  # seconds
 assert timeouts['bootstrax_presumed_dead'] > wait_diskspace_dt, "wait_diskspace_dt too large"
@@ -184,8 +184,9 @@ assert timeouts['bootstrax_presumed_dead'] > wait_diskspace_dt, "wait_diskspace_
 # Fields in the run docs that bootstrax uses
 bootstrax_projection = f"name start end number bootstrax status mode " \
                        f"data.host data.type data.location " \
-                       f"ini.processing_threads ini.compressor ini.strax_fragment_payload_bytes " \
-                       f"ini.strax_chunk_length ini.strax_chunk_overlap".split()
+                       f"daq_config.processing_threads daq_config.compressor " \
+                       f"daq_config.strax_fragment_payload_bytes " \
+                       f"daq_config.strax_chunk_length daq_config.strax_chunk_overlap".split()
 
 # Filename for temporary storage of the exception
 # This is used to communicate the exception from the strax child process
@@ -220,7 +221,7 @@ if os.access(output_folder, os.W_OK) is not True:
 
 if not args.production:
     # This means we are in some test mode
-    wait_diskspace_min_space = 850  # GB
+    wait_diskspace_max_space_percent = 80
     output_folder = test_data_folder
     if not os.path.exists(output_folder):
         log.warning(f'Creating {output_folder}')
@@ -265,6 +266,7 @@ daq_db_username = os.environ['MONGO_DAQ_USERNAME']
 daq_client = pymongo.MongoClient(f"mongodb://{daq_db_username}:{daq_db_password}@xenon1t-daq:27017/admin")
 daq_db = daq_client[daq_db_name]
 bs_coll = daq_db['eb_monitor']
+ag_stat_col = daq_db['aggregate_status']
 
 # Runs database
 run_dbname = 'xenonnt'
@@ -469,7 +471,7 @@ def set_state(state, update_fields=None):
             (now() - previous_entry['_id'].generation_time).seconds > timeouts['min_status_interval']):
         bs_coll.insert_one(bootstrax_state)
     else:
-        bs_coll.find_one_and_update({'_id': previous_entry['_id']}, {'$set': bootstrax_state})
+        bs_coll.update_one({'_id': previous_entry['_id']}, {'$set': bootstrax_state})
 
 
 def send_heartbeat(update_fields=None):
@@ -520,10 +522,9 @@ def eb_can_process():
     # Check that there are runs that are waiting to be processed. If there are few, this
     # eb should not process.
     max_queue_new_runs = 2
-    n_untouched_runs = 0
-    # Count number of runs untouched by bootstrax. Sorry for the sloppy pymongo syntax.
-    for _ in run_coll.find({'bootstrax': {'$exists': False}}):
-        n_untouched_runs += 1
+
+    # Count number of runs untouched by bootstrax.
+    n_untouched_runs = run_coll.count_documents({'bootstrax' : {'$exists' : 0}})
 
     # Check that eb3-5 are all busy for at least some time.
     n_ebs_running = 0
@@ -577,19 +578,21 @@ def infer_mode(rd, input_dir):
         i += 1
         time.sleep(nap_time)
 
-    # Estimate data rate on the bases of the size of the first chunk
-    first_chunk = input_dir + '/000000/'
-    chunk_size = np.sum([os.path.getsize(first_chunk + f) for f in os.listdir(first_chunk)])
-    chunk_time = rd['ini']['strax_chunk_length'] + rd['ini']['strax_chunk_overlap']
-    compression_factor = 2.4  # this is an estimate for lz4
-    data_rate = int(compression_factor * (chunk_size / 1024 ** 2) / chunk_time)  # in MB/s
+    # Get data rate from dispatcher
+    data_rate = 0
+    for det in rd['detectors']:
+        try:
+            data_rate += ag_stat_coll.find_one({'detector' : det}, sort=(['_id', -1]))['rate']
+        except:
+            pass
 
     # Find out if eb is new (eb3-eb5):
-    is_new_eb = int(hostname.strip('eb.xenon.local')) >= 3
-    log.info(f"infer_mode::\teb number {int(hostname.strip('eb.xenon.local'))}")
+    is_new_eb = int(hostname[2]) >= 3  # ebX.xenon.local
+    log.info(f"infer_mode::\teb{int(hostname[2])}")
+    eb = 'new_eb' if is_new_eb else 'old_eb'
 
     # Return a run-mode that is empirically found to provide stable but fast processing.
-    log.info(f'infer_mode::\tWorking with an estimated data rate of {data_rate} MB/s')
+    log.info(f'infer_mode::\tWorking with a data rate of {data_rate:.1f} MB/s')
     run_settings = {
         'new_eb':
             {'low_rate': dict(cores=24, max_messages=20, timeout=200),
@@ -604,15 +607,15 @@ def infer_mode(rd, input_dir):
              'very_high_rate': dict(cores=10, max_messages=10, timeout=300),
              'max_rate': dict(cores=8, max_messages=10, timeout=400)}}
     if data_rate < 100:
-        result = run_settings['new_eb' if is_new_eb else 'old_eb']['low_rate']
+        result = run_settings[eb]['low_rate']
     elif data_rate < 250:
-        result = run_settings['new_eb' if is_new_eb else 'old_eb']['med_rate']
+        result = run_settings[eb]['med_rate']
     elif data_rate < 500:
-        result = run_settings['new_eb' if is_new_eb else 'old_eb']['high_rate']
+        result = run_settings[eb]['high_rate']
     elif data_rate < 700:
-        result = run_settings['new_eb' if is_new_eb else 'old_eb']['very_high_rate']
+        result = run_settings[eb]['very_high_rate']
     else:
-        result = run_settings['new_eb' if is_new_eb else 'old_eb']['max_rate']
+        result = run_settings[eb]['max_rate']
     log.info(f'Override processing mode for run {rd["number"]} changing to:\t {result}')
     return result
 
@@ -623,21 +626,18 @@ def infer_mode(rd, input_dir):
 
 def sufficient_diskspace():
     """Check if there is sufficient space available on the local disk to write to"""
-    disk = disk_usage(output_folder)
-    gigabyte_to_byte = 1024.0 ** 3
-    disk_free = disk.free / gigabyte_to_byte
-    log.info(f'Check disk space. {int(disk_free)} GB free')
-    for i in range(wait_diskspace_min_space):
-        if disk_free > wait_diskspace_min_space:
-            # Good we can write, lets continue
+    for i in range(wait_diskspace_n_max):
+        disk_pct = disk_usage(output_folder).percent
+        if disk_pct < wait_diskspace_max_space_percent:
+            log.info(f'Check disk space: {disk_pct:.1f}% full')
+            # Sufficient space to write to, let's continue
             return
         else:
-            log.info(f'Insufficient free disk space ({int(disk_free)} GB) '
+            log.info(f'Insufficient free disk space ({disk_pct:.1f}% full) '
                      f'on {hostname}. Waiting {wait_diskspace_dt} s ({i}th iteration)')
             time.sleep(wait_diskspace_dt)
-            send_heartbeat()
-            disk = disk_usage(output_folder)
-            disk_free = disk.free / gigabyte_to_byte
+            send_heartbeat(dict(state='disk full'))
+            disk_pct = disk_usage(output_folder).percent
     set_state(dead_state)
     message = f"No disk space to write to. Kill bootstrax on {hostname}"
     log_warning(message, priority='warning')
@@ -656,7 +656,8 @@ def delete_temp_files():
         run_id = int(f.split('-')[0])
         if run_coll.find_one(
                 {'bootstrax.state': 'done',
-                 'number': run_id}):
+                 'number': run_id},
+                {'_id' : 1}):
             log.info(f'removing {output_folder}/{f}')
             shutil.rmtree(f'{output_folder}/{f}')
 
@@ -841,7 +842,7 @@ def set_status_finished(rd):
     # Only update the status if it does not exist or if it needs to be uploaded
     ready_to_upload = {'status': 'eb_ready_to_upload'}
     if rd.get('status') in [None, 'needs_upload']:
-        run_coll.find_one_and_update(
+        run_coll.update_one(
             {'_id': rd['_id']},
             {'$set': ready_to_upload})
     elif rd.get('status') == ready_to_upload.get('status'):
@@ -942,14 +943,14 @@ def manual_fail(*, mongo_id=None, number=None, reason=''):
     fail_run(rd, "Manually set failed state. " + reason)
 
 
-def get_compressor(rd, default_compressor="blosc"):
-    """Read the compressor method from the run_doc. Return 'blosc' if no
+def get_compressor(rd, default_compressor="lz4"):
+    """Read the compressor method from the run_doc. Return 'lz4' if no
     information is specified in the run_doc"""
     try:
-        return rd["ini"]["compressor"]
+        return rd["daq_config"]["compressor"]
     except KeyError:
         log_warning(f"Bootstrax couldn't read the compressor form the run_doc. "
-                    f"Assuming 'blosc' for now")
+                    f"Assuming 'lz4' for now")
         return default_compressor
 
 
@@ -1059,11 +1060,11 @@ def process_run(rd, send_heartbeats=args.production):
         if not osp.exists(dd['location']):
             fail(f"No access to live data folder {dd['location']}")
 
-        thread_info = rd.get('ini', dict()).get('processing_threads', dict())
+        thread_info = rd.get('daq_config', dict()).get('processing_threads', dict())
         n_readout_threads = sum([v for v in thread_info.values()])
         try:
-            daq_chunk_duration = int(rd['ini']['strax_chunk_length'] * 1e9)
-            daq_overlap_chunk_duration = int(rd['ini']['strax_chunk_overlap'] * 1e9)
+            daq_chunk_duration = int(rd['daq_config']['strax_chunk_length'] * 1e9)
+            daq_overlap_chunk_duration = int(rd['daq_config']['strax_chunk_overlap'] * 1e9)
         except Exception as e:
             fail(f"Could not find 'strax_chunk_length' and/or'strax_chunk_overlap' in "
                  f"rundoc: {str(e)}")
@@ -1100,11 +1101,11 @@ def process_run(rd, send_heartbeats=args.production):
             fail(f"Could not find start in datetime.datetime object: {str(e)}")
 
         try:
-            samples_per_record = int(rd['ini']['strax_fragment_payload_bytes'] / 2)  # note that value in rd in bytes
+            samples_per_record = rd['daq_config']['strax_fragment_payload_bytes'] // 2  # note that value in rd in bytes
             if not samples_per_record == 110:
                 log.info(f'Samples_per_record = {samples_per_record}')
         except Exception as e:
-            fail(f"Could not find ini.strax_fragment_payload_bytes in database: {str(e)}")
+            fail(f"Could not find daq_config.strax_fragment_payload_bytes in database: {str(e)}")
 
         if args.infer_mode:
             process_mode = infer_mode(rd, loc)
@@ -1223,7 +1224,7 @@ def clean_run(*, mongo_id=None, number=None, force=False):
     rd = get_run(mongo_id=mongo_id, number=number, full_doc=True)
     have_live_data = False
     for dd in rd['data']:
-        if dd['type'] == 'live' and dd['location'] != 'deleted':
+        if dd['type'] == 'live':
             have_live_data = True
             break
     for ddoc in rd['data']:
@@ -1337,13 +1338,6 @@ def cleanup_db():
                 break
             fail_run(rd, failure_message.format(**rd))
 
-    # Find any duplicated run numbers
-    nos = [x['number']
-           for x in run_coll.find({}, projection=['number'])]
-    duplicate_numbers = [number
-                         for number, n_occ in Counter(nos).items()
-                         if n_occ > 1]
-
     # Abandon runs which we already know are so bad that
     # there is no point in retrying them
     abandon_queries = [
@@ -1351,13 +1345,7 @@ def cleanup_db():
             '$elemMatch': {
                 'name': 'bad'}}},
          "Run has a 'bad' tag"),
-
-        ({'ini.processing_threads': {
-            '$exists': False}},
-         "Old run doc format without processing thread info"),
-
-        ({'number': {'$in': duplicate_numbers}},
-         "Run number is not unique")]
+        ]
 
     for query, failure_message in abandon_queries:
         query['bootstrax.state'] = {'$ne': 'abandoned'}

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -589,14 +589,14 @@ def infer_mode(rd, input_dir):
     log.info(f'infer_mode::\tWorking with an estimated data rate of {data_rate} MB/s')
     run_settings = {
         'new_eb':
-            {'low_rate': dict(cores=24, max_messages=20, timeout=60),
-             'med_rate': dict(cores=24, max_messages=20, timeout=100),
+            {'low_rate': dict(cores=24, max_messages=20, timeout=200),
+             'med_rate': dict(cores=24, max_messages=20, timeout=200),
              'high_rate': dict(cores=20, max_messages=15, timeout=200),
              'very_high_rate': dict(cores=20, max_messages=15, timeout=300),
              'max_rate': dict(cores=16, max_messages=10, timeout=400)},
         'old_eb':
-            {'low_rate': dict(cores=30, max_messages=20, timeout=60),
-             'med_rate': dict(cores=20, max_messages=15, timeout=100),
+            {'low_rate': dict(cores=30, max_messages=20, timeout=200),
+             'med_rate': dict(cores=20, max_messages=15, timeout=200),
              'high_rate': dict(cores=10, max_messages=15, timeout=200),
              'very_high_rate': dict(cores=10, max_messages=10, timeout=300),
              'max_rate': dict(cores=8, max_messages=10, timeout=400)}}

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -165,7 +165,7 @@ timeouts = {
     # Ebs3-5 normally do all the processing. However if all are busy
     # for a longer period of time, the ebs0-2 can also help with
     # processing.
-    'eb3-5_max_busy_time': 10 * 60,
+    'eb3-5_max_busy_time': 5 * 60,
     # Bootstrax writes it's state to the daq-database. To have a backlog we store this
     # state using a TTL collection. To prevent too many entries in this backlog, only
     # create new entries if the previous entry is at least this old (in seconds).
@@ -535,12 +535,13 @@ def eb_can_process():
         if (bootstrax_on_host and
                 bootstrax_on_host.get('time').replace(tzinfo=pytz.utc) > now(-timeouts['bootstrax_presumed_dead'])):
             n_ebs_running += 1
-            running_eb = run_coll.find_one({'state': 'busy',
-                                            'host': f'eb{eb_i}.xenon.local'})
+            running_eb = run_coll.find_one({'bootstrax.state': 'busy',
+                                            'bootstrax.host': f'eb{eb_i}.xenon.local'})
             if (running_eb and
-                running_eb.get('started_processing').replace(tzinfo=pytz.utc) <
+                running_eb.get('bootstrax',{}).get('started_processing',now()).replace(tzinfo=pytz.utc) <
                     now(-timeouts['eb3-5_max_busy_time'])):
                 n_ebs_busy += 1
+                log.info(f'eb_can_process::\t eb{eb_i} is busy')
     if ((n_ebs_running == n_ebs_busy and n_untouched_runs > max_queue_new_runs) or
             not n_ebs_running):
         # There is a need for this eb to also process data (for now).
@@ -548,9 +549,10 @@ def eb_can_process():
                  f' have {n_ebs_running} running and {n_ebs_busy} busy')
         return True
     elif n_untouched_runs and n_untouched_runs < max_queue_new_runs:
-        log.info(f'eb_can_process::\tDo not process on {hostname} as there are few new runs')
+        log.info(f'eb_can_process::\tDo not process on {hostname} as there are few new runs.')
     else:
         log.info(f'eb_can_process::\tDo not process on {hostname}, new ebs are taking care')
+    log.info(f'eb_can_process::\trunning: {n_ebs_running}\tbusy: {n_ebs_busy}\tqueue: {n_untouched_runs}')
     return False
 
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1107,7 +1107,7 @@ def process_run(rd, send_heartbeats=args.production):
         if args.infer_mode:
             process_mode = infer_mode(rd, loc)
         else:
-            process_mode = dict(cores=args.cores, max_messages=args.max_messages)
+            process_mode = dict(cores=args.cores, max_messages=args.max_messages, timeout=300)
 
         strax_proc = multiprocessing.Process(
             target=run_strax,

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -46,7 +46,7 @@ Additionally, bootstrax tracks information with each run in the 'bootstrax' fiel
 Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is running to a collection in the DAQ database into the capped collection 'eb_monitor'. This collection contains information on what bootstrax is thinking of at the moment
   - **disk_used**: used part of the disk whereto this bootstrax instance is writing to (in percent)
 """
-__version__ = '0.4.12'
+__version__ = '0.5.0'
 
 import argparse
 from collections import Counter
@@ -447,8 +447,7 @@ def set_state(state, update_fields=None):
     ping_dbs()
 
     # Find the last message of this host
-    previous_entry = bs_coll.find_one({'host': hostname,
-                                       'time': {'$lt': now(-timeouts['bootstrax_presumed_dead'])}},
+    previous_entry = bs_coll.find_one({'host': hostname},
                                       sort=[('time', pymongo.DESCENDING)])
     if not state:
         state = 'None' if not previous_entry else previous_entry.get('state')
@@ -534,7 +533,7 @@ def eb_can_process():
         bootstrax_on_host = bs_coll.find_one({'host': f'eb{eb_i}.xenon.local'},
                                              sort=[('time', pymongo.DESCENDING)])
         if (bootstrax_on_host and
-                bootstrax_on_host.get('time') < now(-timeouts['bootstrax_presumed_dead'])):
+                bootstrax_on_host.get('time').replace(tzinfo=pytz.utc) < now(-timeouts['bootstrax_presumed_dead'])):
             n_ebs_running += 1
             running_eb = run_coll.find_one({'state': 'busy',
                                             'host': f'eb{eb_i}.xenon.local'})
@@ -655,7 +654,7 @@ def delete_temp_files():
         if run_coll.find_one(
                 {'bootstrax.state': 'done',
                  'number': run_id}):
-            print(f'removing {output_folder}/{f}')
+            log.info(f'removing {output_folder}/{f}')
             shutil.rmtree(f'{output_folder}/{f}')
 
 
@@ -683,19 +682,26 @@ def _delete_data(rd, path, data_type):
     if data_type == 'live' and not args.delete_live and args.production:
         raise ValueError('Unsafe operation. Trying to delete live data!')
     log.info(f'Deleting data at {path}')
-    shutil.rmtree(path)
+    if os.path.exists(path):
+        shutil.rmtree(path)
     log.info(f'deleting {path} finished')
     # Remove the data location from the rundoc and append it to the 'deleted_data' entries
     if not os.path.exists(path):
         log.info('changing data field in rundoc')
-        ddoc = run_coll.find_one({'_id': rd['_id'], 'data.type': data_type})
-        del ddoc['location']
+        for ddoc in rd['data']:
+            if ddoc['type'] == data_type:
+                break
+        for k in ddoc.copy().keys():
+            if k in ['location', 'meta', 'protocol']:
+                ddoc.pop(k)
+
         ddoc.update({'at': now(), 'by': hostname})
+        log.info(f'update with {ddoc}')
         run_coll.update_one({'_id': rd['_id']},
                             {"$addToSet": {'deleted_data': ddoc},
-                             "$pull" : {"data" :
-                                    {"data.type" : data_type,
-                                     "data.host" : hostname}}})
+                             "$pull": {"data":
+                                           {"type": data_type,
+                                            "host": {'$in':['daq', hostname]}}}})
     else:
         raise ValueError(f"Something went wrong we wanted to delete {path}!")
 
@@ -1006,7 +1012,7 @@ def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
         exc_info = strax.formatted_exception()
         with open(exception_tempfile, mode='w') as f:
             f.write(exc_info)
-        with open(f'~/bootstrax_exceptions/{run_id}_exception.txt', mode='w') as f:
+        with open(f'./bootstrax_exceptions/{run_id}_exception.txt', mode='w') as f:
             f.write(exc_info)
         raise
 
@@ -1221,10 +1227,14 @@ def clean_run(*, mongo_id=None, number=None, force=False):
         if 'host' in ddoc and ddoc['host'] == hostname:
             loc = ddoc['location']
             if not force and not have_live_data and 'raw_records' in ddoc['type']:
-            if not force and not have_live_data and 'raw_records' in ddoc['type']:
                 log.info(f'prevent {loc} from being deleted. The live_data has already'
                          f' been removed')
             elif os.path.exists(loc):
+                log.info(f'delete data at {loc}')
+                _delete_data(rd, loc, ddoc['type'])
+            else:
+                loc = loc + '_temp'
+                log.info(f'delete data at {loc}')
                 _delete_data(rd, loc, ddoc['type'])
 
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -533,7 +533,7 @@ def eb_can_process():
         bootstrax_on_host = bs_coll.find_one({'host': f'eb{eb_i}.xenon.local'},
                                              sort=[('time', pymongo.DESCENDING)])
         if (bootstrax_on_host and
-                bootstrax_on_host.get('time').replace(tzinfo=pytz.utc) < now(-timeouts['bootstrax_presumed_dead'])):
+                bootstrax_on_host.get('time').replace(tzinfo=pytz.utc) > now(-timeouts['bootstrax_presumed_dead'])):
             n_ebs_running += 1
             running_eb = run_coll.find_one({'state': 'busy',
                                             'host': f'eb{eb_i}.xenon.local'})
@@ -544,7 +544,8 @@ def eb_can_process():
     if ((n_ebs_running == n_ebs_busy and n_untouched_runs > max_queue_new_runs) or
             not n_ebs_running):
         # There is a need for this eb to also process data (for now).
-        log.info(f'eb_can_process::\tThere is a need for {hostname} to process data')
+        log.info(f'eb_can_process::\tThere is a need for {hostname} to process data. As we'
+                 f' have {n_ebs_running} running and {n_ebs_busy} busy')
         return True
     elif n_untouched_runs and n_untouched_runs < max_queue_new_runs:
         log.info(f'eb_can_process::\tDo not process on {hostname} as there are few new runs')

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -203,6 +203,11 @@ dead_state = 'dead_bootstrax'
 # duration of the run (from the runs metadeta). Fail if the difference is larger than:
 max_timetamp_diff = 2
 
+# The maximum number of retries for processing a run. After this many times of retrying
+# to process a run, the DAQ-group has to either manually fix this run or manually fail it.
+max_n_retry = 20
+
+
 ##
 # Initialize globals (e.g. rundb connection)
 ##
@@ -373,6 +378,7 @@ def main_loop():
         # Any failed runs to retry?
         # Only try one run, we want to be back for new runs quickly
         rd = consider_run({"bootstrax.state": 'failed',
+                           "bootstrax.n_failures": {'$lt': max_n_retry},
                            "bootstrax.next_retry": {'$lt': now()}
                            }, test_counter=failed_runs_seen)
         if rd is not None:

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -46,7 +46,7 @@ Additionally, bootstrax tracks information with each run in the 'bootstrax' fiel
 Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is running to a collection in the DAQ database into the capped collection 'eb_monitor'. This collection contains information on what bootstrax is thinking of at the moment
   - **disk_used**: used part of the disk whereto this bootstrax instance is writing to (in percent)
 """
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 
 import argparse
 from datetime import datetime, timedelta, timezone
@@ -1115,7 +1115,10 @@ def process_run(rd, send_heartbeats=args.production):
             os.remove(exception_tempfile)
 
         target = args.target
-        if rd['bootstrax'].get('n_failures', 0) > 1 and not args.process:
+        if not args.production and not 'bootstrax'in rd:
+            # Bootstrax does not register in non-production mode
+            pass
+        elif rd['bootstrax'].get('n_failures', 0) > 1 and not args.process:
             # Failed before, and on autopilot: do just raw_records
             target = 'raw_records'
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -201,7 +201,7 @@ dead_state = 'dead_bootstrax'
 
 # The maximum time difference (s) allowed between the timestamps in the data and the
 # duration of the run (from the runs metadeta). Fail if the difference is larger than:
-max_timetamp_diff = 5
+max_timetamp_diff = 2
 
 ##
 # Initialize globals (e.g. rundb connection)

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -585,7 +585,7 @@ def infer_mode(rd, input_dir):
                     {'$match': {'number': rd['number']}},
                     {'$group': {'_id': '$detector', 'rate': {'$max': '$rate'}}}
                 ])
-        data_rate = sum(docs.values())
+        data_rate = sum([d['rate'] for d in docs])
     except:
         pass
 


### PR DESCRIPTION
In this PR several bootstrax/bin changes are implemented mostly aimed at safely removing data from the eventbuilders.

Most importantly, I envisage a new script ``ajax`` for deleting old data from the eventbuilders. I think that as bootstrax is dynamically increasing quite some functionality is now aimed at removing data from the eventbuilders. By moving this functionality to a separate script bootstrax may become more clearly aimed at processing new data.

Furthermore there is a small change was made in the logic when to start up the old event builders (in case the new ones are swamped), we saw this recently if the buffers were full.

Please note that bootstrax is not using ajax at the moment (this is still a draft). I used it for cleaning stuff of the very old runs in the incorrect format we had when the buffers were filled up.

Additionally Darryl added several improvements as explained below.

