### PR TITLE
forbid creation of records

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -65,7 +65,7 @@ def xenonnt_online(output_folder='./strax_data',
             st.storage.append(
                 strax.DataDirectory(output_folder))
 
-        st.context_config['forbid_creation_of'] = 'raw_records'
+        st.context_config['forbid_creation_of'] = ('raw_records', 'records')
 
     return st
 


### PR DESCRIPTION
**Why**
There previously was an error in strax that also forbade the creation of records (see https://github.com/AxFoundation/strax/pull/289).

**Forbid user to create records-datatype**
This is up to the ACs to decide but I think we don't want people to start making records on dali as this can be computationally intense. 

This also means that people cannot create e.g. lone_hits on dali.

