### PR TITLE
check all records for endtime determination as it affects chunking

### DIFF
--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -156,8 +156,9 @@ class DAQReader(strax.Plugin):
         first_start, last_start, last_end = None, None, None
         if len(records):
             first_start, last_start = records[0]['time'], records[-1]['time']
-            # Records are fixed length, so we also know the last end:
-            last_end = strax.endtime(records[-1])
+            # Records are sorted by (start)time and are of variable length.
+            # Their endtimes can differ.
+            last_end = strax.endtime(records).max()
             if first_start < start or last_start >= end:
                 raise ValueError(
                     f"Bad data from DAQ: chunk {path} should contain data "

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -157,8 +157,12 @@ class DAQReader(strax.Plugin):
         if len(records):
             first_start, last_start = records[0]['time'], records[-1]['time']
             # Records are sorted by (start)time and are of variable length.
-            # Their endtimes can differ.
-            last_end = strax.endtime(records).max()
+            # Their end-times can differ. In the most pessimistic case we have
+            # to look back one record length for each channel.
+            tot_channels = np.sum([np.diff(x)+1 for x in
+                                   self.config['channel_map'].values()])
+            look_n_samples = self.config["record_length"] * tot_channels
+            last_end = strax.endtime(records[-look_n_samples:]).max()
             if first_start < start or last_start >= end:
                 raise ValueError(
                     f"Bad data from DAQ: chunk {path} should contain data "


### PR DESCRIPTION
This is the straxen counterpart of https://github.com/AxFoundation/strax/pull/281. Please see the problem explained there. 

**The problem**
See https://github.com/AxFoundation/strax/pull/281.

**Symptoms**
During a high rate run we didn't observe any problems for `raw_records` and `records` however for `lone_hits` we ran into:
``` 
ValueError: Attempt to create chunk [008543.raw_records: 1594281342sec 999999000 ns - 1594281348sec 499999000 ns, 5836752 items, 258.9 MB/s] whose data ends late at 1594281348499999220
```

This was presumably caused by the fact that while the (long) pulse was in the middle of  `raw_records` and `records` but was classified as the last `lone_hit` leading to the error above.

**Daqreader implementation**
As illustrated nicely below by Daniel we need to make sure we have all the latest possible wfs of each channel as raw_records may overlap. In a worse case scenario we need to look for all the channels and each of the channels has a 1 sample long pulse (which is unrealistic but lets assume this for the sake of argument).

This means we have to look back for a single channel the length of each of the samples. Next we treat all the channels known to the daqreader as an independent channel with its own timestamps (which is also very conservative). Hence we have to look back:
```
n_samples * length_of_samples
```