### PR TITLE
Update led_calibration.py

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -433,8 +433,8 @@ def override_target(rd):
         return False
 
     # Special modes override target for these
-    led_modes = ['pmtgain', 'pmtap']
-    diagnostic_modes = ['exttrig', 'noise']
+    led_modes = ['pmtgain']
+    diagnostic_modes = ['exttrig', 'noise', 'pmtap']
 
     mode = str(rd.get('mode'))
     log.info(f'override_target::\tmode is {mode}, changing target if needed')

--- a/straxen/plugins/led_calibration.py
+++ b/straxen/plugins/led_calibration.py
@@ -83,13 +83,19 @@ def get_records(raw_records, baseline_window):
     Determine baseline as the average of the first baseline_samples
     of each pulse. Subtract the pulse float(data) from baseline.
     """  
+    
+    if len(raw_records):
+        record_length = len(raw_records['data'][0])
+    else:
+        return
+        
     _dtype = [(('Start time since unix epoch [ns]', 'time'), '<i8'), 
               (('Length of the interval in samples', 'length'), '<i4'), 
               (('Width of one sample [ns]', 'dt'), '<i2'), 
               (('Channel/PMT number', 'channel'), '<i2'), 
               (('Length of pulse to which the record belongs (without zero-padding)', 'pulse_length'), '<i4'), 
               (('Fragment number in the pulse', 'record_i'), '<i2'), 
-              (('Waveform data in raw ADC counts', 'data'), 'f4', (165,))]
+              (('Waveform data in raw ADC counts', 'data'), 'f4', (record_length,))]
               
     records = np.zeros(len(raw_records), dtype=_dtype)
 


### PR DESCRIPTION
A quick fix that will hopefully stop the eventbuilders from crashing:
```
"""
Traceback (most recent call last):
  File "/home/xedaq/miniconda/envs/py37/lib/python3.7/concurrent/futures/process.py", line 239, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/home/xedaq/software/npshmex/npshmex.py", line 193, in shm_wrap_f
    result = f(*args, **kwargs)
  File "/home/xedaq/software/strax/strax/plugin.py", line 806, in do_compute
    r = p.do_compute(**compute_kwargs)
  File "/home/xedaq/software/strax/strax/plugin.py", line 451, in do_compute
    result = self.compute(**kwargs)
  File "/home/xedaq/software/straxen/straxen/plugins/led_calibration.py", line 62, in compute
    r    = get_records(rr, baseline_window=self.config['baseline_window'])
  File "/home/xedaq/software/straxen/straxen/plugins/led_calibration.py", line 102, in get_records
    records['data']         = raw_records['data']
ValueError: could not broadcast input array from shape (424396,805) into shape (424396,165)
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/xedaq/software/straxen/bin/bootstrax", line 1032, in run_strax
    st_make()
  File "/home/xedaq/software/straxen/bin/bootstrax", line 1029, in st_make
    max_workers=process_mode['cores'])
  File "/home/xedaq/software/strax/strax/context.py", line 922, in make
    save=save, max_workers=max_workers, **kwargs):
  File "/home/xedaq/software/strax/strax/context.py", line 831, in get_iter
    generator.throw(e)
  File "/home/xedaq/software/strax/strax/context.py", line 812, in get_iter
    for result in strax.continuity_check(generator):
  File "/home/xedaq/software/strax/strax/chunk.py", line 251, in continuity_check
    for s in chunk_iter:
  File "/home/xedaq/software/strax/strax/processor.py", line 270, in iter
    raise exc.with_traceback(traceback)
  File "/home/xedaq/software/strax/strax/processor.py", line 223, in iter
    yield from final_generator
  File "/home/xedaq/software/strax/strax/mailbox.py", line 401, in _read
    res = msg.result(timeout=self.timeout)
  File "/home/xedaq/miniconda/envs/py37/lib/python3.7/concurrent/futures/_base.py", line 435, in result
    return self.__get_result()
  File "/home/xedaq/miniconda/envs/py37/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
ValueError: could not broadcast input array from shape (424396,805) into shape (424396,165)
```