### PR TITLE
lower bootstrax resources and use xenon_sectets

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -568,26 +568,14 @@ def eb_can_process():
     return False
 
 
-def infer_mode(rd, input_dir):
+def infer_mode(rd):
     """Infer a safe operating mode of running bootstrax based on the size of the first
     chunk. Estimating save parameters for running bootstrax from:
     https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:eb_speed_tests_update
     returns: dictionary of how many cores and max_messages should be used based on an
     estimated data rate.
     """
-    nap_time, i = 10, 0
-    default_opt = result = dict(cores=args.cores, max_messages=args.max_messages, timeout=300)
-
-    # min. of 3 chunks with each pre_, chunk and post_
-    min_chunks = 3
-    while len(os.listdir(input_dir)) < min_chunks * 3:
-        if i >= 10:
-            # Too few files to be sure the first chunk is completely written
-            log.info(f'Waited {i * nap_time} s but less than {min_chunks} were written. '
-                     f'Could not infer run mode. Using default: {result}.')
-            return default_opt
-        i += 1
-        time.sleep(nap_time)
+    default_opt = dict(cores=args.cores, max_messages=args.max_messages, timeout=300)
 
     # Get data rate from dispatcher
     try:
@@ -598,7 +586,7 @@ def infer_mode(rd, input_dir):
         data_rate = sum([d['rate'] for d in docs])
     except Exception as e:
         log_warning(f'infer_mode ran into {e}. Cannot infer mode, using default mode.')
-        return default_opt
+        data_rate = None
 
     # Find out if eb is new (eb3-eb5):
     is_new_eb = int(hostname[2]) >= 3  # ebX.xenon.local
@@ -620,7 +608,9 @@ def infer_mode(rd, input_dir):
              'high_rate': dict(cores=10, max_messages=15, timeout=200),
              'very_high_rate': dict(cores=10, max_messages=10, timeout=300),
              'max_rate': dict(cores=8, max_messages=10, timeout=400)}}
-    if data_rate < 100:
+    if data_rate is None:
+        result = default_opt
+    elif data_rate < 100:
         result = run_settings[eb]['low_rate']
     elif data_rate < 250:
         result = run_settings[eb]['med_rate']
@@ -635,9 +625,10 @@ def infer_mode(rd, input_dir):
 
     # Lower the settings if there are continuous failures on this run:
     if rd['bootstrax'].get('n_failures', 0) >= lower_resources_after_n_failures:
