### PR TITLE
Rechunk pulse_counts and veto_regions

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -1,5 +1,3 @@
-import warnings
-
 from immutabledict import immutabledict
 import strax
 import straxen

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -1,3 +1,4 @@
+from immutabledict import immutabledict
 import numba
 import numpy as np
 
@@ -92,7 +93,10 @@ class PulseProcessing(strax.Plugin):
     __version__ = '0.2.1'
 
     parallel = 'process'
-    rechunk_on_save = False
+    rechunk_on_save = immutabledict(
+        records=False,
+        veto_regions=True,
+        pulse_counts=True)
     compressor = 'lz4'
 
     depends_on = 'raw_records'


### PR DESCRIPTION
This uses the new strax feature in https://github.com/AxFoundation/strax/pull/272 to indicate pulse_counts and veto_regions should be rechunked. 

I tested this by building 180215_1029 from fake_daq-generated fake-live data. Indeed pulse_counts and veto_regions now have just one file, as opposed to 28 for records and raw_records.