### PR TITLE
Remap old runs.

### DIFF
--- a/straxen/common.py
+++ b/straxen/common.py
@@ -14,6 +14,7 @@ import urllib.request
 import tqdm
 import numpy as np
 import pandas as pd
+from re import match
 
 import strax
 export, __all__ = strax.exporter()
@@ -401,16 +402,24 @@ def remap_channels(data, verbose=True, safe_copy=False, _tqdm=False, ):
     return _dat
 
 
-def remap_old(data):
+def remap_old(data, targets, works_on_target=''):
     """
     If the data is of before the time sectors were re-cabled, apply a software remap
         otherwise just return the data is it is.
-    :param data: numpy array of data with at least the field time. It is assumed
-        the data is sorted by time
+    :param data: numpy array of data with at least the field time. It is assumed the data
+        is sorted by time
+    :param targets: targets in the st.get_array to get
+    :param works_on_target: regex match string to match any of the targets. By default set
+        to '' such that any target in the targets would be remapped (which is what we want
+        as channels are present in most data types). If one only wants records (no
+        raw-records) and peaks* use e.g. works_on_target = 'records|peaks'.
     """
 
     if np.any(data['time'][:2] >= t_start_first_correctly_cabled_run):
         # We leave the 'new' data be
+        pass
+    elif not np.any([match(works_on_target, t) for t in strax.to_str_tuple(targets)]):
+        # None of the targets are such that we want to remap
         pass
     else:
         # select the old data and do the remapping for this

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -28,7 +28,10 @@ aux_repo = 'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/'
 tpc_r = 66.4   # Not really radius, but apothem: from MC paper draft 1.0
 n_tpc_pmts = 494
 n_top_pmts = 253
+
+# See https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:sector_swap
 last_miscabled_run = 8796
+t_start_first_correctly_cabled_run = 1596036001000000000
 
 @export
 def pmt_positions(xenon1t=False):
@@ -377,7 +380,7 @@ def remap_channels(data, verbose=True, safe_copy=False, _tqdm=False, ):
     # Take the last two samples as otherwise the pd.DataFrame gives an unexpected output.
     # I would have preferred st.estimate_run_start(f'00{last_miscabled_run}')) but st is
     # not per se initialized.
-    if np.any(data['time'][-2:] > 1596036001000000000):
+    if np.any(data['time'][-2:] > t_start_first_correctly_cabled_run):
         raise ValueError(f'Do not remap the data after run 00{last_miscabled_run}')
 
     if safe_copy:
