### PR TITLE
Mounts for microstrax

### DIFF
--- a/bin/microstrax
+++ b/bin/microstrax
@@ -4,6 +4,7 @@ import argparse
 import hug
 import strax
 import straxen
+import os
 
 st: strax.Context
 max_load_mb = 1000
@@ -18,6 +19,8 @@ def load_context(name, extra_dirs=None):
 
     if extra_dirs is not None:
         for d in extra_dirs:
+            if os.access(d, os.W_OK) is not True:
+                raise IOError(f'No writing access to {d}. Check mountpoints ')
             st.storage.append(strax.DataDirectory(d, readonly=True))
 
     st.context_config['allow_incomplete'] = True

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -156,9 +156,8 @@ class DAQReader(strax.Plugin):
         first_start, last_start, last_end = None, None, None
         if len(records):
             first_start, last_start = records[0]['time'], records[-1]['time']
-            # Records are sorted by (start)time and are of variable length.
-            # Their endtimes can differ.
-            last_end = strax.endtime(records).max()
+            # Records are fixed length, so we also know the last end:
+            last_end = strax.endtime(records[-1])
             if first_start < start or last_start >= end:
                 raise ValueError(
                     f"Bad data from DAQ: chunk {path} should contain data "

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -157,12 +157,8 @@ class DAQReader(strax.Plugin):
         if len(records):
             first_start, last_start = records[0]['time'], records[-1]['time']
             # Records are sorted by (start)time and are of variable length.
-            # Their end-times can differ. In the most pessimistic case we have
-            # to look back one record length for each channel.
-            tot_channels = np.sum([np.diff(x)+1 for x in
-                                   self.config['channel_map'].values()])
-            look_n_samples = self.config["record_length"] * tot_channels
-            last_end = strax.endtime(records[-look_n_samples:]).max()
+            # Their endtimes can differ.
+            last_end = strax.endtime(records).max()
             if first_start < start or last_start >= end:
                 raise ValueError(
                     f"Bad data from DAQ: chunk {path} should contain data "


### PR DESCRIPTION
**Problem**
As illustrated in https://github.com/XENONnT/straxen/issues/145 we can run into problems when some mount-points for the host of microstrax are not correctly configured. This resulted in an error like:
```
error | "Can't load metadata, data for XXXXX-raw_records-rfzvpzj4mf not available"
```
This is of course not very enlightening. 

**Solution**
At startup of microstrax, make sure that we actually have access to all the requested folders. 

**Test**
Below I show the resultant output when trying to read from the non-existing eb6.
```
(py37) xedaq@eb2:~$ microstrax --extra_dirs /nfs/eb6 --max_load_mb 10000 --
max_return_mb 200
Traceback (most recent call last):
  File "/home/xedaq/miniconda/envs/py37/bin/microstrax", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/xedaq/software/straxen/bin/microstrax", line 139, in <module>
    load_context(args.context, extra_dirs=args.extra_dirs)
  File "/home/xedaq/software/straxen/bin/microstrax", line 23, in load_context
    raise IOError(f'No writing access to {d}. Check mountpoints ')
OSError: No writing access to /nfs/eb6. Check mountpoints
```