### PR TITLE
change S1 split threshold main contexts

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -26,7 +26,11 @@ xnt_common_config = dict(
          aqmon=(790, 807),
          tpc_blank=(999, 999),
          mv=(1000, 1083),
-         mv_blank=(1999, 1999)))
+         mv_blank=(1999, 1999)),
+    peak_split_gof_threshold=(
+        None,  # Reserved
+        ((0.5, 1), (4, 0.4)),
+        ((2, 1), (4.5, 0.4))))
 
 
 ##

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -26,11 +26,7 @@ xnt_common_config = dict(
          aqmon=(790, 807),
          tpc_blank=(999, 999),
          mv=(1000, 1083),
-         mv_blank=(1999, 1999)),
-    peak_split_gof_threshold=(
-        None,  # Reserved
-        ((0.5, 1), (4, 0.4)),
-        ((2, 1), (4.5, 0.4))))
+         mv_blank=(1999, 1999)))
 
 
 ##
@@ -140,7 +136,11 @@ x1t_common_config = dict(
     peak_right_extension=30,
     peak_min_pmts=2,
     save_outside_hits=(3, 3),
-    hit_min_amplitude='XENON1T_SR1')
+    hit_min_amplitude='XENON1T_SR1',
+    peak_split_gof_threshold=(
+        None,  # Reserved
+        ((0.5, 1), (3.5, 0.25)),
+        ((2, 1), (4.5, 0.4))))
 
 
 def demo():

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -85,18 +85,19 @@ def xenonnt_led(**kwargs):
         storage=st.storage,
         **st.context_config)
 
-#This gain model is a temp solution untill we have a nice stable one
-def xenonnt_simulation(output_folder = './strax_data'):
+
+# This gain model is a temp solution untill we have a nice stable one
+def xenonnt_simulation(output_folder='./strax_data'):
     import wfsim
     xnt_common_config['gain_model'] = ('to_pe_per_run',
-                                        aux_repo+'58e615f99a4a6b15e97b12951c510de91ce06045/fax_files/to_pe_nt.npy')
+                                        straxen.aux_repo+'58e615f99a4a6b15e97b12951c510de91ce06045/fax_files/to_pe_nt.npy')
     return strax.Context(
         storage=strax.DataDirectory(output_folder),
         register=wfsim.RawRecordsFromFaxNT,
         config=dict(detector='XENONnT',
-                    fax_config=aux_repo+'4e71b8a2446af772c83a8600adc77c0c3b7e54d1/fax_files/fax_config_nt.json',
+                    fax_config=straxen.aux_repo+'4e71b8a2446af772c83a8600adc77c0c3b7e54d1/fax_files/fax_config_nt.json',
                     **straxen.contexts.xnt_common_config,
-                   ),
+                     ),
         **straxen.contexts.common_opts)
 
 
@@ -208,13 +209,13 @@ def xenon1t_led(**kwargs):
         storage=st.storage,
         **st.context_config)
 
-def xenon1t_simulation(output_folder = './strax_data'):
+
+def xenon1t_simulation(output_folder='./strax_data'):
     import wfsim
     return strax.Context(
         storage=strax.DataDirectory(output_folder),
         register=wfsim.RawRecordsFromFax1T,
-        config=dict(fax_config=aux_repo+'1c5793b7d6c1fdb7f99a67926ee3c16dd3aa944f/fax_files/fax_config_1t.json',
-
+        config=dict(fax_config=straxen.aux_repo+'1c5793b7d6c1fdb7f99a67926ee3c16dd3aa944f/fax_files/fax_config_1t.json',
                     detector='XENON1T',
                     **straxen.contexts.x1t_common_config),
         **straxen.contexts.common_opts)

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -25,7 +25,7 @@ export, __all__ = strax.exporter()
                  # for more information
                  default=(
                      None,  # Reserved
-                     ((0.5, 1), (3.5, 0.25)),
+                     ((0.5, 1), (4, 0.4)),
                      ((2, 1), (4.5, 0.4))),
                  help='Natural breaks goodness of fit/split threshold to split '
                       'a peak. Specify as tuples of (log10(area), threshold).'),


### PR DESCRIPTION
For the data we are currently taking we see that too many peaks are split. This is due to the fact that we are detecting a lot of large S1s, the split threshold for these S1-like signals is to low. This PR solves this.

For more info see [Raise peak splitting requirement for S1-like signals in GXe on the XENONnT wiki](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:analysis:meetings:peak_splitting_gxe) as this repo is public.

**Implications of merging this PR**
If we merge this PR, that means that effectively **all** nT data we currently have is out of date and could not be able to be loaded using this context until we rebuild from records. Only the the datatypes in the figure below would be loadable of the data we currently have. This includes simulation data!

![afbeelding](https://user-images.githubusercontent.com/22295914/87667347-7749af80-c76a-11ea-81f2-969940af08a0.png)
Everything above this we would have to reprocess (see https://straxen.readthedocs.io/en/latest/reference/datastructure.html#event-positions).

1T data / context / analyses would not be affected.

**Alternative(s)**
We could alternatively change only the xenonnt_online context by adding lines and inserting ```context``` 
[here](https://github.com/XENONnT/straxen/blob/92aaf23f6635cfab06ad9d0de13ccb4cadbf47da/straxen/contexts.py#L55):
```python
 config = straxen.contexts.xnt_common_config
 config['peak_split_gof_threshold'] = (
        None,  # Reserved
        ((0.5, 1), (4, 0.4)),
        ((2, 1), (4.5, 0.4)))
```
I choose not to do this as the simulation- and data-contexts would diverge and we couldn't compare the two easily anymore.

**Related PRs and notes**
- https://github.com/AxFoundation/strax/pull/225
- https://github.com/XENONnT/straxen/pull/45
- [Peak splitting note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:analysis:meetings:peak_splitting_gxe)
- [Natural breaks splitting](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:analysis:strax_clustering_classification#b_natural_breaks_splitting)
- [Example wfs](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:analysis:meetings:20200713:fast_response_gxe:alpha_s1_wf)

**Unrelated**
I fixed some error in the simulation context.