### PR TITLE
Datastructure documentation (see #185, #187)

### DIFF
--- a/docs/source/build_datastructure_doc.py
+++ b/docs/source/build_datastructure_doc.py
@@ -184,7 +184,7 @@ def build_datastructure_doc():
 
     # Make graph for each suffix ('' referring to TPC)
     for suffix in tree_suffices:
-        out = page_header.format(title = {titles[suffix]})
+        out = page_header.format(title=titles[suffix])
         print(f'------------ {suffix} ------------')
         os.makedirs(this_dir + f'/graphs{suffix}', exist_ok=True)
         for n_deps in list(reversed(sorted(list(plugins_by_deps[suffix].keys())))):


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Add the HE and NV to the documentation. Actually, most is done in #185 and #187, now that its actually possible to see the end product (documentation) I'm requesting a review. I needed to merge these former to PRs first otherwise the effects would be hard to see). This PR currently only solves a style issue. 

I decided to add the HE and NV data-structures to separate pages from the TPC as they are in essence different data-streams (at the moment). 

**What needs to be reviewed?**
I'd ask the reviewers to only look at the final product (https://straxen.readthedocs.io/en/latest/reference/datastructure_he.html, https://straxen.readthedocs.io/en/latest/reference/datastructure_nv.html). The hideous "{" will be fixed with the code change in this PR. Please let me know if there are any missing things or you think the different data-structures need a more elaborate explanation.


**Can you briefly describe how it works?**
We auto generate the documentation from a context (used to be 1T). We will now do it from an nT-like context. First I tried xenonnt_online() but that requires runDB access (#187) and didn't work. I opted to mimic the nT context by making a new one to generate the data-structure from the nT-like context. I could also have changed the contexts.py to no init the rundb if requested. I decided against this because it's a) very easy to change and b) I don't directly see how we would actually have this context I use here would differ from the nT context.

**What did I not include?**
- Muon veto (although the machinery is fully equipped to add it with a single line)
- The LED plugin

**Can you give a minimal working example (or illustrate with a figure)?**
- https://straxen.readthedocs.io/en/latest/reference/datastructure_he.html
- https://straxen.readthedocs.io/en/latest/reference/datastructure_nv.html

