### PR TITLE
Bootstrax/Ajax/Microstrax updates

### DIFF
--- a/bin/ajax
+++ b/bin/ajax
@@ -81,7 +81,7 @@ def main_ajax():
         remove_run_from_host(args.number, delete_live=args.delete_live, force=args.force)
 
     if args.clean:
-        _modes = {'ceph': clean_cehp,
+        _modes = {'ceph': clean_ceph,
                   'high_level_data': clean_high_level_data,
                   'non_latest': clean_non_latest,
                   'unregistered': clean_unregistered,
@@ -101,7 +101,7 @@ def main_ajax():
         elif args.clean == 'all':
             while True:
                 if hostname == eb_can_clean_ceph:
-                    clean_cehp()
+                    clean_ceph()
                     clean_abandoned(delete_live=True)
                     clean_unregistered(delete_live=True)
                     clean_database(delete_live=True)
@@ -120,13 +120,13 @@ def main_ajax():
             raise ValueError(f'Unknown cleaning mode {args.clean}')
 
 
-def clean_cehp():
+def clean_ceph():
     """
     Look for old data on ceph. If found, delete it. Recursively iterate until no old data
     is found. This function only works on the the host that is eb_can_clean_ceph.
     """
     if not hostname == eb_can_clean_ceph:
-        log.info(f'clean_cehp::\tfor cleaning ceph, go to {eb_can_clean_ceph}')
+        log.info(f'clean_ceph::\tfor cleaning ceph, go to {eb_can_clean_ceph}')
         return
 
     rd = run_coll.find_one({'bootstrax.state': 'done',
@@ -140,16 +140,16 @@ def clean_cehp():
         return
     else:
         run_number = rd['number']
-        log.info(f'clean_cehp::\tremove data associated to run {run_number}')
+        log.info(f'clean_ceph::\tremove data associated to run {run_number}')
         remove_run_from_host(run_number, delete_live=True, force=args.force)
-        log.info(f'clean_cehp::\tfinished for {run_number}, take a'
+        log.info(f'clean_ceph::\tfinished for {run_number}, take a'
                  f' {ajax_thresholds["short_nap"]} s nap')
         time.sleep(ajax_thresholds['short_nap'])
 
         # Repeat.
         if args.execute:
             wait_on_delete_thread()
-            clean_cehp()
+            clean_ceph()
 
     # Finally, check that there is no old data on ceph that is also not in the rundoc.
     clean_unregistered(delete_live=True)
@@ -293,38 +293,23 @@ def clean_unregistered(delete_live=False):
 
 def clean_old_hash():
     """
-    Query the database for data that was processed with other settings of straxen that
-    lead to a different linage hash. If we can find something on this host that is not in
-    correspondence with the latest hash: delete it.
+    Loop over the files on the host and check that the lineage is the same as the current
+    lineage hash we would get from straxen
     """
-    rds = run_coll.find({'data.type.$': {'$nin': low_level_data}, 'data.host': hostname})
-
-    for rd in rds:
-        run_id = f'{rd["number"]:06d}'
-        for ddoc in rd['data']:
-            if (
-                    ('host' in ddoc and ddoc['host'] != hostname) or
-                    (bool(re.findall('|'.join(low_level_data), ddoc['type']))) or
-                    ('meta' not in ddoc or 'lineage' not in ddoc['meta'])
-            ):
-                # We don't consider this ddoc because:
-                # - The ddoc is from another host
-                # - The ddoc is low-level (then it should be handled by admix not by ajax)
-                # - The ddoc is not in the right format because it's probably not made by
-                # bootstrax. It doesn't have the info we need to check if the hash is old.
-                continue
-
-            ddoc_hash = (ddoc['meta']['lineage_hash'] if 'lineage_hash' in ddoc['meta']
-                         else strax.DataKey(run_id, 'raw_records', ddoc['meta']['lineage']
-                                            ).lineage_hash)
-            current_st_hash = st.key_for(run_id, ddoc['type']).lineage_hash
-
-            if current_st_hash != ddoc_hash:
-                loc = ddoc['location']
-                log.info(f'clean_old_hash::\tLineage for run {run_id}, {ddoc["type"]} is '
-                         f'{current_st_hash}. Removing old hash: {ddoc_hash} from {loc}.')
-                delete_data(rd, loc, ddoc['type'], test=not args.execute)
-
+    files = os.listdir(output_folder)
+    for f in files:
+        run_id, data_type, lineage_hash = f.split('-')
+        if bool(re.findall('|'.join(low_level_data), data_type)):
+            continue
+        current_st_hash = st.key_for(run_id, data_type).lineage_hash
+        if current_st_hash != lineage_hash:
+            loc = os.path.join(output_folder, f)
+            log.info(f'clean_old_hash::\tLineage for run {run_id}, {data_type} is '
+                     f'{current_st_hash}. Removing old hash: {lineage_hash} from {loc}.')
+            rd = run_coll.find({'data.type': data_type,
+                                'data.host': hostname,
+                                'number': int(run_id)})
+            delete_data(rd, loc, data_type, test=not args.execute)
 
 def clean_abandoned(delete_live=False):
     """

--- a/bin/ajax
+++ b/bin/ajax
@@ -1,25 +1,21 @@
 #!/usr/bin/env python
 """
-AJAX: XENONnT
-Aggregate Junking Ancient Xenondata
-cleaning tool to remove old data from eventbuilders.
+AJAX: XENON-nT
+Aggregate Junking Ancient Xenon-data
+cleaning tool to remove old data from event builders.
 =============================================
 Joran Angevaare, 2020
 
-This tool keeps the event builders clean by:
- A) deleting data associated to a run if it has been abandoned (delete live_data and data from eb)
- B) deleting data if there is old high level data on the machine
- C) (re)moving old raw_records_nv as we do not plan to store this data long term
- D) check that the live_data is deleted if a run has been successfully processed and uploaded
+This tool keeps the event builders clean by performing any of the cleaning modes
+(try 'ajax --help' for a complete description).
 
-Whereas A-C can be performed on autopilot D is a rather delicate task as it can become somewhat complicated if multiple
-ajax instances are running on different machines.
-This could be solved by registering ajax like bootstrax but this seems overkill at the moment.
-Therefore D) can only be performed on one of the eventbuiders (see eb_can_clean_ceph).
-
+Some of these modes also affect the live_data rather than the processed data. As there can
+be multiple instances of ajax running there is a dedicated machine 'eb_can_clean_ceph'
+that may delete the live_data such that we prevent multiple attempts to perform a single
+action.
 """
 
-__version__ = '0.2.0'
+__version__ = '0.2.2'
 
 import argparse
 from datetime import datetime, timedelta
@@ -34,6 +30,9 @@ import time
 import re
 import numpy as np
 import sys
+import strax
+import straxen
+
 
 ##
 # Parameters
@@ -81,33 +80,25 @@ def main_ajax():
     if args.number:
         remove_run_from_host(args.number, delete_live=args.delete_live, force=args.force)
 
-    if args.mode:
-        _modes = {'clean_ceph': clean_cehp,
-                  'clean_high_level_data': clean_high_level_data,
-                  'clean_non_latest': clean_non_latest,
-                  'clean_unregistered': clean_unregistered,
-                  'clean_raw_records_nv': clean_raw_records_nv,
-                  'clean_abandoned': clean_abandoned,
-                  'clean_database': clean_database}
+    if args.clean:
+        _modes = {'ceph': clean_cehp,
+                  'high_level_data': clean_high_level_data,
+                  'non_latest': clean_non_latest,
+                  'unregistered': clean_unregistered,
+                  'raw_records_nv': clean_raw_records_nv,
+                  'abandoned': clean_abandoned,
+                  'old_hash': clean_old_hash,
+                  'database': clean_database}
 
-        if args.mode in _modes:
-            print(args.mode)
+        if args.clean in _modes:
             # Do this mode
-            mode = _modes[args.mode]
-            mode()
-            print(f'Done with {args.mode}')
-        elif args.mode != 'clean_all':
-            raise ValueError(f'Unknown mode {args.mode}')
+            _modes[args.clean]()
+            if hostname == eb_can_clean_ceph and (
+                    args.clean in ['abandoned', 'unregistered', 'database']):
+                _modes[args.clean](delete_live=True)
 
-        if hostname == eb_can_clean_ceph:
-            if args.mode == 'clean_unregistered':
-                clean_unregistered(delete_live=True)
-            elif args.mode == 'clean_abandoned':
-                clean_abandoned(delete_live=True)
-            elif args.mode == 'clean_database':
-                clean_database(delete_live=True)
-
-        if args.mode == 'clean_all':
+            log.info(f'Done with {args.clean}')
+        elif args.clean == 'all':
             while True:
                 if hostname == eb_can_clean_ceph:
                     clean_cehp()
@@ -125,6 +116,8 @@ def main_ajax():
                     break
                 log.info(f'Loop finished, take a {ajax_thresholds["nap_time"]} s nap')
                 time.sleep(ajax_thresholds['nap_time'])
+        else:
+            raise ValueError(f'Unknown cleaning mode {args.clean}')
 
 
 def clean_cehp():
@@ -264,6 +257,7 @@ def clean_raw_records_nv():
     """Based on the runsDB, remove the raw_records_nv if they are old"""
     check_sn_trigger()
     rd = run_coll.find_one({'data.type': 'raw_records_nv',
+                            'data.host': hostname,
                             'start':
                                 {'$lt': now(-ajax_thresholds["remove_raw_records_nv"])}})
     if not rd:
@@ -293,11 +287,43 @@ def clean_unregistered(delete_live=False):
     log.info(f'clean_unregistered::\tfound {len(run_ids)} runs stored on'
              f'{folder_to_check}. Checking that each is in the runs-database')
     for run_id in run_ids:
-        try:
-            run_number = int(run_id)
-        except ValueError:
-            print(f"Strange {run_id} cannot be converted to a run_number")
+        run_number = int(run_id)
         remove_if_unregistered(run_number, delete_live=delete_live)
+
+
+def clean_old_hash():
+    """
+    Query the database for data that was processed with other settings of straxen that
+    lead to a different linage hash. If we can find something on this host that is not in
+    correspondence with the latest hash: delete it.
+    """
+    rds = run_coll.find({'data.type.$': {'$nin': low_level_data}, 'data.host': hostname})
+
+    for rd in rds:
+        run_id = f'{rd["number"]:06d}'
+        for ddoc in rd['data']:
+            if (
+                    ('host' in ddoc and ddoc['host'] != hostname) or
+                    (bool(re.findall('|'.join(low_level_data), ddoc['type']))) or
+                    ('meta' not in ddoc or 'lineage' not in ddoc['meta'])
+            ):
+                # We don't consider this ddoc because:
+                # - The ddoc is from another host
+                # - The ddoc is low-level (then it should be handled by admix not by ajax)
+                # - The ddoc is not in the right format because it's probably not made by
+                # bootstrax. It doesn't have the info we need to check if the hash is old.
+                continue
+
+            ddoc_hash = (ddoc['meta']['lineage_hash'] if 'lineage_hash' in ddoc['meta']
+                         else strax.DataKey(run_id, 'raw_records', ddoc['meta']['lineage']
+                                            ).lineage_hash)
+            current_st_hash = st.key_for(run_id, ddoc['type']).lineage_hash
+
+            if current_st_hash != ddoc_hash:
+                loc = ddoc['location']
+                log.info(f'clean_old_hash::\tLineage for run {run_id}, {ddoc["type"]} is '
+                         f'{current_st_hash}. Removing old hash: {ddoc_hash} from {loc}.')
+                delete_data(rd, loc, ddoc['type'], test=not args.execute)
 
 
 def clean_abandoned(delete_live=False):
@@ -623,23 +649,24 @@ if __name__ == '__main__':
     actions = parser.add_mutually_exclusive_group()
     actions.add_argument('--number', type=int, metavar='NUMBER',
                          help="Process a single run, regardless of its status.")
-    actions.add_argument('--mode', type=str,
+    actions.add_argument('--clean', type=str,
                          help=
-                         'Run ajax in any of the following modes: [clean_ceph, clean_raw_records_nv, '
-                         'clean_unregistered, clean_abandoned, clean_high_level_data, clean_all]\n'
-                         '"clean_ceph": Remove successfully processed runs and abandoned runs from /live_data\n'
-                         '"clean_raw_records_nv": (re)move raw_records_nv if older than threshold\n'
-                         '"clean_unregistered": remove all data from this host that is not registered in the rundb\n'
-                         '"clean_abandoned": remove all the data associated to abandoned runs\n'
-                         '"clean_high_level_data": remove all the data on host that is not registered in the rundb\n'
-                         '"clean_non_latest": remove data on this host if it was not the last to process a given run \n'
-                         '"clean_database": check if all the entries that the database claims are actually here \n' 
-                         '"clean_all": Clean everything that AJAX can get its hands on: unregistered data, high level '
+                         'Run ajax in any of the following modes: clean [ceph, raw_records_nv, '
+                         'unregistered, abandoned, high_level_data, all]\n'
+                         '"ceph": Remove successfully processed runs and abandoned runs from /live_data\n'
+                         '"raw_records_nv": (re)move raw_records_nv if older than threshold\n'
+                         '"unregistered": remove all data from this host that is not registered in the rundb\n'
+                         '"abandoned": remove all the data associated to abandoned runs\n'
+                         '"high_level_data": remove all the data on host that is not registered in the rundb\n'
+                         '"non_latest": remove data on this host if it was not the last to process a given run \n'
+                         '"database": check if all the entries that the database claims are actually here \n'
+                         '"old_hash": remove high level data if the hash doesnt equal the latest for this datatype \n' 
+                         '"all": Clean everything that AJAX can get its hands on: unregistered data, high level '
                          'data, old raw_records_nv')
 
     args = parser.parse_args()
 
-    if args.mode == 'clean_raw_records_nv':
+    if args.clean == 'raw_records_nv':
         log.info(f'main::\tDelete neutron veto data from {hostname} older than '
                  f'{ajax_thresholds["remove_raw_records_nv"]} s')
         raise NotImplementedError("I dont know what to do with the raw_records of the NV")
@@ -654,9 +681,13 @@ if __name__ == '__main__':
         if not input('Want to proceed willingly? [y]').lower() == 'y':
             log.info(f'main::\tAlright no unsafe operations, bye bye')
             exit(-1)
-        if args.mode != 'clean_abandoned' and not args.number:
+        if args.clean != 'abandoned' and not args.number:
             raise NotImplementedError('main::\tI dont want to have this option enabled '
                                       'yet.')
+
+    if args.clean in ['all', 'old_hash']:
+        # Need the context for the latest hash
+        st = straxen.contexts.xenonnt_online()
 
     # Set the folders
     ceph_folder = '/live_data/xenonnt/'

--- a/bin/ajax
+++ b/bin/ajax
@@ -19,7 +19,7 @@ Therefore D) can only be performed on one of the eventbuiders (see eb_can_clean_
 
 """
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 import argparse
 from datetime import datetime, timedelta