-        result['cores'] //= 2
-        result['max_messages'] //= 2
-        result['timeout'] *= 1.5
+        result = dict(cores=max(4, result['cores'] // 2),
+                      max_messages=max(4, result['max_messages'] // 2),
+                      timeout=min(1000, result['timeout']* 1.5)
+                      )
         log_warning(f'infer_mode::\tRepeated failures. Lowering mode to {result}. This '
                     f'may indicated a sub-optimal state of {hostname}!')
 
@@ -1153,7 +1144,7 @@ def process_run(rd, send_heartbeats=args.production):
             fail(f"Could not find daq_config.strax_fragment_payload_bytes in database: {str(e)}")
 
         if args.infer_mode:
-            process_mode = infer_mode(rd, loc)
+            process_mode = infer_mode(rd)
         else:
             process_mode = dict(cores=args.cores, max_messages=args.max_messages, timeout=300)
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -635,8 +635,8 @@ def infer_mode(rd, input_dir):
 
     # Lower the settings if there are continuous failures on this run:
     if rd['bootstrax'].get('n_failures', 0) >= lower_resources_after_n_failures:
-        result['cores'] /= 2
-        result['max_messages'] /= 2
+        result['cores'] //= 2
+        result['max_messages'] //= 2
         result['timeout'] *= 1.5
         log_warning(f'infer_mode::\tRepeated failures. Lowering mode to {result}. This '
                     f'may indicated a sub-optimal state of {hostname}!')

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -46,7 +46,7 @@ Additionally, bootstrax tracks information with each run in the 'bootstrax' fiel
 Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is running to a collection in the DAQ database into the capped collection 'eb_monitor'. This collection contains information on what bootstrax is thinking of at the moment
   - **disk_used**: used part of the disk whereto this bootstrax instance is writing to (in percent)
 """
-__version__ = '0.5.2'
+__version__ = '0.5.3'
 
 import argparse
 from datetime import datetime, timedelta, timezone
@@ -80,7 +80,7 @@ parser.add_argument('--debug', action='store_true',
 parser.add_argument('--profile', type=str, default='false',
                     help="Option to run strax in profiling mode. "
                          "argument specifies the name of the profile if not 'false'. Use e.g. 'date'.prof")
-parser.add_argument('--cores', type=int, default=4,
+parser.add_argument('--cores', type=int, default=8,
                     help="Maximum number of workers to use in a strax process. "
                          "Set to -1 for all available cores")
 parser.add_argument('--target', default='event_info',
@@ -98,7 +98,7 @@ parser.add_argument('--production', action='store_true',
 parser.add_argument('--undying', action='store_true',
                     help="Except any error and ignore it")
 parser.add_argument('--max_messages', type=int,
-                    default=4,
+                    default=10,
                     help="number of max mailbox messages")
 
 actions = parser.add_mutually_exclusive_group()
@@ -200,11 +200,17 @@ dead_state = 'dead_bootstrax'
 
 # The maximum time difference (s) allowed between the timestamps in the data and the
 # duration of the run (from the runs metadeta). Fail if the difference is larger than:
-max_timetamp_diff = 2
+max_timetamp_diff = 5
 
 # The maximum number of retries for processing a run. After this many times of retrying
 # to process a run, the DAQ-group has to either manually fix this run or manually fail it.
 max_n_retry = 20
+
+# Bootstrax retries runs multiple times. If there have been this many fails we could lower
+# the resources to be somewhat more lenient on the CPU and RAM of the eventbuilders. Use
+# this option with care as we might be running in a sub-optimal mode that may not be
+# noticed and eventbuilders may be spending more time on trying to reprocess failed runs.
+lower_resources_after_n_failures = 10
 
 
 ##
@@ -265,8 +271,8 @@ st = new_context()
 
 # DAQ database
 daq_db_name = 'daq'
-daq_db_password = os.environ['MONGO_DAQ_PASSWORD']
-daq_db_username = os.environ['MONGO_DAQ_USERNAME']
+daq_db_password = straxen.get_secret('MONGO_DAQ_PASSWORD'.lower())
+daq_db_username = straxen.get_secret('MONGO_DAQ_USERNAME'.lower())
 daq_client = pymongo.MongoClient(f"mongodb://{daq_db_username}:{daq_db_password}@xenon1t-daq:27017/admin")
 daq_db = daq_client[daq_db_name]
 bs_coll = daq_db['eb_monitor']
@@ -279,8 +285,8 @@ if args.production:
     run_db = st.storage[0].client[run_dbname]
 else:
     # Please note, this is a read only account on the rundb
-    run_db_username = os.environ['RUNDB_USERNAME']
-    run_db_password = os.environ['RUNDB_PASSWORD']
+    run_db_username = straxen.get_secret('RUNDB_USERNAME'.lower())
+    run_db_password = straxen.get_secret('RUNDB_PASSWORD'.lower())
     run_client = pymongo.MongoClient(
         f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017/xenonnt")
     run_db = run_client[run_dbname]
@@ -624,7 +630,17 @@ def infer_mode(rd, input_dir):
         result = run_settings[eb]['very_high_rate']
     else:
         result = run_settings[eb]['max_rate']
-    log.info(f'Override processing mode for run {rd["number"]} changing to:\t {result}')
+    log.info(f'infer_mode::\tOverride processing mode for run {rd["number"]} changing to:'
+             f'\t {result}')
+
+    # Lower the settings if there are continuous failures on this run:
+    if rd['bootstrax'].get('n_failures', 0) >= lower_resources_after_n_failures:
+        result['cores'] /= 2
+        result['max_messages'] /= 2
+        result['timeout'] *= 1.5
+        log_warning(f'infer_mode::\tRepeated failures. Lowering mode to {result}. This '
+                    f'may indicated a sub-optimal state of {hostname}!')
+
     return result
 
 


### PR DESCRIPTION
Two minor additions are made to bootstrax:
  - **lower the resources available to process a run to be more lenient on CPU/RAM when a run has failed 10 times or more.**  Was raised in https://github.com/XENONnT/straxen/issues/138. 
I could have implemented a roll-of where each fail gradually lowers the amount of resources. I choose not to do this as this might waste too much time on a problem that actually needs a proper fix or is simply not related to the CPU/RAM usage. 
Please do note that sub-optimal performance of the eventbuilders may stay undetected if this happens regularly! For example a few days I restarted the eventbuilders as their swap and RAM were clogged up with all kind of stuff. One could imagine that if this happens very often one would not notice after this PR. However, especially comming year, I will be paying close attention to the rundb and often query the runsdb with the following syntax to check that this doesn't happen too often: 
```
{"bootstrax.n_failures":{"$gt":1}, "number":{"$gt":8000}}
```

  - **use xenon_sectrets.py as a resource for rundb passwords.** This is a technical issue of not being able to restart bootstrax as the environment variables are not available over ```ssh -t 'bootstrax'```. Using this syntax allow us to store the passwords in the xenon_sectrets.py without having to mingle with the sshd_config of the eventbuilders.
 - Finally I've also **upgraded the default of the number of cores and max messages** as these values were ridiculously low. 
