### PR TITLE
Added average baseline and average baseline rms values to pulse_counts

### DIFF
--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -5,6 +5,7 @@ import strax
 import straxen
 
 export, __all__ = strax.exporter()
+__all__ += ['NO_PULSE_COUNTS']
 
 
 # These are also needed in peaklets, since hitfinding is repeated
@@ -374,6 +375,7 @@ def count_pulses(records, n_channels):
     return np.zeros(0, dtype=pulse_count_dtype(n_channels))
 
 
+NO_PULSE_COUNTS = -9999  # Special value required by average_baseline in case counts = 0
 @numba.njit(cache=True, nogil=True)
 def _count_pulses(records, n_channels, result):
     count = np.zeros(n_channels, dtype=np.int64)
@@ -426,7 +428,9 @@ def _count_pulses(records, n_channels, result):
     res['lone_pulse_count'][:] = lone_count[:]
     res['pulse_area'][:] = area[:]
     res['lone_pulse_area'][:] = lone_area[:]
-    res['baseline_mean'][:] = (baseline_buffer/count)[:]
+    means = (baseline_buffer/count)
+    means[np.isnan(means)] = NO_PULSE_COUNTS
+    res['baseline_mean'][:] = means[:]
     res['baseline_rms_mean'][:] = (baseline_rms_buffer/count)[:]
 
 

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -365,17 +365,17 @@ def pulse_count_dtype(n_channels):
     ]
 
 
-def count_pulses(records, n_channels, start_channel=0):
+def count_pulses(records, n_channels):
     """Return array with one element, with pulse count info from records"""
     if len(records):
         result = np.zeros(1, dtype=pulse_count_dtype(n_channels))
-        _count_pulses(records, n_channels, start_channel, result)
+        _count_pulses(records, n_channels, result)
         return result
     return np.zeros(0, dtype=pulse_count_dtype(n_channels))
 
 
 @numba.njit(cache=True, nogil=True)
-def _count_pulses(records, n_channels, start_channel, result):
+def _count_pulses(records, n_channels, result):
     count = np.zeros(n_channels, dtype=np.int64)
     lone_count = np.zeros(n_channels, dtype=np.int64)
     area = np.zeros(n_channels, dtype=np.int64)
@@ -393,9 +393,9 @@ def _count_pulses(records, n_channels, start_channel, result):
         if r_i != len(records) - 1:
             next_start = records[r_i + 1]['time']
 
-        ch = r['channel'] - start_channel  # start_channel needed for e.g. nveto
-        if ch >= n_channels or ch < 0:
-            print('Channel:', ch, 'Start channel:', start_channel)
+        ch = r['channel']
+        if ch >= n_channels:
+            print('Channel:', ch)
             raise RuntimeError("Out of bounds channel in get_counts!")
 
         area[ch] += r['area']  # <-- Summing total area in channel

--- a/tests/test_count_pulses.py
+++ b/tests/test_count_pulses.py
@@ -44,5 +44,12 @@ def _check_pulse_count(records):
         # Not sure how to check lone pulses other than duplicating logic
         # already in count_pulses, so just do a basic check:
         assert count['lone_pulse_area'][ch] <= count['pulse_area'][ch]
-        assert count['baseline_mean'][ch] == int(np.mean(rc0['baseline']))
-        assert count['baseline_rms_mean'][ch] == np.mean(rc0['baseline_rms'])
+        
+        # Check baseline values:
+        # nan does not exist for integer:
+        mean = strax.NO_PULSE_COUNTS if np.isnan(np.mean(rc0['baseline'])) else int(np.mean(rc0['baseline']))
+        assert count['baseline_mean'][ch] == mean
+        if not np.isnan(count['baseline_rms_mean'][ch]):
+            assert count['baseline_rms_mean'][ch] == np.mean(rc0['baseline_rms'])
+        else:
+            assert np.isnan(np.mean(rc0['baseline_rms']))

--- a/tests/test_count_pulses.py
+++ b/tests/test_count_pulses.py
@@ -47,7 +47,7 @@ def _check_pulse_count(records):
         
         # Check baseline values:
         # nan does not exist for integer:
-        mean = strax.NO_PULSE_COUNTS if np.isnan(np.mean(rc0['baseline'])) else int(np.mean(rc0['baseline']))
+        mean = straxen.NO_PULSE_COUNTS if np.isnan(np.mean(rc0['baseline'])) else int(np.mean(rc0['baseline']))
         assert count['baseline_mean'][ch] == mean
         if not np.isnan(count['baseline_rms_mean'][ch]):
             assert count['baseline_rms_mean'][ch] == np.mean(rc0['baseline_rms'])

--- a/tests/test_count_pulses.py
+++ b/tests/test_count_pulses.py
@@ -43,3 +43,5 @@ def _check_pulse_count(records):
         # Not sure how to check lone pulses other than duplicating logic
         # already in count_pulses, so just do a basic check:
         assert count['lone_pulse_area'][ch] <= count['pulse_area'][ch]
+        assert count['baseline_mean'][ch] == int(np.mean(rc0['baseline']))
+        assert count['baseline_rms_mean'][ch] == np.mean(rc0['baseline_rms'])

--- a/tests/test_count_pulses.py
+++ b/tests/test_count_pulses.py
@@ -2,6 +2,7 @@ from hypothesis import given, settings
 import strax
 import strax.testutils
 import straxen
+import numpy as np
 
 
 @settings(deadline=None)


### PR DESCRIPTION
For a quickly monitoring the overall PMT rates `pulse_counts` is already quite handy and fast to load. However if one wants to check the stability of the baseline one has to go back all the way down to records where data loading becomes slow. To overcome this problem I added an additional `baseline_mean` field as well as an `baseline_rms_mean` field which stores the average baseline and baseline rms value per PMT.  