### PR TITLE
up version peaklets

### DIFF
--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -60,7 +60,7 @@ class Peaklets(strax.Plugin):
     parallel = 'process'
     compressor = 'zstd'
 
-    __version__ = '0.3.4'
+    __version__ = '0.3.5'
 
     def infer_dtype(self):
         return dict(peaklets=strax.peak_dtype(


### PR DESCRIPTION
**Get ready for straxen v. 0.9.2**
Up version for change in dtype as in:
https://github.com/AxFoundation/strax/pull/286

Can be merged together with:
https://github.com/XENONnT/straxen/pull/150

Will require reprocessing of Xenon1T and XENONnT data for peaklets and above as explained in https://github.com/XENONnT/straxen/pull/150.