### PR TITLE
Fix waveform_display plot

### DIFF
--- a/straxen/analyses/holoviews_waveform_display.py
+++ b/straxen/analyses/holoviews_waveform_display.py
@@ -43,7 +43,7 @@ def hvdisp_plot_pmt_pattern(*, config, records, to_pe, array='bottom'):
                hv.Dimension('y',
                             unit='cm',
                             range=(-straxen.tpc_r * f, straxen.tpc_r * f)),
-               hv.Dimension('i', range=(0, 248), label='PMT number'),
+               hv.Dimension('i', range=(0, config['n_tpc_pmts']), label='PMT number'),
                hv.Dimension('area', label='Area', unit='PE')])
     pmts = pmts.to(
         hv.Points,

--- a/straxen/analyses/holoviews_waveform_display.py
+++ b/straxen/analyses/holoviews_waveform_display.py
@@ -254,6 +254,6 @@ def waveform_display(
             show_largest=show_largest),
         streams=[time_stream])
 
-    layout = (peak_wvs + array_plot['top']
-              + time_v_channel + array_plot['bottom'])
+    layout = (time_v_channel + peak_wvs 
+              + array_plot['top'] +  array_plot['bottom'])
     return layout.cols(2)

--- a/straxen/analyses/holoviews_waveform_display.py
+++ b/straxen/analyses/holoviews_waveform_display.py
@@ -6,6 +6,9 @@ free of holoviews.
 import numpy as np
 import pandas as pd
 
+import straxen
+
+
 def seconds_from(t, t_reference):
     return (t - t_reference) / int(1e9)
 

--- a/straxen/analyses/holoviews_waveform_display.py
+++ b/straxen/analyses/holoviews_waveform_display.py
@@ -5,10 +5,6 @@ free of holoviews.
 
 import numpy as np
 import pandas as pd
-import bokeh
-
-import straxen
-
 
 def seconds_from(t, t_reference):
     return (t - t_reference) / int(1e9)


### PR DESCRIPTION
The pull request addresses issue #135 by changing the order of the layout in the returned value of waveform_display function. I also added a title "Time vs Channel" which is previously non-existent to the plot. The code being changed is essentially:
```
 layout = (time_v_channel + peak_wvs 
              + array_plot['top'] +  array_plot['bottom'])
```
```
layout = time_v_channel + peak_wvs + array_plot['top'] + array_plot['bottom']
```

The file being changed is holoviews_waveform_display, which is entirely based on pull request #128 which provides a fix for the plot in the first place. The new time vs channel plot is now correct and looks like below:

![bokeh_plot (5)](https://user-images.githubusercontent.com/50539795/85414871-3ca38b80-b59f-11ea-916b-d208ca2bf86d.png)

Why does changing the order of the layout address an issue related to y-axis of a plot? Not entirely sure, the question is rather: why does holoviews layout reconfigure your plot when the plot is in a certain order, which causes the weird issue that is #135.