@@ -405,13 +408,13 @@ def remap_old(data):
     :param data: numpy array of data with at least the field time. It is assumed
         the data is sorted by time
     """
-    start_first_correcly_cabled_run = 1596036001000000000
-    if np.any(data['time'][:2] >= start_first_correcly_cabled_run):
+
+    if np.any(data['time'][:2] >= t_start_first_correctly_cabled_run):
         # We leave the 'new' data be
         pass
     else:
         # select the old data and do the remapping for this
-        mask = data['time'] < start_first_correcly_cabled_run
+        mask = data['time'] < t_start_first_correctly_cabled_run
         data[mask] = remap_channels(data[mask])
     return data
 

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 from re import match
 import numba
+from warnings import warn
 
 import strax
 export, __all__ = strax.exporter()
@@ -412,6 +413,8 @@ def remap_old(data, targets, works_on_target=''):
         pass
     else:
         # select the old data and do the remapping for this
+        warn('Correcting data of runs with mis-cabled PMTs. \nSee: https://'
+             'xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:sector_swap')
         mask = data['time'] < TSTART_FIRST_CORRECTLY_CABLED_RUN
         data[mask] = remap_channels(data[mask])
     return data

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -1,7 +1,6 @@
 from immutabledict import immutabledict
 import strax
 import straxen
-from warnings import warn
 
 common_opts = dict(
     register_all=[

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -37,8 +37,8 @@ xnt_common_config = dict(
 ##
 
 def xenonnt_online(output_folder='./strax_data',
-                         we_are_the_daq=False,
-                         **kwargs):
+                   we_are_the_daq=False,
+                   **kwargs):
     """XENONnT online processing and analysis"""
     context_options = {
         **straxen.contexts.common_opts,

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -1,6 +1,7 @@
 from immutabledict import immutabledict
 import strax
 import straxen
+from warnings import warn
 
 common_opts = dict(
     register_all=[
@@ -35,9 +36,9 @@ xnt_common_config = dict(
 # XENONnT
 ##
 
-def xenonnt_online(output_folder='./strax_data',
-                   we_are_the_daq=False,
-                   **kwargs):
+def xenonnt_online_test2(output_folder='./strax_data',
+                         we_are_the_daq=False,
+                         **kwargs):
     """XENONnT online processing and analysis"""
     context_options = {
         **straxen.contexts.common_opts,
@@ -69,7 +70,41 @@ def xenonnt_online(output_folder='./strax_data',
 
         st.context_config['forbid_creation_of'] = ('raw_records', 'records')
 
-    return st
+    # This patch warns users to load old data. In this data the channels were swapped
+    # (hardware-wise)
+    st2 = st.new_context(
+        replace=True,
+        register=list(st._plugin_class_registry.values()),
+        config=st.config,
+        storage=st.storage,
+        **st.context_config)
+
+    def _get_df(run_id: str, targets, **kwargs):
+        __doc__ = st.get_df.__doc__
+        return straxen.remap_wrapper(run_id, st.get_df(run_id, targets, **kwargs))
+
+    def _get_array(run_id: str, targets, **kwargs):
+        __doc__ = st.get_array.__doc__
+        return straxen.remap_wrapper(run_id, st.get_array(run_id, targets, **kwargs))
+
+    def _accumulate(run_id: str, targets, **kwargs):
+        __doc__ = st.accumulate.__doc__
+        return straxen.remap_wrapper(run_id, st.accumulate(run_id, targets, **kwargs))
+
+    def _get_iter(run_id: str, targets, **kwargs):
+        __doc__ = st.get_iter.__doc__
+        if int(run_id) <= straxen.common.last_miscabled_run:
+            warn('This data has swapped channels. Do \n'
+                 'data = straxen.common.remap_channels(<data>)\nSee: '
+                 'https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:sector_swap')
+        return st.get_iter(run_id, targets, **kwargs)
+
+    st2.get_array = _get_array
+    st2.get_df = _get_df
+    st2.accumulate = _accumulate
+    st2.get_iter = _get_iter
+
+    return st2
 
 
 def xenonnt_led(**kwargs):


### PR DESCRIPTION
**Required strax-implementation**
This PR only works if https://github.com/AxFoundation/strax/pull/304 is merged.

**What is the problem / what does the code in this PR do**
As discussed in https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:sector_swap some channels were swapped. In this implementation we fix this by remapping all channels as soon as the data is loaded. This is done only for 'old' data.

**Can you briefly describe how it works?**
[like in https://github.com/AxFoundation/strax/pull/304] when one loads data you do either st.get_array or st.get_df (which then calls st.get_array for you). In the lines changed in this PR, you see that the results that is usually returned directly can now be changed by a function. 

In this PR we use this feature to:
1. Check if the data is older than the timestamp where we changed the cabling
2. If so, remap all data that is associated to channel-numbers. 

**Can you give a minimal working example (or illustrate with a figure)?**
A (very elaborate) example can be found here https://github.com/XENONnT/analysiscode/blob/master/DAQ/remap_sectors/Software_remap.ipynb (please note option 3 is what we are doing here).

**Cons**
 - The extra step naturally takes time and memory. At the moment I consider this an acceptable loss considering the low likelihood that a lot of analyses will be done on this data. The other option would be to reprocess all the data we have taken so far but this sounds like a lot larger effort.
 - I haven't included the he-channels. This can easily be done if we also update the reference to the auxiliary files accordingly after we merge https://github.com/XENONnT/straxen/pull/161. 