@@ -82,34 +82,40 @@ def main_ajax():
         remove_run_from_host(args.number, delete_live=args.delete_live, force=args.force)
 
     if args.mode:
-        if args.mode == 'clean_ceph':
-            clean_cehp()
-        elif args.mode == 'clean_high_level_data':
-            clean_high_level_data()
-        elif args.mode == 'clean_non_latest':
-            clean_non_latest()
-        elif args.mode == 'clean_unregistered':
-            clean_unregistered()
-            if hostname == eb_can_clean_ceph:
+        _modes = {'clean_ceph': clean_cehp,
+                  'clean_high_level_data': clean_high_level_data,
+                  'clean_non_latest': clean_non_latest,
+                  'clean_unregistered': clean_unregistered,
+                  'clean_raw_records_nv': clean_raw_records_nv,
+                  'clean_abandoned': clean_abandoned,
+                  'clean_database': clean_database}
+
+        if args.mode in _modes:
+            # Do this mode
+            _modes[args.mode]()
+
+        if hostname == eb_can_clean_ceph:
+            if args.mode == 'clean_unregistered':
                 clean_unregistered(delete_live=True)
-        elif args.mode == 'clean_raw_records_nv':
-            clean_raw_records_nv()
-        elif args.mode == 'clean_abandoned':
-            clean_abandoned()
-            if hostname == eb_can_clean_ceph:
+            elif args.mode == 'clean_abandoned':
                 clean_abandoned(delete_live=True)
