### PR TITLE
Pytest all plugins

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -46,6 +46,7 @@ xnt_common_config = dict(
 
 def xenonnt_online(output_folder='./strax_data',
                    we_are_the_daq=False,
+                   _database_init=True,
                    **kwargs):
     """XENONnT online processing and analysis"""
     context_options = {
@@ -53,17 +54,17 @@ def xenonnt_online(output_folder='./strax_data',
         **kwargs}
 
     st = strax.Context(
-        storage=[
-            straxen.RunDB(
-                readonly=not we_are_the_daq,
-                runid_field='number',
-                new_data_path=output_folder,
-                rucio_path='/dali/lgrandi/rucio/'),
-        ],
         config=straxen.contexts.xnt_common_config,
         **context_options)
     st.register([straxen.DAQReader, straxen.LEDCalibration])
 
+    st.storage = [
+        straxen.RunDB(
+            readonly=not we_are_the_daq,
+            runid_field='number',
+            new_data_path=output_folder,
+            rucio_path='/dali/lgrandi/rucio/'), ] \
+        if _database_init else []
     if not we_are_the_daq:
         st.storage += [
             strax.DataDirectory(

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -58,13 +58,11 @@ def xenonnt_online(output_folder='./strax_data',
         **context_options)
     st.register([straxen.DAQReader, straxen.LEDCalibration])
 
-    st.storage = [
-        straxen.RunDB(
-            readonly=not we_are_the_daq,
-            runid_field='number',
-            new_data_path=output_folder,
-            rucio_path='/dali/lgrandi/rucio/'), ] \
-        if _database_init else []
+    st.storage = [straxen.RunDB(
+        readonly=not we_are_the_daq,
+        runid_field='number',
+        new_data_path=output_folder,
+        rucio_path='/dali/lgrandi/rucio/'), ] if _database_init else []
     if not we_are_the_daq:
         st.storage += [
             strax.DataDirectory(

--- a/straxen/plugins/led_calibration.py
+++ b/straxen/plugins/led_calibration.py
@@ -61,42 +61,39 @@ class LEDCalibration(strax.Plugin):
         rr   = raw_records[mask]
         r    = get_records(rr, baseline_window=self.config['baseline_window'])
         del rr, raw_records
-               
+
         temp = np.zeros(len(r), dtype=self.dtype)
-        
+
         temp['channel'] = r['channel']
         temp['time']    = r['time']
         temp['dt']      = r['dt']
         temp['length']  = r['length']
-        
+
         on, off = get_amplitude(r, self.config['led_window'], self.config['noise_window'])
         temp['amplitude_led']   = on['amplitude']
         temp['amplitude_noise'] = off['amplitude']
-               
+
         area = get_area(r, self.config['led_window'])
         temp['area'] = area['area']
-        
         return temp
-    
+
+
 def get_records(raw_records, baseline_window):
     """
     Determine baseline as the average of the first baseline_samples
     of each pulse. Subtract the pulse float(data) from baseline.
-    """  
-    
-    if len(raw_records):
-        record_length = len(raw_records['data'][0])
-    else:
-        return
-        
-    _dtype = [(('Start time since unix epoch [ns]', 'time'), '<i8'), 
-              (('Length of the interval in samples', 'length'), '<i4'), 
-              (('Width of one sample [ns]', 'dt'), '<i2'), 
-              (('Channel/PMT number', 'channel'), '<i2'), 
-              (('Length of pulse to which the record belongs (without zero-padding)', 'pulse_length'), '<i4'), 
-              (('Fragment number in the pulse', 'record_i'), '<i2'), 
+    """
+
+    record_length = np.shape(raw_records.dtype['data'])[0]
+
+    _dtype = [(('Start time since unix epoch [ns]', 'time'), '<i8'),
+              (('Length of the interval in samples', 'length'), '<i4'),
+              (('Width of one sample [ns]', 'dt'), '<i2'),
+              (('Channel/PMT number', 'channel'), '<i2'),
+              (('Length of pulse to which the record belongs (without zero-padding)', 'pulse_length'), '<i4'),
+              (('Fragment number in the pulse', 'record_i'), '<i2'),
               (('Waveform data in raw ADC counts', 'data'), 'f4', (record_length,))]
-              
+
     records = np.zeros(len(raw_records), dtype=_dtype)
 
     records['time']         = raw_records['time']

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -222,7 +222,6 @@ class PulseProcessingHe(PulseProcessing):
         records_he=False,
         pulse_counts_he=True)
     depends_on = 'raw_records_he'
-    parallel = 'process'
     compressor = 'lz4'
     child_ends_with = '_he'
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -4,13 +4,18 @@ import straxen
 import numpy as np
 from immutabledict import immutabledict
 from strax.testutils import run_id, recs_per_chunk
+
+# Number of chunks for the dummy raw records we are writing here
 N_CHUNKS = 2
 
 
 @strax.takes_config(
     strax.Option('secret_time_offset', default=0, track=False)
 )
-class RawRecords(strax.Plugin):
+class DummyRawRecords(strax.Plugin):
+    """
+    Provide dummy raw records for the mayor raw_record types
+    """
     provides = ('raw_records', 'raw_records_he', 'raw_records_nv',)
     parallel = 'process'
     depends_on = tuple()
@@ -37,41 +42,70 @@ class RawRecords(strax.Plugin):
 
 
 def test_all_plugins():
+    """
+    Try all plugins (except the DAQReader) in both multicore and signle core mode to see
+    if we can really push some (empty) data from it and don't have any nasty problems like
+    that we are referring to some non existant dali folder.
+    """
     # Test both lazy and not lazy multicore/single core
-    for max_workers in [1, 2]:
+    for max_workers in [2, 1]:
         for it, (context_name, st) in enumerate(
                 {"nT": straxen.contexts.xenonnt_online(_database_init=False),
                  "1T": straxen.contexts.xenon1t_dali()}.items()
         ):
             print(f'Testing {context_name} context')
             with tempfile.TemporaryDirectory() as temp_dir:
+
+                # Don't concern ourselves with rr_aqmon et cetera
                 forbidden_plugins = tuple([p for p in
                                            straxen.daqreader.DAQReader.provides
-                                           if p not in RawRecords.provides])
-                st.set_context_config(
-                    {'forbid_creation_of': forbidden_plugins,
-                     'allow_multiprocess': bool(max_workers-1),
+                                           if p not in DummyRawRecords.provides])
+
+                # Change config to allow for testing both multiprocessing and lazy mode
+                st.set_context_config({'forbid_creation_of': forbidden_plugins})
+                if max_workers - 1:
+                     st.set_context_config({
+                         'allow_multiprocess': True,
+                         'allow_lazy': False,
+                         'timeout': 60,  # we don't want to build travis for ever
                      })
-                st.register(RawRecords)
+
+                st.register(DummyRawRecords)
                 st.storage = [strax.DataDirectory(temp_dir)]
+
+                # As we use a temporary directory we should have a clean start
                 assert not st.is_stored(run_id, 'raw_records'), 'have RR???'
 
-                target = {'nT': 'event_info',
-                          '1T': 'peak_basics'}[context_name]
+                # 1Ts NN seems funky, let's ignore it for now?
+                target = {'nT': 'event_info', '1T': 'peak_basics'}[context_name]
+
                 # Create stuff
-                st.make(
-                    run_id=run_id,
-                    targets=target,
-                    max_workers=max_workers)
+                st.make(run_id=run_id,
+                        targets=target,
+                        max_workers=max_workers)
+                # The stuff should be there
                 assert st.is_stored(run_id, target), f'Could not make {target}'
 
+                # I'm only going to do this for nT because:
+                #  A) Doing this many more times does not give us much more
+                #     info (everything above already worked fine)
+                #  B) Most development will be on nT, 1T may get less changes
+                #     in the near future
                 if context_name == 'nT':
                     # First make some _he stuff for multiprocessing
                     st.make(run_id, 'peaks_he', max_workers=max_workers)
+
                     # Now make sure we can get some data for all plugins
                     for p in list(st._plugin_class_registry.keys()):
                         if p not in forbidden_plugins:
-                            st.get_array(
-                               run_id=run_id,
-                               targets=p,
-                               max_workers=max_workers)
+                            st.get_array(run_id=run_id,
+                                         targets=p,
+                                         max_workers=max_workers)
+
+                            # Check for types that we want to save that they are stored.
+                            if (int(st._plugin_class_registry['peaks'].save_when) >
+                                    int(strax.SaveWhen.TARGET)):
+                                is_stored = st.is_stored(run_id, p)
+                                assert is_stored, f"{p} did not save correctly!"
+
+    print("Wonderful all plugins work (= at least they don't fail), bye bye")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,77 @@
+import tempfile
+import strax
+import straxen
+import numpy as np
+from immutabledict import immutabledict
+from strax.testutils import run_id, recs_per_chunk
+N_CHUNKS = 2
+
+
+@strax.takes_config(
+    strax.Option('secret_time_offset', default=0, track=False)
+)
+class RawRecords(strax.Plugin):
+    provides = ('raw_records', 'raw_records_he', 'raw_records_nv',)
+    parallel = 'process'
+    depends_on = tuple()
+    data_kind = immutabledict(zip(provides, provides))
+    rechunk_on_save = False
+    dtype = {p: strax.raw_record_dtype() for p in provides}
+
+    def source_finished(self):
+        return True
+
+    def is_ready(self, chunk_i):
+        return chunk_i < N_CHUNKS
+
+    def compute(self, chunk_i):
+        r = np.zeros(recs_per_chunk, self.dtype['raw_records'])
+        t0 = chunk_i + self.config['secret_time_offset']
+        r['time'] = t0
+        r['length'] = r['dt'] = 1
+        r['channel'] = np.arange(len(r))
+
+        res = {p: self.chunk(start=t0, end=t0 + 1, data=r, data_type=p)
+               for p in self.provides}
+        return res
+
+
+def test_all_plugins():
+    # Test both lazy and not lazy multicore/single core
+    for max_workers in [1, 2]:
+        for it, (context_name, st) in enumerate(
+                {"nT": straxen.contexts.xenonnt_online(_database_init=False),
+                 "1T": straxen.contexts.xenon1t_dali()}.items()
+        ):
+            print(f'Testing {context_name} context')
+            with tempfile.TemporaryDirectory() as temp_dir:
+                forbidden_plugins = tuple([p for p in
+                                           straxen.daqreader.DAQReader.provides
+                                           if p not in RawRecords.provides])
+                st.set_context_config(
+                    {'forbid_creation_of': forbidden_plugins,
+                     'allow_multiprocess': bool(max_workers-1),
+                     })
+                st.register(RawRecords)
+                st.storage = [strax.DataDirectory(temp_dir)]
+                assert not st.is_stored(run_id, 'raw_records'), 'have RR???'
+
+                target = {'nT': 'event_info',
+                          '1T': 'peak_basics'}[context_name]
+                # Create stuff
+                st.make(
+                    run_id=run_id,
+                    targets=target,
+                    max_workers=max_workers)
+                assert st.is_stored(run_id, target), f'Could not make {target}'
+
+                if context_name == 'nT':
+                    # First make some _he stuff for multiprocessing
+                    st.make(run_id, 'peaks_he', max_workers=max_workers)
+                    # Now make sure we can get some data for all plugins
+                    for p in list(st._plugin_class_registry.keys()):
+                        if p not in forbidden_plugins:
+                            st.get_array(
+                               run_id=run_id,
+                               targets=p,
+                               max_workers=max_workers)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -141,4 +141,3 @@ def test_nT_mutlticore():
 def test_1T_mutlticore():
     print('1T multicore')
     test_1T(2)
-gi


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
We don't test new plugins using travis (at least, until this PR). We do test some test data pulling for a 1T context (the demo in test_basics.py) but that will not catch all registered plugins.

**Can you briefly describe how it works?**
For each plugin, it tries to get some data and check if it's stored (as long as the plugin is actually saving it's results).

One important thing I had to do is disable the init of the rundb as that wouldn't work while building Travis. I think this is an okay work around but if someone knows a better work around I'd be most interested because if people don't know what they are doing and disable the rundb in their context that might lead to unwanted behavior (although the same is true for the ``we_are_the_daq`` option). 

**Can you give a minimal working example (or illustrate with a figure)?**
```bash
(strax) joran@DESKTOP-URE1BBI:~/software/straxen$ pytest tests/test_plugins.py
```
