### PR TITLE
Quick patch bootstrax

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1250,7 +1250,10 @@ def process_run(rd, send_heartbeats=args.production):
                             # 'raw_records_nv' # not in the DAQ-reader yet.
                                     ):
                         md = st.get_meta(run_id, rr_type)
-                        if len(md['chunks']):
+                        if len(md['chunks']) and (
+                                'first_time' in md['chunks'][0] and
+                                'last_endtime' in md['chunks'][0]
+                        ):
                             break
                 except Exception:
                     fail("Processing succeeded, but metadata not readable: "
@@ -1268,7 +1271,7 @@ def process_run(rd, send_heartbeats=args.production):
                 # this has to be done with some care...
                 t_covered = timedelta(
                     seconds=(max([x.get('last_endtime', 0) for x in md['chunks']]) -
-                             min([x.get('first_time', float('inf')) for x in md['chunks']])) / 1e9)
+                             min([x.get('first_time', 10e9*1e9) for x in md['chunks']])) / 1e9)
                 run_duration = rd['end'] - rd['start']
                 if not (0 < t_covered.seconds < float('inf')):
                     fail(f"Processed data covers {t_covered} sec")

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -96,7 +96,7 @@ class PeakBasics(strax.Plugin):
 
 
 @export
-class PeakBasicsHe(PeakBasics):
+class PeakBasicsHighEnergy(PeakBasics):
     __doc__ = PeakBasics.__doc__
     __version__ = '0.0.1'
     depends_on = 'peaks_he'

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -220,7 +220,7 @@ class Peaklets(strax.Plugin):
                  help="Minimum number of contributing PMTs needed to define a peak"),
     *HITFINDER_OPTIONS_he
 )
-class PeakletsHe(Peaklets):
+class PeakletsHighEnergy(Peaklets):
     __doc__ = Peaklets.__doc__
     depends_on = 'records_he'
     provides = 'peaklets_he'
@@ -297,7 +297,7 @@ class PeakletClassification(strax.Plugin):
 
 
 @export
-class PeakletClassificationHe(PeakletClassification):
+class PeakletClassificationHighEnergy(PeakletClassification):
     __doc__ = PeakletClassification.__doc__
     provides = 'peaklet_classification_he'
     depends_on = ('peaklets_he',)
@@ -414,7 +414,7 @@ class MergedS2s(strax.OverlapWindowPlugin):
 
     
 @export
-class MergedS2sHe(MergedS2s):
+class MergedS2sHighEnergy(MergedS2s):
     __doc__ = MergedS2s.__doc__
     depends_on = ('peaklets_he', 'peaklet_classification_he')
     data_kind = 'merged_s2s_he'
@@ -464,7 +464,7 @@ class Peaks(strax.Plugin):
 
 
 @export
-class PeaksHe(Peaks):
+class PeaksHighEnergy(Peaks):
     __doc__ = Peaks.__doc__
     depends_on = ('peaklets_he', 'peaklet_classification_he', 'merged_s2s_he')
     data_kind = 'peaks_he'

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -221,7 +221,7 @@ class PulseProcessing(strax.Plugin):
     strax.Option('record_length', default=110, track=False, type=int,
                  help="Number of samples per raw_record"),
     *HITFINDER_OPTIONS_he)
-class PulseProcessingHe(PulseProcessing):
+class PulseProcessingHighEnergy(PulseProcessing):
     __doc__ = PulseProcessing.__doc__
     __version__ = '0.0.1'
     provides = ('records_he', 'pulse_counts_he')


### PR DESCRIPTION
Solve these kind of issues:
```python
Traceback (most recent call last):
  File "/home/xedaq/miniconda/envs/py37/bin/bootstrax", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/xedaq/software/straxen/bin/bootstrax", line 1464, in <module>
    main()
  File "/home/xedaq/software/straxen/bin/bootstrax", line 326, in main
    main_loop()
  File "/home/xedaq/software/straxen/bin/bootstrax", line 388, in main_loop
    process_run(rd)
  File "/home/xedaq/software/straxen/bin/bootstrax", line 1271, in process_run
    min([x.get('first_time', float('inf')) for x in md['chunks']])) / 1e9)
OverflowError: cannot convert float infinity to integer
```