-        elif args.mode == 'clean_all':
+            elif args.mode == 'clean_database':
+                clean_database(delete_live=True)
+
+        if args.mode == 'clean_all':
             while True:
                 if hostname == eb_can_clean_ceph:
                     clean_cehp()
                     clean_abandoned(delete_live=True)
                     clean_unregistered(delete_live=True)
+                    clean_database(delete_live=True)
 
                 clean_high_level_data()
                 clean_unregistered()
                 clean_raw_records_nv()
                 clean_abandoned()
                 clean_non_latest()
+                clean_database()
                 if not args.execute:
                     break
                 log.info(f'Loop finished, take a {ajax_thresholds["nap_time"]} s nap')
@@ -515,6 +521,33 @@ def _remove_unregistered_run(base_folder, run_id, checked_db=False):
         raise FileNotFoundError(f'No data registered on {hostname} for {run_id}')
 
 
+def clean_database(delete_live=False):
+    """
+    Remove entries from the database if the data is not on this host anymore
+    """
+    # We need to grep all the rundocs at once as simply doing one at the time (find_one)
+    # might get stuck as the query may yield the same result the next time it is called.
+    if not delete_live:
+        rds = run_coll.find({'data.host': hostname})
+    else:
+        rds = run_coll.find({'data.host': 'daq'})
+    if not rds:
+        # Great, we are clean
+        return
+
+    for rd in rds:
+        # Okay, good to go let's see if it is high level data and if so, delete it
+        for ddoc in rd['data']:
+            # Only delete data on this host
+            if (('host' in ddoc and ddoc['host'] == hostname) or
+                    ('host' in ddoc and ddoc['host'] == 'daq' and delete_live)):
+                loc = ddoc['location']
+                if not os.path.exists(loc):
+                    log.info(f'clean_non_latest::\tdelete entry of data at {loc} as it '
+                             f'does not exist')
+                    delete_data(rd, loc, ddoc['type'], test=not args.execute)
+
+
 ##
 # Helper functions
 ##
