### PR TITLE
Fix documentation styling

### DIFF
--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -66,14 +66,14 @@ class DAQReader(strax.Plugin):
     Does nothing whatsoever to the live_data; not even baselining.
 
     Provides:
-        raw_records: (tpc)raw_records.
-        raw_records_he: raw_records for the high energy boards
-            digitizing the top PMT-array at lower amplification.
-        raw_records_nv: neutron veto raw_records; only stored temporary
-            as the software coincidence trigger not applied yet.
-        raw_records_mv: muon veto raw_records.
-        raw_records_aqmon: raw_records for the acquisition monitor (_nv
-            for neutron veto).
+        - raw_records: (tpc)raw_records.
+        - raw_records_he: raw_records for the high energy boards
+        digitizing the top PMT-array at lower amplification.
+        - raw_records_nv: neutron veto raw_records; only stored temporary
+        as the software coincidence trigger not applied yet.
+        - raw_records_mv: muon veto raw_records.
+        - raw_records_aqmon: raw_records for the acquisition monitor (_nv
+        for neutron veto).
     """
     provides = (
         'raw_records',

--- a/straxen/plugins/double_scatter.py
+++ b/straxen/plugins/double_scatter.py
@@ -39,7 +39,7 @@ class DistinctChannels(strax.LoopPlugin):
 @export
 class EventInfoDouble(strax.MergeOnlyPlugin):
     """Alternate version of event_info for Kr and other double scatter
-    analyses:
+        analyses:
       - Uses a different naming convention:
         s1 -> s1_a, alt_s1 -> s1_b, and similarly for s2s;
       - Adds s1_b_distinct_channels, which can be tricky to compute

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -30,9 +30,9 @@ class Events(strax.OverlapWindowPlugin):
     which satisfies certain conditions:
         1. The triggering peak must have a certain area.
         2. The triggering peak must have less than
-            "trigger_max_competing" peaks. (A competing peak must have a
-            certain area fraction of the triggering peak and must be in a
-            window close to the main peak)
+        "trigger_max_competing" peaks. (A competing peak must have a
+        certain area fraction of the triggering peak and must be in a
+        window close to the main peak)
 
     Note:
         The time range which defines an event gets chopped at the chunk

--- a/straxen/plugins/led_calibration.py
+++ b/straxen/plugins/led_calibration.py
@@ -33,12 +33,13 @@ class LEDCalibration(strax.Plugin):
     LEDCalibration returns: channel, time, dt, lenght, Area,
     amplitudeLED and amplitudeNOISE.
     The new variables are:
-    - Area: Area computed in the given window, averaged over 6 windows
-        that have the same starting sample and different end samples.
-    - amplitudeLED: peak amplitude of the LED on run in the given
+        - Area: Area computed in the given window, averaged over 6
+        windowsthat have the same starting sample and different end
+        samples.
+        - amplitudeLED: peak amplitude of the LED on run in the given
         window.
-    - amplitudeNOISE: amplitude of the LED on run in a window far from
-        the signal one.
+        - amplitudeNOISE: amplitude of the LED on run in a window far
+         from the signal one.
     """
     
     __version__ = '0.2.3'

--- a/straxen/plugins/nveto_hitlets.py
+++ b/straxen/plugins/nveto_hitlets.py
@@ -50,9 +50,9 @@ class nVETOHitlets(strax.Plugin):
     and right extension. The plugin does the following:
         1. Generate hitlets which includes these sub-steps:
             * Apply left and right hit extension and concatenate
-                overlapping hits.
+            overlapping hits.
             * Generate temp. hitelts and look for their waveforms in
-                their corresponding records.
+            their corresponding records.
             * Split hitlets if they satisfy the set criteria.
         2. Compute the properties of the hitlets.
 

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -53,26 +53,26 @@ export, __all__ = strax.exporter()
     *HITFINDER_OPTIONS,
 )
 class Peaklets(strax.Plugin):
-    depends_on = ('records',)
     """
     Split records into:
         -peaklets
         -lone_hits
 
-    Peaklets are very aggressively split peaks such that we are able 
-        to find S1-S2s even if they are close to each other. (S2) Peaks
-        that are split into too many peaklets will be merged later on.
-    
+    Peaklets are very aggressively split peaks such that we are able
+    to find S1-S2s even if they are close to each other. (S2) Peaks
+    that are split into too many peaklets will be merged later on.
+
     To get Peaklets from records apply/do:
         1. Hit finding
         2. Peak finding
         3. Peak splitting using the natural breaks algorithm
         4. Compute the digital sum waveform
 
-    Lone hits are all hits which are outside of any peak. The area of 
-        lone_hits includes the left and right hit extension, except the
-        extension overlaps with any peaks or other hits.
+    Lone hits are all hits which are outside of any peak. The area of
+    lone_hits includes the left and right hit extension, except the
+    extension overlaps with any peaks or other hits.
     """
+    depends_on = ('records',)
     provides = ('peaklets', 'lone_hits')
     data_kind = dict(peaklets='peaklets',
                      lone_hits='lone_hits')
@@ -436,8 +436,8 @@ class MergedS2sHe(MergedS2s):
 class Peaks(strax.Plugin):
     """
     Merge peaklets and merged S2s such that we obtain our peaks
-        (replacing all peaklets that were later re-merged as S2s). As
-        this step is computationally trivial, never save this plugin.
+    (replacing all peaklets that were later re-merged as S2s). As this
+    step is computationally trivial, never save this plugin.
     """
     depends_on = ('peaklets', 'peaklet_classification', 'merged_s2s')
     data_kind = 'peaks'

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -95,15 +95,15 @@ class PulseProcessing(strax.Plugin):
      - pulse_counts
 
     For TPC records, apply basic processing:
-    1. Flip, baseline, and integrate the waveform
-    2. Apply software HE veto after high-energy peaks.
-    3. Find hits, apply linear filter, and zero outside hits.
+        1. Flip, baseline, and integrate the waveform
+        2. Apply software HE veto after high-energy peaks.
+        3. Find hits, apply linear filter, and zero outside hits.
     
     pulse_counts holds some average information for the individual PMT
-        channels for each chunk of raw_records. This includes e.g.
-        number of recorded pulses, lone_pulses (pulses which do not
-        overlap with any other pulse), or mean values of baseline and
-        baseline rms channel.
+    channels for each chunk of raw_records. This includes e.g.
+    number of recorded pulses, lone_pulses (pulses which do not
+    overlap with any other pulse), or mean values of baseline and
+    baseline rms channel.
     """
     __version__ = '0.2.2'
 


### PR DESCRIPTION
Fix https://github.com/XENONnT/straxen/pull/192 for https://straxen.readthedocs.io/en/latest/reference/datastructure.html. As one can see some Plugins have funny formats. Let's hopefully fix it like this.