@@ -593,6 +626,7 @@ if __name__ == '__main__':
                          '"clean_abandoned": remove all the data associated to abandoned runs\n'
                          '"clean_high_level_data": remove all the data on host that is not registered in the rundb\n'
                          '"clean_non_latest": remove data on this host if it was not the last to process a given run \n'
+                         '"clean_database": check if all the entries that the database claims are actually here \n'                         
                          '"clean_all": Clean everything that AJAX can get its hands on: unregistered data, high level '
                          'data, old raw_records_nv')
 
@@ -617,19 +651,9 @@ if __name__ == '__main__':
             raise NotImplementedError('main::\tI dont want to have this option enabled '
                                       'yet.')
 
-    # The event builders write to different directories on the respective machines.
-    eb_directories = {
-        'eb0.xenon.local': '/data2/xenonnt_processed/',
-        'eb1.xenon.local': '/data1/xenonnt_processed/',
-        'eb2.xenon.local': '/nfs/eb0_data1/xenonnt_processed/',
-        'eb3.xenon.local': '/data/xenonnt_processed/',
-        'eb4.xenon.local': '/data/xenonnt_processed/',
-        'eb5.xenon.local': '/data/xenonnt_processed/',
-    }
-
     # Set the folders
     ceph_folder = '/live_data/xenonnt/'
-    output_folder = eb_directories[hostname]
+    output_folder = '/data/xenonnt_processed/'
     if os.access(output_folder, os.W_OK) is not True:
         raise IOError(f'main::\tNo writing access to {output_folder}')
 

--- a/bin/ajax
+++ b/bin/ajax
@@ -19,7 +19,7 @@ Therefore D) can only be performed on one of the eventbuiders (see eb_can_clean_
 
 """
 
-__version__ = '0.1.2'
+__version__ = '0.2.0'
 
 import argparse
 from datetime import datetime, timedelta
@@ -91,8 +91,13 @@ def main_ajax():
                   'clean_database': clean_database}
 
         if args.mode in _modes:
+            print(args.mode)
             # Do this mode
-            _modes[args.mode]()
+            mode = _modes[args.mode]
+            mode()
+            print(f'Done with {args.mode}')
+        elif args.mode != 'clean_all':
+            raise ValueError(f'Unknown mode {args.mode}')
 
         if hostname == eb_can_clean_ceph:
             if args.mode == 'clean_unregistered':
@@ -120,8 +125,6 @@ def main_ajax():
                     break
                 log.info(f'Loop finished, take a {ajax_thresholds["nap_time"]} s nap')
                 time.sleep(ajax_thresholds['nap_time'])
-        else:
-            raise ValueError(f'Unknown mode {args.mode}')
 
 
 def clean_cehp():
@@ -290,7 +293,11 @@ def clean_unregistered(delete_live=False):
     log.info(f'clean_unregistered::\tfound {len(run_ids)} runs stored on'
              f'{folder_to_check}. Checking that each is in the runs-database')
     for run_id in run_ids:
-        remove_if_unregistered(int(run_id), delete_live=delete_live)
+        try:
+            run_number = int(run_id)
+        except ValueError:
+            print(f"Strange {run_id} cannot be converted to a run_number")
+        remove_if_unregistered(run_number, delete_live=delete_live)
 
 
 def clean_abandoned(delete_live=False):
@@ -543,8 +550,8 @@ def clean_database(delete_live=False):
                     ('host' in ddoc and ddoc['host'] == 'daq' and delete_live)):
                 loc = ddoc['location']
                 if not os.path.exists(loc):
-                    log.info(f'clean_non_latest::\tdelete entry of data at {loc} as it '
-                             f'does not exist')
+                    log.info(f'clean_database::\tdelete entry of data from {rd["number"]} '
+                             f'at {loc} as it does not exist')
                     delete_data(rd, loc, ddoc['type'], test=not args.execute)
 
 
@@ -626,7 +633,7 @@ if __name__ == '__main__':
                          '"clean_abandoned": remove all the data associated to abandoned runs\n'
                          '"clean_high_level_data": remove all the data on host that is not registered in the rundb\n'
                          '"clean_non_latest": remove data on this host if it was not the last to process a given run \n'
-                         '"clean_database": check if all the entries that the database claims are actually here \n'                         
+                         '"clean_database": check if all the entries that the database claims are actually here \n' 
                          '"clean_all": Clean everything that AJAX can get its hands on: unregistered data, high level '
                          'data, old raw_records_nv')
 

--- a/bin/ajax
+++ b/bin/ajax
@@ -19,7 +19,7 @@ Therefore D) can only be performed on one of the eventbuiders (see eb_can_clean_
 
 """
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 import argparse
 from datetime import datetime, timedelta
@@ -613,7 +613,7 @@ if __name__ == '__main__':
         if not input('Want to proceed willingly? [y]').lower() == 'y':
             log.info(f'main::\tAlright no unsafe operations, bye bye')
             exit(-1)
-        if args.mode != 'clean_abandoned' or not args.number:
+        if args.mode != 'clean_abandoned' and not args.number:
             raise NotImplementedError('main::\tI dont want to have this option enabled '
                                       'yet.')
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -361,7 +361,8 @@ def main_loop():
         # Check resources are still OK, otherwise crash / reboot program
 
         # Process new runs
-        rd = consider_run({"bootstrax": {"$exists": False}}, test_counter=new_runs_seen)
+        rd = consider_run({"bootstrax.state": {"$exists": False}},
+                          test_counter=new_runs_seen)
         if rd is not None:
             new_runs_seen += 1
             process_run(rd)

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -46,7 +46,7 @@ Additionally, bootstrax tracks information with each run in the 'bootstrax' fiel
 Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is running to a collection in the DAQ database into the capped collection 'eb_monitor'. This collection contains information on what bootstrax is thinking of at the moment
   - **disk_used**: used part of the disk whereto this bootstrax instance is writing to (in percent)
 """
-__version__ = '0.5.4'
+__version__ = '0.5.5'
 
 import argparse
 from datetime import datetime, timedelta, timezone
@@ -119,17 +119,9 @@ args = parser.parse_args()
 
 print(f'---\n bootstrax version {__version__}\n---')
 
-# The event builders write to different directories on the respective machines.
-eb_directories = {
-    'eb0.xenon.local': '/data2/xenonnt_processed/',
-    'eb1.xenon.local': '/data1/xenonnt_processed/',
-    'eb2.xenon.local': '/nfs/eb0_data1/xenonnt_processed/',
-    'eb3.xenon.local': '/data/xenonnt_processed/',
-    'eb4.xenon.local': '/data/xenonnt_processed/',
-    'eb5.xenon.local': '/data/xenonnt_processed/',
-}
 # The folder that can be used for testing bootstrax (i.e. non production mode). It will be written to:
-test_data_folder = './bootstrax/'
+test_data_folder = ('/nfs/scratch/bootstrax/' if os.path.exists('/nfs/scratch/bootstrax/')
+                    else './bootstrax/')
 
 # Timeouts in seconds
 timeouts = {
@@ -225,7 +217,7 @@ log = logging.getLogger()
 hostname = socket.getfqdn()
 
 # Set the output folder
-output_folder = eb_directories[hostname]
+output_folder = '/data/xenonnt_processed/'
 if os.access(output_folder, os.W_OK) is not True:
     raise IOError(f'No writing access to {output_folder}')
 
@@ -529,6 +521,9 @@ def eb_can_process():
     # In test mode we can always process
     if not args.production:
         return True
+    elif 'eb2' in hostname:
+        log_warning('Why is eb2 alive?!')
+        return False
 
     # Check that there are runs that are waiting to be processed. If there are few, this
     # eb should not process.

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -840,7 +840,7 @@ def upload_file_metadata(rd):
     :param rd: rundoc
     """
     try:
-        st_meta = new_context(dict(cores=args.cores, max_messages=args.max_messages, timeout=100))
+        st_meta = new_context(cores=args.cores, max_messages=args.max_messages, timeout=100)
         st_meta.set_context_config({'forbid_creation_of': '*'})
     except Exception as e:
         log_warning(f"Cannot create context to read the metadata: {e}")

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1346,7 +1346,8 @@ def cleanup_db():
         bd = bs_coll.find_one(
                 {'host': f'eb{eb_i}.xenon.local'},
                 sort=[('time', pymongo.DESCENDING)])
-        if (bd['time'] < now(-timeouts['bootstrax_presumed_dead']) and
+        if (bd and
+                bd['time'] < now(-timeouts['bootstrax_presumed_dead']) and
                 bd['state'] is not dead_state):
             bs_coll.find_one_and_update({'_id': bd['_id']},
                                         {'$set': {'state': dead_state}})

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -46,7 +46,7 @@ Additionally, bootstrax tracks information with each run in the 'bootstrax' fiel
 Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is running to a collection in the DAQ database into the capped collection 'eb_monitor'. This collection contains information on what bootstrax is thinking of at the moment
   - **disk_used**: used part of the disk whereto this bootstrax instance is writing to (in percent)
 """
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 
 import argparse
 from datetime import datetime, timedelta, timezone
@@ -1087,28 +1087,38 @@ def process_run(rd, send_heartbeats=args.production):
                 fail("Corrupted data doc, found entry without 'type' field")
             if dd['type'] == 'live':
                 break
-            else:
-                if args.production:
-                    fail("Non-live data already registered; untracked failure?")
-                else:
-                    dd = {'type': 'live', 'location': '/live_data/xenonnt/', 'host': 'daq'}
-        else:
-            if args.production:
-                fail(f"No live data entry in rundoc")
-            else:
+            elif not args.production:
+                # We are just testing let's assume its on the usual location
                 dd = {'type': 'live', 'location': '/live_data/xenonnt/', 'host': 'daq'}
+            else:
+                fail("Non-live data already registered; untracked failure?")
+        else:
+            fail(f"No live data entry in rundoc")
 
         if not osp.exists(dd['location']):
             fail(f"No access to live data folder {dd['location']}")
 
-        thread_info = rd.get('daq_config', dict()).get('processing_threads', dict())
-        n_readout_threads = sum([v for v in thread_info.values()])
         try:
-            daq_chunk_duration = int(rd['daq_config']['strax_chunk_length'] * 1e9)
-            daq_overlap_chunk_duration = int(rd['daq_config']['strax_chunk_overlap'] * 1e9)
+            # Fetch parameters from the rundoc. If not readably, let's use redax' default
+            # values (that are hardcoded here).
+            if 'daq_conig' not in rd:
+                log_warning('No daq_config in the rundoc!')
+            dq_conf = rd.get('daq_config', dict())
+            to_read = ('processing_threads', 'strax_chunk_length','strax_chunk_overlap',
+                       'strax_fragment_payload_bytes')
+            for conf in to_read:
+                if conf not in dq_conf:
+                    log_warning(f'{conf} not in rundoc for {run_id}! Using default values.')
+            thread_info = dq_conf.get('processing_threads', dict())
+            n_readout_threads = sum([v for v in thread_info.values()])
+            daq_chunk_duration = int(dq_conf.get('strax_chunk_length', 5) * 1e9)
+            daq_overlap_chunk_duration = int(dq_conf.get('strax_chunk_overlap', 0.5) * 1e9)
+            # note that value in rd in bytes hence //2
+            samples_per_record = dq_conf.get('strax_fragment_payload_bytes', 220) // 2
+            if not samples_per_record == 110:
+                log.info(f'Samples_per_record = {samples_per_record}')
         except Exception as e:
-            fail(f"Could not find 'strax_chunk_length' and/or'strax_chunk_overlap' in "
-                 f"rundoc: {str(e)}")
+            fail(f"Could not find {to_read} in rundoc: {str(e)}")
 
         if not n_readout_threads:
             fail(f"Run doc for {run_id} has no readout thread count info")
@@ -1130,7 +1140,7 @@ def process_run(rd, send_heartbeats=args.production):
             os.remove(exception_tempfile)
 
         target = args.target
-        if not args.production and not 'bootstrax'in rd:
+        if not args.production and 'bootstrax' not in rd:
             # Bootstrax does not register in non-production mode
             pass
         elif rd['bootstrax'].get('n_failures', 0) > 1 and not args.process:
@@ -1143,13 +1153,6 @@ def process_run(rd, send_heartbeats=args.production):
             run_start_time = rd['start'].replace(tzinfo=timezone.utc).timestamp()
         except Exception as e:
             fail(f"Could not find start in datetime.datetime object: {str(e)}")
-
-        try:
-            samples_per_record = rd['daq_config']['strax_fragment_payload_bytes'] // 2  # note that value in rd in bytes
-            if not samples_per_record == 110:
-                log.info(f'Samples_per_record = {samples_per_record}')
-        except Exception as e:
-            fail(f"Could not find daq_config.strax_fragment_payload_bytes in database: {str(e)}")
 
         if args.infer_mode:
             process_mode = infer_mode(rd)
@@ -1192,7 +1195,14 @@ def process_run(rd, send_heartbeats=args.production):
                 log.info(f"Strax done on run {run_id}, performing basic data quality check")
 
                 try:
-                    md = st.get_meta(run_id, 'raw_records')
+                    # Sometimes we have only he channels or mv channels, try loading one
+                    # until we get one with chunks.
+                    for rr_type in ('raw_records', 'raw_records_he', 'raw_records_mv',
+                                    # 'raw_records_nv' # not in the DAQ-reader yet.
+                                    ):
+                        md = st.get_meta(run_id, rr_type)
+                        if len(md['chunks']):
+                            break
                 except Exception:
                     fail("Processing succeeded, but metadata not readable: "
                          + traceback.format_exc())
@@ -1247,7 +1257,6 @@ def process_run(rd, send_heartbeats=args.production):
 
     except RunFailed:
         return
-
 
 
 ##

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1347,7 +1347,8 @@ def cleanup_db():
                 {'host': f'eb{eb_i}.xenon.local'},
                 sort=[('time', pymongo.DESCENDING)])
         if (bd and
-                bd['time'] < now(-timeouts['bootstrax_presumed_dead']) and
+                bd['time'].replace(tzinfo=pytz.utc) < now(
+                    -timeouts['bootstrax_presumed_dead']) and
                 bd['state'] is not dead_state):
             bs_coll.find_one_and_update({'_id': bd['_id']},
                                         {'$set': {'state': dead_state}})

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -831,23 +831,52 @@ def check_data_written(rd):
     return files_written > 0
 
 
-def count_files(rd):
+def upload_file_metadata(rd):
     """
-    Count the number of files on the location on the basis of the data entry in the rundoc
-    This info is used for Admix to checksum that all the files are correctly uploaded to
-    Rucio
+    Update the data-field in the rundoc with a portion of the metadata. Also count the
+    number of files on the location on the basis of the data entry in the rundoc. The
+    filecount info is used for Admix to checksum that all the files are correctly uploaded
+    to Rucio.
     :param rd: rundoc
     """
+    try:
+        st_meta = new_context(dict(cores=args.cores, max_messages=args.max_messages, timeout=100))
+        st_meta.set_context_config({'forbid_creation_of': '*'})
+    except Exception as e:
+        log_warning(f"Cannot create context to read the metadata: {e}")
+        st_meta = None
+
     for ddoc in rd['data']:
         if hostname != ddoc['host']:
             continue
         loc = ddoc.get('location', '')
+
         if os.path.exists(loc):
             file_count = len(os.listdir(loc))
+            # Can also get the latter from st.lineage_for but too lazy for that
+            data_size_mb, avg_data_size_mb, lineage_hash = None, None, None
+            run_id = '%06d' % rd['number']
+            if st_meta is not None:
+                try:
+                    md = st.get_meta(run_id, ddoc['type'])
+                    chunk_mb = [chunk['nbytes']/(1e6) for chunk in md['chunks']]
+                    data_size_mb = int(np.sum(chunk_mb))
+                    avg_data_size_mb = int(np.average(chunk_mb))
+                    lineage_hash = md['lineage_hash']
+                except Exception as e:
+                    log_warning(f"Cannot load metadata if {ddoc['type']}: {e}")
+
             run_coll.update_one(
                     {'_id': rd['_id'],
                      'data.location': ddoc['location']},
-                    {'$set': {'data.$.file_count': file_count}})
+                    {'$set':
+                         {'data.$.file_count': file_count,
+                          'data.$.strax_version': strax.__version__,
+                          'data.$.straxen_version': straxen.__version__,
+                          'data.$.size_mb': data_size_mb,
+                          'data.$.avg_chunk_mb': avg_data_size_mb,
+                          'data.$.lineage_hash': lineage_hash}
+                     })
 
 
 def set_status_finished(rd):
@@ -1228,7 +1257,7 @@ def process_run(rd, send_heartbeats=args.production):
                 if args.production:
                     set_run_state(rd, 'done', **info)
                     set_status_finished(rd)
-                    count_files(rd)
+                    upload_file_metadata(rd)
 
                     if args.delete_live:
                         delete_live_data(rd, loc)
@@ -1312,21 +1341,15 @@ def cleanup_db():
 
     log.info("Checking for bad stuff in database")
 
-    # TODO
-    #  the lines below are obsolete given the changed strategy of how to use the bs_coll
-    # Bootstrax instances that say they are active, but haven't reported in for a while
-    # (these are on other hosts, or we would have killed them already)
-    # while True:
-    #     send_heartbeat()
-    #     bd = bs_coll.find_one_and_update(
-    #         {'host': hostname,
-    #          'status': {'$ne': dead_state},
-    #          'time': {'$lt': now(-timeouts['bootstrax_presumed_dead'])}
-    #          },
-    #         {'$set': {'state': dead_state}})
-    #     if bd is None:
-    #         break
-    #     log.info(f"Cleaned old boostrax entry on host {bd['host']}. Now presumed dead. Rest in peace")
+    # Check for all the ebs if their last state message is not longer ago than the time we assume that the eb is dead.
+    for eb_i in range(6):
+        bd = bs_coll.find_one(
+                {'host': f'eb{eb_i}.xenon.local'},
+                sort=[('time', pymongo.DESCENDING)])
+        if (bd['time'] < now(-timeouts['bootstrax_presumed_dead']) and
+                bd['state'] is not dead_state):
+            bs_coll.find_one_and_update({'_id': bd['_id']},
+                                        {'$set': {'state': dead_state}})
 
     # Runs that say they are 'considering' or 'busy' but nothing happened for a while
     for state, timeout in [

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1088,9 +1088,15 @@ def process_run(rd, send_heartbeats=args.production):
             if dd['type'] == 'live':
                 break
             else:
-                fail("Non-live data already registered; untracked failure?")
+                if args.production:
+                    fail("Non-live data already registered; untracked failure?")
+                else:
+                    dd = {'type': 'live', 'location': '/live_data/xenonnt/', 'host': 'daq'}
         else:
-            fail(f"No live data entry in rundoc")
+            if args.production:
+                fail(f"No live data entry in rundoc")
+            else:
+                dd = {'type': 'live', 'location': '/live_data/xenonnt/', 'host': 'daq'}
 
         if not osp.exists(dd['location']):
             fail(f"No access to live data folder {dd['location']}")

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -46,7 +46,7 @@ Additionally, bootstrax tracks information with each run in the 'bootstrax' fiel
 Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is running to a collection in the DAQ database into the capped collection 'eb_monitor'. This collection contains information on what bootstrax is thinking of at the moment
   - **disk_used**: used part of the disk whereto this bootstrax instance is writing to (in percent)
 """
-__version__ = '0.5.5'
+__version__ = '0.5.6'
 
 import argparse
 from datetime import datetime, timedelta, timezone
@@ -168,7 +168,7 @@ timeouts = {
 # hence, we can check if there is sufficient diskspace and if not, wait a while.
 # Below are the max number of times and number of seconds bootstrax will wait.
 wait_diskspace_max_space_percent = 90
-wait_diskspace_n_max = 60 * 24 * 7 # times
+wait_diskspace_n_max = 60 * 24 * 7  # times
 wait_diskspace_dt = 60  # seconds
 assert timeouts['bootstrax_presumed_dead'] > wait_diskspace_dt, "wait_diskspace_dt too large"
 
@@ -537,16 +537,19 @@ def eb_can_process():
     n_ebs_busy = 0
     for eb_i in range(3, 6):
         # Should count if eb3-5 are registered as running (as one might be offline).
-        bootstrax_on_host = bs_coll.find_one({'host': f'eb{eb_i}.xenon.local'},
-                                             sort=[('time', pymongo.DESCENDING)])
-        if (bootstrax_on_host and
-                bootstrax_on_host.get('time').replace(tzinfo=pytz.utc) > now(-timeouts['bootstrax_presumed_dead'])):
+        bootstrax_on_host = bs_coll.find_one({
+            'host': f'eb{eb_i}.xenon.local',
+            'time': {'$gt': now(-timeouts['bootstrax_presumed_dead'])}},
+            sort=[('time', pymongo.DESCENDING)])
+
+        if bootstrax_on_host:
             n_ebs_running += 1
-            running_eb = run_coll.find_one({'bootstrax.state': 'busy',
-                                            'bootstrax.host': f'eb{eb_i}.xenon.local'})
-            if (running_eb and
-                running_eb.get('bootstrax', {}).get('started_processing', now()).replace(tzinfo=pytz.utc) <
-                    now(-timeouts['eb3-5_max_busy_time'])):
+            running_eb = run_coll.find_one({
+                    'bootstrax.state': 'busy',
+                    'bootstrax.host': f'eb{eb_i}.xenon.local',
+                    'bootstrax.started_processing': {
+                        '$gt': now(-timeouts['eb3-5_max_busy_time'])}})
+            if running_eb:
                 n_ebs_busy += 1
                 log.info(f'eb_can_process::\t eb{eb_i} is busy')
     if ((n_ebs_running == n_ebs_busy and n_untouched_runs > max_queue_new_runs) or

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -871,11 +871,11 @@ def upload_file_metadata(rd):
                      'data.location': ddoc['location']},
                     {'$set':
                          {'data.$.file_count': file_count,
-                          'data.$.strax_version': strax.__version__,
-                          'data.$.straxen_version': straxen.__version__,
-                          'data.$.size_mb': data_size_mb,
-                          'data.$.avg_chunk_mb': avg_data_size_mb,
-                          'data.$.lineage_hash': lineage_hash}
+                          'data.$.meta.strax_version': strax.__version__,
+                          'data.$.meta.straxen_version': straxen.__version__,
+                          'data.$.meta.size_mb': data_size_mb,
+                          'data.$.meta.avg_chunk_mb': avg_data_size_mb,
+                          'data.$.meta.lineage_hash': lineage_hash}
                      })
 
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -168,7 +168,7 @@ timeouts = {
 # hence, we can check if there is sufficient diskspace and if not, wait a while.
 # Below are the max number of times and number of seconds bootstrax will wait.
 wait_diskspace_max_space_percent = 90
-wait_diskspace_n_max = 100  # times
+wait_diskspace_n_max = 60 * 24 * 7 # times
 wait_diskspace_dt = 60  # seconds
 assert timeouts['bootstrax_presumed_dead'] > wait_diskspace_dt, "wait_diskspace_dt too large"
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1122,13 +1122,13 @@ def process_run(rd, send_heartbeats=args.production):
         if not osp.exists(dd['location']):
             fail(f"No access to live data folder {dd['location']}")
 
+        if 'daq_config' not in rd:
+            fail('No daq_config in the rundoc!')
         try:
             # Fetch parameters from the rundoc. If not readably, let's use redax' default
             # values (that are hardcoded here).
-            if 'daq_conig' not in rd:
-                log_warning('No daq_config in the rundoc!')
-            dq_conf = rd.get('daq_config', dict())
-            to_read = ('processing_threads', 'strax_chunk_length','strax_chunk_overlap',
+            dq_conf = rd['daq_config']
+            to_read = ('processing_threads', 'strax_chunk_length', 'strax_chunk_overlap',
                        'strax_fragment_payload_bytes')
             for conf in to_read:
                 if conf not in dq_conf:
@@ -1222,7 +1222,7 @@ def process_run(rd, send_heartbeats=args.production):
                     # Sometimes we have only he channels or mv channels, try loading one
                     # until we get one with chunks.
                     for rr_type in ('raw_records', 'raw_records_he', 'raw_records_mv',
-                                    # 'raw_records_nv' # not in the DAQ-reader yet.
+                            # 'raw_records_nv' # not in the DAQ-reader yet.
                                     ):
                         md = st.get_meta(run_id, rr_type)
                         if len(md['chunks']):

--- a/bin/microstrax
+++ b/bin/microstrax
@@ -1,10 +1,15 @@
 #!/usr/bin/env python
 import argparse
-
+import pymongo
 import hug
 import strax
 import straxen
 import os
+import socket
+from datetime import datetime, timedelta
+import pytz
+import time
+import threading
 
 st: strax.Context
 max_load_mb = 1000
@@ -119,6 +124,49 @@ def get_data(
     return [dict(zip(row.dtype.names, row)) for row in x]
 
 
+def now(plus=0):
+    return datetime.now(pytz.utc) + timedelta(seconds=plus)
+
+
+def _set_state():
+    """
+    Inform the bootstrax collection we're running microstrax
+    """
+    # DAQ database
+    daq_db_name = 'daq'
+    daq_db_password = straxen.get_secret('MONGO_DAQ_PASSWORD'.lower())
+    daq_db_username = straxen.get_secret('MONGO_DAQ_USERNAME'.lower())
+    daq_client = pymongo.MongoClient(f"mongodb://{daq_db_username}:{daq_db_password}@xenon1t-daq:27017/admin")
+    daq_db = daq_client[daq_db_name]
+    bs_coll = daq_db['eb_monitor']
+    while True:
+        microstrax_state = dict(
+            host=socket.getfqdn(),
+            pid=os.getpid(),
+            time=now(),
+            state='running',
+            max_load_mb=args.max_load_mb,
+            max_return_mb=args.max_return_mb,
+            context=args.context,
+            n_dirs=len(args.extra_dirs)
+        )
+        try:
+            daq_db.command('ping')
+        except Exception as timeout_error:
+            print(f"Ran into {timeout_error}. Can be bad. Let's take a nap")
+        bs_coll.insert_one(microstrax_state)
+        time.sleep(60)
+
+
+def set_state():
+    """
+    Open thread to set the state of microstrax
+    """
+    update_thread = threading.Thread(name='Update_db', target=_set_state)
+    update_thread.setDaemon(True)
+    update_thread.start()
+
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
@@ -137,4 +185,5 @@ if __name__ == "__main__":
     max_return_mb = args.max_return_mb
 
     load_context(args.context, extra_dirs=args.extra_dirs)
+    set_state()
     hug.API(__name__).http.serve(port=args.port)

--- a/bin/microstrax
+++ b/bin/microstrax
@@ -186,4 +186,10 @@ if __name__ == "__main__":
 
     load_context(args.context, extra_dirs=args.extra_dirs)
     set_state()
-    hug.API(__name__).http.serve(port=args.port)
+
+    while True:
+        try:
+            hug.API(__name__).http.serve(port=args.port)
+        except pymongo.errors.NotMasterError:
+            print('Ran into the infamous pymongo.errors.NotMasterError. Sleep for a sec')
+            time.sleep(60)

--- a/bin/microstrax
+++ b/bin/microstrax
@@ -144,7 +144,7 @@ def _set_state():
             host=socket.getfqdn(),
             pid=os.getpid(),
             time=now(),
-            state='running',
+            state='hosting microstrax',
             max_load_mb=args.max_load_mb,
             max_return_mb=args.max_return_mb,
             context=args.context,


### PR DESCRIPTION
**Preamble**
This is a aggregation of the scripts running on the eventbuilders to process data and maintain the hosts/rundatabse. Below the changes to each script are highlighted.

Also for all of the scripts, we have changed the disks on eb0 and eb1 to also read `/data`. Also, the scripts are changed such that eb2 is not contributing at all to live processing.

**Ajax**
- Delete old lineage-data from the host. Remove any high-level data if the lineage hash for that datatype is not in correspondence with the latest lineage hash.
- Clean the runsdatabase. We had some entries that were listed in the database but they appeared non-existent. Therefore we add a task to ajax to check that the data listed in the runs-database actually exist.


**Bootstrax**

- Prepare bootstrax for the linked mode. At the moment we have some muon-veto data that we should be able to open with bootstrax. **Please be aware.** We are now just trying to open the data with the defaults from redax but it's much better if these are properly set. 
- Reinstate a check for 'dead' bootstrax instances, mark as dead if bootstrax hasn't checked in for a while.
- Update the data-document in the rundoc with metadata concerning the strax(en) version and the data-size. See for example:
![afbeelding](https://user-images.githubusercontent.com/22295914/89791644-ddd0ac00-db23-11ea-853b-7c06d19f2d45.png).


**Microstrax**
- Have eb2 now write a document every minute that it is hosting microstrax.