### PR TITLE
Eb data management

### DIFF
--- a/bin/ajax
+++ b/bin/ajax
@@ -15,7 +15,7 @@ that may delete the live_data such that we prevent multiple attempts to perform 
 action.
 """
 
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 
 import argparse
 from datetime import datetime, timedelta
@@ -258,6 +258,7 @@ def check_sn_trigger():
     Get the information of a supernova trigger from some place. If occurred we should
     crash immediately to prevent data loss
     """
+    raise NotImplementedError("Don't have SN checks yet")
     # Check some database for supernova triggers
     super_nova = False
     # super_nova = True if run_db['sn_trigger'].find_one({'time':{'$exists':True}}) else False
@@ -268,6 +269,8 @@ def check_sn_trigger():
 
 def clean_raw_records_nv():
     """Based on the runsDB, remove the raw_records_nv if they are old"""
+    raise NotImplementedError("NV integration not yet part of AJAX")
+
     check_sn_trigger()
     rd = run_coll.find_one({'bootstrax.state': 'done',
                             'status': 'transferred',
@@ -290,7 +293,7 @@ def clean_raw_records_nv():
 def clean_unregistered(delete_live=False):
     """
     Clean data that is not in the database. To do this check the output folder and remove
-    files if there is no corresponding entry in the rundoc
+    files if there is no corresponding entry in the rundoc.
     :param delete_live: bool, if true delete unregistered live data.
     """
     folder_to_check = output_folder if delete_live is False else ceph_folder
@@ -333,6 +336,9 @@ def clean_old_hash():
                                     'data.type': data_type,
                                     'data.host': hostname,
                                     'number': int(run_id)})
+            if 'raw_records' in data_type:
+                raise ValueError(f'You did some sloppy regex on the data-type, almost '
+                                 f'deleted {data_type}!')
             if rd:
                 delete_data(rd, loc, data_type, test=not args.execute)
             else:
@@ -390,194 +396,6 @@ def clean_abandoned(delete_live=False):
         return clean_abandoned(delete_live=delete_live)
 
 
-##
-# Core functions
-##
-
-
-def _rmtree(path):
-    """
-    Wrapper for shutil.rmtree. All deletion statements in this script go through this
-    function in order to make sure that the args.execute statement is always double
-    (tripple) checked before deleting data.
-    :param path: path to delete
-    :return:
-    """
-    if args.execute:
-        if confirm(f'delete {path}?'):
-            shutil.rmtree(path)
-    else:
-        log.info(f'TESTING:\tshutil.rmtree({path})')
-        if not os.path.exists(path):
-            raise ValueError(f'{path} does not exist')
-
-
-def threaded_delete_data(rd, path, data_type, test=True):
-    """Wrapper for delete_data to run in separate threads."""
-    thread_name = thread_prefix + path.split('/')[-1]
-    delete_thread = threading.Thread(name=thread_name,
-                                     target=delete_data,
-                                     args=(rd, path, data_type, test))
-    log.info(f'Starting thread to delete {path} at {now()}')
-    # We rather not stop deleting the live_data if something else fails. Set the thread
-    # to daemon.
-    delete_thread.setDaemon(True)
-    delete_thread.start()
-    log.info(f'DeleteThread {path} should be running in parallel, continue MainThread '
-             f'now: {now()}')
-
-
-def delete_data(rd, path, data_type, test=True):
-    """Delete data and update the rundoc"""
-    # if data_type == 'live' and not args.delete_live:
-    #     raise ValueError('Unsafe operation. Trying to delete live data!')
-    if os.path.exists(path):
-        log.info(f'Deleting data at {path}')
-        if not test:
-            _rmtree(path)
-        log.info(f'deleting {path} finished')
-    else:
-        log.info(f'There is no data on {path}! Just doing the rundoc.')
-    # Remove the data location from the rundoc and append it to the 'deleted_data' entries
-    if not os.path.exists(path):
-        log.info('changing data field in rundoc')
-        for ddoc in rd['data']:
-            if ddoc['type'] == data_type and ddoc['host'] in ('daq', hostname):
-                break
-        for k in ddoc.copy().keys():
-            if k in ['location', 'meta', 'protocol']:
-                ddoc.pop(k)
-
-        ddoc.update({'at': now(), 'by': hostname + '.ajax'})
-        log.info(f'update with {ddoc}')
-        if args.execute and not test:
-            if confirm('update rundoc?'):
-                run_coll.update_one({'_id': rd['_id']},
-                                    {"$addToSet": {'deleted_data': ddoc},
-                                     "$pull": {"data":
-                                                   {"type": data_type,
-                                                    "host": {'$in': ['daq', hostname]}}}})
-        else:
-            log.info(f'Update ddoc with : {ddoc}')
-    elif not test and not args.ask_confirm:
-        raise ValueError(f"Something went wrong we wanted to delete {path}!")
-
-
-def remove_run_from_host(number, delete_live=False, force=False):
-    """
-    Save way of removing data from host if data registered elsewhere
-    :param number: run number (not ID!)
-    :param delete_live: bool, if true delete the live_data else the processed data
-    :param force: forcefully remove the data even if we don't have the right copies (e.g.
-    deleting /live_data when the raw_records are not stored. Be careful with this option!
-    Should only be used for the deletion of abandoned runs.
-    """
-    # Query the database to remove data
-    rd = run_coll.find_one({'number': number,
-                            'data.host': hostname if not delete_live else 'daq'})
-    if not rd:
-        log.info(f'No registered data for {number} on {hostname}')
-        return
-
-    have_live_data, have_raw_records = False, False
-    for dd in rd['data']:
-        if dd['type'] == 'live' and dd['location'] != 'deleted':
-            have_live_data = True
-        if dd['type'] == 'raw_records' and dd['location'] != 'deleted':
-            have_raw_records = True
-    for ddoc in rd['data']:
-        # This is processed data on the eventbuilders
-        if 'host' in ddoc and ddoc['host'] == hostname:
-            if delete_live:
-                # If you want to delete the live data you shouldn't consider this ddoc
-                continue
-            loc = ddoc['location']
-            if not force and not have_live_data and 'raw_records' in ddoc['type']:
-                # If we do not have live_data, don't delete raw_records. However, if we
-                # --force deletion, do go to the next else statement
-                log.info(f'prevent {loc} from being deleted. The live_data has already'
-                         f' been removed')
-            else:
-                log.info(f'delete data at {loc}')
-                delete_data(rd, loc, ddoc['type'], test=not args.execute)
-
-                loc = loc + '_temp'
-                if os.path.exists(loc):
-                    log.info(f'delete data at {loc}')
-                    delete_data(rd, loc, ddoc['type'], test=not args.execute)
-        elif 'host' in ddoc and ddoc['host'] == 'daq':
-            # This is the live_data
-            if not delete_live:
-                # If you want to delete processed data you shouldn't consider this ddoc
-                continue
-            run_id = '%06d' % number
-            loc = os.path.join(ddoc['location'], run_id)
-            if not delete_live:
-                log.info(f'prevent {loc} from being deleted. Do so with --delete_live')
-            elif not force and not have_raw_records:
-                # If we do not have raw records, don't delete this data. However, if we
-                # --force deletion, do go to the next else statement
-                log.info(f'Unsafe to delete {loc}, no raw_records registered. Force with '
-                         f'--force')
-            else:
-                if force and not have_raw_records:
-                    log.info(f'Forcefully delete {loc}, but no raw_records registered!')
-                else:
-                    log.info(f'Deleting data at {loc}')
-                threaded_delete_data(rd, loc, ddoc['type'], test=not args.execute)
-
-
-def remove_if_unregistered(number, delete_live=False):
-    """
-    Given a run number delete data on this machine that matches that number
-    :param number: int! the run_number (not run_id)
-    :param delete_live: Bool, if True: Remove the live_data. Else remove processed data
-    """
-    # Query the database to remove data
-    rd = run_coll.find_one({'bootstrax.state': 'done',
-                            'status': 'transferred',
-                            'bootstrax.time':
-                                {"$lt": now(-ajax_thresholds['wait_after_processing'])},
-                            'number': number,
-                            'data.host': hostname if not delete_live else 'daq'})
-    run_id = '%06d' % number
-
-    if not rd:
-        log.info(f'remove_if_unregistered::\trun {number} is NOT registered in the runDB')
-        if not delete_live:
-            # Check the local ebs disk for data.
-            _remove_unregistered_run(output_folder, run_id, checked_db=True)
-        else:
-            # Check ceph for data associated to this run (which is apparently not in the
-            # runDB)
-            _remove_unregistered_run(ceph_folder, run_id, checked_db=True)
-
-
-def _remove_unregistered_run(base_folder, run_id, checked_db=False):
-    """
-    NB: The check that this run is not registered should be performed first!
-    Deletes any folder from base_folder that matches run_id.
-    :param base_folder: folder to check
-    :param run_id: run_id to remove from folder
-    :param checked_db: Bool if it is checked that this run in not in the database.
-    """
-    if not checked_db:
-        raise ValueError("Only insert runs where for it is checked that it is "
-                         "not registered in the runs database ")
-    log.warning(f'No data for {run_id} found! Double checking {base_folder}!')
-    deleted_data = False
-    for folder in os.listdir(base_folder):
-        if run_id in folder:
-            log.info(f'Cleaning {base_folder + folder}')
-            if args.execute:
-                _rmtree(base_folder + folder)
-            else:
-                log.info(f'TEST\tdeleting {base_folder + folder}')
-            deleted_data = True
-    if not deleted_data:
-        raise FileNotFoundError(f'No data registered on {hostname} for {run_id}')
-
-
 def clean_database(delete_live=False):
     """
     Remove entries from the database if the data is not on this host anymore
@@ -610,6 +428,257 @@ def clean_database(delete_live=False):
                              f'at {loc} as it does not exist')
                     delete_data(rd, loc, ddoc['type'], test=not args.execute)
 
+##
+# Core functions
+##
+
+
+def _rmtree(path):
+    """
+    Wrapper for shutil.rmtree. All deletion statements in this script go through this
+    function in order to make sure that the args.execute statement is always double
+    (tripple) checked before deleting data.
+    :param path: path to delete
+    :return:
+    """
+    if args.execute:
+        if confirm(f'delete {path}?'):
+            shutil.rmtree(path)
+    else:
+        log.info(f'TESTING:\tshutil.rmtree({path})')
+        if not os.path.exists(path):
+            raise ValueError(f'{path} does not exist')
+
+
+def threaded_delete_data(rd, path, data_type,
+                         test=True, ignore_low_data_check=False):
+    """
+    Wrapper for delete_data to run in separate threads.
+    :param rd: rundoc
+    :param path: location of the folder to be deleted
+    :param data_type: type of data to be deleted
+    :param test: bool if we are testing or not. If true, nothing will be deleted.
+    :param ignore_low_data_check: ignore the fact that this might be the only copy of the
+    data. We can specify this e.g. if we know this is data associated to some abandoned
+    run.
+    """
+
+    thread_name = thread_prefix + path.split('/')[-1]
+    delete_thread = threading.Thread(name=thread_name,
+                                     target=delete_data,
+                                     args=(rd, path, data_type,
+                                           test, ignore_low_data_check))
+    log.info(f'Starting thread to delete {path} at {now()}')
+    # We rather not stop deleting the live_data if something else fails. Set the thread
+    # to daemon.
+    delete_thread.setDaemon(True)
+    delete_thread.start()
+    log.info(f'DeleteThread {path} should be running in parallel, continue MainThread '
+             f'now: {now()}')
+
+
+def delete_data(rd, path, data_type,
+                test=True, ignore_low_data_check=False
+                ):
+    """
+    Delete data and update the rundoc
+    :param rd: rundoc
+    :param path: location of the folder to be deleted
+    :param data_type: type of data to be deleted
+    :param test: bool if we are testing or not. If true, nothing will be deleted.
+    :param ignore_low_data_check: ignore the fact that this might be the only copy of the
+    data. We can specify this e.g. if we know this is data associated to some abandoned
+    run.
+    """
+    # if data_type == 'live' and not args.delete_live:
+    #     raise ValueError('Unsafe operation. Trying to delete live data!')
+    if not ignore_low_data_check:
+        n_live, n_rr = check_rundoc_for_live_and_raw(rd)
+        if not (
+                n_live or
+                n_rr >= 1 + int('raw_records' in data_type)):
+            raise ValueError(f'Trying to delete {data_type} but we only have {n_live} '
+                             f'live- and {n_rr} raw_record-files in the runs-database. '
+                             f'This might be an essential copy of the data!')
+    if os.path.exists(path):
+        log.info(f'Deleting data at {path}')
+        if not test:
+            _rmtree(path)
+        log.info(f'deleting {path} finished')
+    else:
+        log.info(f'There is no data on {path}! Just doing the rundoc.')
+    # Remove the data location from the rundoc and append it to the 'deleted_data' entries
+    if not os.path.exists(path):
+        log.info('changing data field in rundoc')
+        for ddoc in rd['data']:
+            if ddoc['type'] == data_type and ddoc['host'] in ('daq', hostname):
+                break
+        for k in ddoc.copy().keys():
+            if k in ['location', 'meta', 'protocol']:
+                ddoc.pop(k)
+
+        ddoc.update({'at': now(), 'by': hostname + '.ajax'})
+        log.info(f'update with {ddoc}')
+        if args.execute and not test:
+            if confirm('update rundoc?'):
+                run_coll.update_one({'_id': rd['_id']},
+                                    {"$addToSet": {'deleted_data': ddoc},
+                                     "$pull": {"data":
+                                                   {"type": data_type,
+                                                    "host": {'$in': ['daq', hostname]}}}})
+        else:
+            log.info(f'Update ddoc with : {ddoc}')
+    elif not test and not args.ask_confirm:
+        raise ValueError(f"Something went wrong we wanted to delete {path}!")
+
+
+def check_rundoc_for_live_and_raw(rd):
+    """
+    Count the number of files of live_data (cannot be >1) and raw_data (transfers can get
+    it greater than 1)
+    :param rd: rundoc
+    :return: length 2 tuple with n_live_data and n_raw_records being the number of files
+    in the rundoc for the live data and raw records respectively.
+    """
+    n_live_data, n_raw_records = 0, 0
+    for dd in rd['data']:
+        if dd['type'] == 'live' and dd['location'] != 'deleted':
+            n_live_data += 1
+        if dd['type'] == 'raw_records' and dd['location'] != 'deleted':
+            n_raw_records += 1
+    return n_live_data, n_raw_records
+
+
+def remove_run_from_host(number, delete_live=False, force=False):
+    """
+    Save way of removing data from host if data registered elsewhere
+    :param number: run number (not ID!)
+    :param delete_live: bool, if true delete the live_data else the processed data
+    :param force: forcefully remove the data even if we don't have the right copies (e.g.
+    deleting /live_data when the raw_records are not stored. Be careful with this option!
+    Should only be used for the deletion of abandoned runs.
+    """
+    # Query the database to remove data
+    rd = run_coll.find_one({'number': number,
+                            'data.host': hostname if not delete_live else 'daq'})
+    if not rd:
+        log.info(f'No registered data for {number} on {hostname}')
+        return
+
+    have_live_data, have_raw_records = check_rundoc_for_live_and_raw(rd)
+
+    for ddoc in rd['data']:
+        # This is processed data on the eventbuilders
+        if 'host' in ddoc and ddoc['host'] == hostname:
+            if delete_live:
+                # If you want to delete the live data you shouldn't consider this ddoc
+                continue
+            loc = ddoc['location']
+            if not force and not have_live_data and 'raw_records' in ddoc['type']:
+                # If we do not have live_data, don't delete raw_records. However, if we
+                # --force deletion, do go to the next else statement
+                log.info(f'prevent {loc} from being deleted. The live_data has already'
+                         f' been removed')
+            else:
+                log.info(f'delete data at {loc}')
+                delete_data(rd, loc, ddoc['type'], test=not args.execute, ignore_low_data_check=force)
+
+                loc = loc + '_temp'
+                if os.path.exists(loc):
+                    log.info(f'delete data at {loc}')
+                    delete_data(rd, loc, ddoc['type'], test=not args.execute, ignore_low_data_check=force)
+        elif 'host' in ddoc and ddoc['host'] == 'daq':
+            # This is the live_data
+            if not delete_live:
+                log.info(f'prevent {loc} from being deleted. Do so with --delete_live')
+                # If you want to delete processed data you shouldn't consider this ddoc
+                continue
+
+            run_id = '%06d' % number
+            loc = os.path.join(ddoc['location'], run_id)
+            if not force and not have_raw_records:
+                # If we do not have raw records, don't delete this data. However, if we
+                # --force deletion, do go to the next else statement
+                log.info(f'Unsafe to delete {loc}, no raw_records registered. Force with '
+                         f'--force')
+            elif not force and have_raw_records:
+                log.info(f'Deleting {loc} since we have raw_records registered.')
+                threaded_delete_data(rd, loc, ddoc['type'], test=not args.execute,
+                                     ignore_low_data_check=False)
+            # Redundant elif but let's double check the force nonetheless.
+            elif force:
+                log.info(f'Forcefully delete {loc}, but no raw_records registered!')
+                threaded_delete_data(rd, loc, ddoc['type'], test=not args.execute,
+                                     ignore_low_data_check=True)
+
+
+def remove_if_unregistered(number, delete_live=False):
+    """
+    Given a run number delete data on this machine that matches that number
+    :param number: int! the run_number (not run_id)
+    :param delete_live: Bool, if True: Remove the live_data. Else remove processed data
+    """
+    # Query the database to remove data
+    # WANRING! If we don't find something we WILL remove the data! Don't make the query
+    # specific! We only check if any of the data is on this host (i.e. not get None from
+    # the query below)
+    rd = run_coll.find_one({'number': number,
+                            'data.host': hostname if not delete_live else 'daq'})
+    run_id = '%06d' % number
+
+    if rd:
+        # Just for explicitness, this is where we want to end up. If we have a rundoc,
+        # the data is registered and we don't have to do anything.
+        return
+    else:
+        log.info(f'remove_if_unregistered::\trun {number} is NOT registered in the runDB')
+        if not delete_live:
+            # Check the local ebs disk for data.
+            _remove_unregistered_run(output_folder, run_id, checked_db=True)
+        else:
+            # Check ceph for data associated to this run (which is apparently not in the
+            # runDB)
+            _remove_unregistered_run(ceph_folder, run_id, checked_db=True)
+
+
+def _remove_unregistered_run(base_folder, run_id, checked_db=False):
+    """
+    NB: The check that this run is not registered should be performed first!
+    Deletes any folder from base_folder that matches run_id.
+    :param base_folder: folder to check
+    :param run_id: run_id to remove from folder
+    :param checked_db: Bool if it is checked that this run in not in the database.
+    """
+    if not checked_db:
+        raise ValueError("Only insert runs where for it is checked that it is "
+                         "not registered in the runs database and double checked.")
+    log.warning(f'No data for {run_id} found! Double checking {base_folder}!')
+    deleted_data = False
+
+    for folder in os.listdir(base_folder):
+        if run_id in folder:
+            log.info(f'Cleaning {base_folder + folder}')
+
+            # Do a final check if we are not deleting essential data!
+            # Do not disable this check! If you don't like it: make a smarter query
+            rd = run_coll.find_one({'number': int(run_id)})
+            n_live, n_rr = check_rundoc_for_live_and_raw(rd)
+
+            if not (n_live or n_rr >= 1 + int('raw_records' in folder)):
+                raise ValueError(
+                    f'Trying to delete {folder} but we only have {n_live} live- and '
+                    f'{n_rr} raw_record-files in the runs-database. This might be an '
+                    f'essential copy of the data!')
+
+            # OK, we still have live_data somewhere or we have raw_records (elsewhere)
+            if args.execute:
+                _rmtree(base_folder + folder)
+            else:
+                log.info(f'TEST\tdeleting {base_folder + folder}')
+            deleted_data = True
+
+    if not deleted_data:
+        raise FileNotFoundError(f'No data registered on {hostname} for {run_id}')
 
 ##
 # Helper functions
@@ -708,12 +777,17 @@ if __name__ == '__main__':
                     f'result in an irrecoverable loss of data.')
         log.info(f'main::\tPlease note that execute argument is {args.execute} which '
                  f'means you are {"" if not args.execute else "!NOT!"} safe')
+        if not args.ask_confirm:
+            raise NotImplementedError(
+                f'main::\tI cannot let your forcefully delete data without asking for '
+                f'confirmation. Add --ask_confirm. Bye, bye')
+
         if not input('Want to proceed willingly? [y]').lower() == 'y':
             log.info(f'main::\tAlright no unsafe operations, bye bye')
             exit(-1)
         if args.clean != 'abandoned' and not args.number:
-            raise NotImplementedError('main::\tI dont want to have this option enabled '
-                                      'yet.')
+            raise NotImplementedError(
+                'main::\tI dont want to have this option enabled (yet).')
 
     if args.clean in ['all', 'old_hash']:
         # Need the context for the latest hash

--- a/bin/ajax
+++ b/bin/ajax
@@ -103,7 +103,7 @@ def main_ajax():
                 if hostname == eb_can_clean_ceph:
                     clean_ceph()
                     clean_abandoned(delete_live=True)
-                    clean_database(delete_live=True)
+                    # clean_database(delete_live=True)
 
                     # Don't do clean_unregistered by default (only if specified
                     # as specific argument on host "eb_can_clean_ceph") as

--- a/bin/ajax
+++ b/bin/ajax
@@ -42,7 +42,7 @@ ajax_thresholds = {
     'remove_live_after': 24 * 3600,  # s
     # Remove do not remove successfully processed runs if they have finished less than
     # this many seconds ago to e.g. allow for saving et cetera
-    'wait_after_processing': 2 * 3600,  # s
+    'wait_after_processing': 12 * 3600,  # s
     # Remove the raw records of the neutron veto after this many seconds
     'remove_raw_records_nv': 365.25 * 24 * 3600,  # s
     # Remove high level plugins if the run is this old
@@ -103,15 +103,25 @@ def main_ajax():
                 if hostname == eb_can_clean_ceph:
                     clean_ceph()
                     clean_abandoned(delete_live=True)
-                    clean_unregistered(delete_live=True)
                     clean_database(delete_live=True)
 
-                clean_high_level_data()
-                clean_unregistered()
-                clean_raw_records_nv()
+                    # Don't do clean_unregistered by default (only if specified
+                    # as specific argument on host "eb_can_clean_ceph") as
+                    # someone might be storing some test data in the /live_data
+                    # folder
+                    # clean_unregistered(delete_live=True)
+
+                # Not yet implemented functions
+                # clean_high_level_data()
+                # clean_raw_records_nv()
+
                 clean_abandoned()
                 clean_non_latest()
-                clean_database()
+
+                # These two modes below shouldn't be done on autopilot at the
+                # time of writing.
+                # clean_unregistered()
+                # clean_database()
                 if not args.execute:
                     break
                 log.info(f'Loop finished, take a {ajax_thresholds["nap_time"]} s nap')
@@ -208,6 +218,7 @@ def clean_non_latest():
     # We need to grep all the rundocs at once as simply doing one at the time (find_one)
     # might get stuck as the query may yield the same result the next time it is called.
     rds = run_coll.find({'bootstrax.state': 'done',
+                         'status': 'transferred',
                          'bootstrax.time':
                              {"$lt": now(-ajax_thresholds['wait_after_processing'])},
                          'bootstrax.host': {'$ne': hostname},
@@ -259,6 +270,7 @@ def clean_raw_records_nv():
     """Based on the runsDB, remove the raw_records_nv if they are old"""
     check_sn_trigger()
     rd = run_coll.find_one({'bootstrax.state': 'done',
+                            'status': 'transferred',
                             'data.type': 'raw_records_nv',
                             'data.host': hostname,
                             'start':
@@ -315,6 +327,9 @@ def clean_old_hash():
             log.info(f'clean_old_hash::\tLineage for run {run_id}, {data_type} is '
                      f'{current_st_hash}. Removing old hash: {lineage_hash} from {loc}.')
             rd = run_coll.find_one({'bootstrax.state': 'done',
+                                    'status': 'transferred',
+                                    'bootstrax.time':
+                                        {"$lt": now(-ajax_thresholds['wait_after_processing'])},
                                     'data.type': data_type,
                                     'data.host': hostname,
                                     'number': int(run_id)})
@@ -335,6 +350,8 @@ def clean_abandoned(delete_live=False):
     # runs to be deleted simultaneously.
     if not delete_live:
         rd = run_coll.find_one({'bootstrax.state': 'abandoned',
+                                'bootstrax.time':
+                                    {"$lt": now(-ajax_thresholds['wait_after_processing'])},
                                 'data.host': hostname})
         if rd is None:
             log.info('clean_abandoned::\tNo more matches in rundoc')
@@ -344,6 +361,8 @@ def clean_abandoned(delete_live=False):
             rds = [rd]
     else:
         rds = run_coll.find({'bootstrax.state': 'abandoned',
+                             'bootstrax.time':
+                                 {"$lt": now(-ajax_thresholds['wait_after_processing'])},
                              'data.location': '/live_data/xenonnt',
                              'data.host': 'daq'})
 
@@ -416,7 +435,9 @@ def delete_data(rd, path, data_type, test=True):
         log.info(f'Deleting data at {path}')
         if not test:
             _rmtree(path)
-    log.info(f'deleting {path} finished')
+        log.info(f'deleting {path} finished')
+    else:
+        log.info(f'There is no data on {path}! Just doing the rundoc.')
     # Remove the data location from the rundoc and append it to the 'deleted_data' entries
     if not os.path.exists(path):
         log.info('changing data field in rundoc')
@@ -514,6 +535,7 @@ def remove_if_unregistered(number, delete_live=False):
     """
     # Query the database to remove data
     rd = run_coll.find_one({'bootstrax.state': 'done',
+                            'status': 'transferred',
                             'bootstrax.time':
                                 {"$lt": now(-ajax_thresholds['wait_after_processing'])},
                             'number': number,

--- a/bin/ajax
+++ b/bin/ajax
@@ -94,7 +94,7 @@ def main_ajax():
             # Do this mode
             _modes[args.clean]()
             if hostname == eb_can_clean_ceph and (
-                    args.clean in ['abandoned', 'unregistered', 'database']):
+                    args.clean in ['abandoned', 'database']):
                 _modes[args.clean](delete_live=True)
 
             log.info(f'Done with {args.clean}')
@@ -682,8 +682,12 @@ def _remove_unregistered_run(base_folder, run_id, checked_db=False):
 
             # OK, we still have live_data somewhere or we have raw_records (elsewhere)
             if args.execute:
-                shutil.move(os.path.join(base_folder, folder),
-                            os.path.join(non_registered_folder, folder))
+                # Double check returns True automatically if not args.ask_confirm
+                if confirm(
+                        f'Should we really move {os.path.join(base_folder, folder)} '
+                        f'to {os.path.join(non_registered_folder, folder)}?'):
+                    shutil.move(os.path.join(base_folder, folder),
+                                os.path.join(non_registered_folder, folder))
             else:
                 log.info(f'TEST\tmoving {base_folder + folder}')
             deleted_data = True
@@ -850,10 +854,10 @@ if __name__ == '__main__':
     # Runs database
     run_dbname = 'xenonnt'
     run_collname = 'runs'
-    run_db_username = straxen.get_secret('RUNDB_USERNAME'.lower())
-    run_db_password = straxen.get_secret('RUNDB_PASSWORD'.lower())
+    run_db_username = straxen.get_secret('mongo_rdb_username'.lower())
+    run_db_password = straxen.get_secret('mongo_rdb_password'.lower())
     run_client = pymongo.MongoClient(
-        f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017/xenonnt")
+        f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017,old-gw:27017/admin")
     run_db = run_client[run_dbname]
     run_coll = run_db[run_collname]
     run_db.command('ping')

--- a/bin/ajax
+++ b/bin/ajax
@@ -356,8 +356,6 @@ def clean_abandoned(delete_live=False):
     # runs to be deleted simultaneously.
     if not delete_live:
         rd = run_coll.find_one({'bootstrax.state': 'abandoned',
-                                'bootstrax.time':
-                                    {"$lt": now(-ajax_thresholds['wait_after_processing'])},
                                 'data.host': hostname})
         if rd is None:
             log.info('clean_abandoned::\tNo more matches in rundoc')
@@ -490,16 +488,20 @@ def delete_data(rd, path, data_type,
     data. We can specify this e.g. if we know this is data associated to some abandoned
     run.
     """
-    # if data_type == 'live' and not args.delete_live:
-    #     raise ValueError('Unsafe operation. Trying to delete live data!')
+    # First check that we are not deleting essential data (unless we are working
+    # with abandoned runs or so.
     if not ignore_low_data_check:
         n_live, n_rr = check_rundoc_for_live_and_raw(rd)
         if not (
                 n_live or
                 n_rr >= 1 + int('raw_records' in data_type)):
-            raise ValueError(f'Trying to delete {data_type} but we only have {n_live} '
-                             f'live- and {n_rr} raw_record-files in the runs-database. '
-                             f'This might be an essential copy of the data!')
+            message = (f'Trying to delete {data_type} but we only have {n_live}'
+                       f' live- and {n_rr} raw_record-files in the '
+                       f'runs-database. This might be an essential copy of the'
+                       f' data!')
+            log_warning(message, priority='fatal', run_id=f'{rd["number"]:06}')
+            raise ValueError(message)
+
     if os.path.exists(path):
         log.info(f'Deleting data at {path}')
         if not test:
@@ -507,6 +509,7 @@ def delete_data(rd, path, data_type,
         log.info(f'deleting {path} finished')
     else:
         log.info(f'There is no data on {path}! Just doing the rundoc.')
+
     # Remove the data location from the rundoc and append it to the 'deleted_data' entries
     if not os.path.exists(path):
         log.info('changing data field in rundoc')
@@ -562,7 +565,8 @@ def remove_run_from_host(number, delete_live=False, force=False):
     rd = run_coll.find_one({'number': number,
                             'data.host': hostname if not delete_live else 'daq'})
     if not rd:
-        log.info(f'No registered data for {number} on {hostname}')
+        log_warning(f'No registered data for {number} on {hostname}',
+                    run_id=f'{number:06}', priority='info')
         return
 
     have_live_data, have_raw_records = check_rundoc_for_live_and_raw(rd)
@@ -599,8 +603,9 @@ def remove_run_from_host(number, delete_live=False, force=False):
             if not force and not have_raw_records:
                 # If we do not have raw records, don't delete this data. However, if we
                 # --force deletion, do go to the next else statement
-                log.info(f'Unsafe to delete {loc}, no raw_records registered. Force with '
-                         f'--force')
+                log_warning(
+                    f'Unsafe to delete {loc}, no raw_records registered. Force with '
+                    f'--force', priority='info')
             elif not force and have_raw_records:
                 log.info(f'Deleting {loc} since we have raw_records registered.')
                 threaded_delete_data(rd, loc, ddoc['type'], test=not args.execute,
@@ -631,7 +636,10 @@ def remove_if_unregistered(number, delete_live=False):
         # the data is registered and we don't have to do anything.
         return
     else:
-        log.info(f'remove_if_unregistered::\trun {number} is NOT registered in the runDB')
+        log_warning(f'remove_if_unregistered::\trun {number} is NOT registered '
+                    f'in the runDB but is stored on {hostname}',
+                    run_id=run_id,
+                    priority='error')
         if not delete_live:
             # Check the local ebs disk for data.
             _remove_unregistered_run(output_folder, run_id, checked_db=True)
@@ -650,9 +658,14 @@ def _remove_unregistered_run(base_folder, run_id, checked_db=False):
     :param checked_db: Bool if it is checked that this run in not in the database.
     """
     if not checked_db:
+        log_warning(f'remove_if_unregistered::\trogue ajax operations! Trying '
+                    f'to delete {run_id} from {hostname}',
+                    run_id=run_id,
+                    priority='fatal')
         raise ValueError("Only insert runs where for it is checked that it is "
                          "not registered in the runs database and double checked.")
-    log.warning(f'No data for {run_id} found! Double checking {base_folder}!')
+    log_warning(f'No data for {run_id} found! Double checking {base_folder}!',
+                run_id=run_id, priority='warning')
     deleted_data = False
 
     for folder in os.listdir(base_folder):
@@ -665,20 +678,25 @@ def _remove_unregistered_run(base_folder, run_id, checked_db=False):
             n_live, n_rr = check_rundoc_for_live_and_raw(rd)
 
             if not (n_live or n_rr >= 1 + int('raw_records' in folder)):
-                raise ValueError(
-                    f'Trying to delete {folder} but we only have {n_live} live- and '
-                    f'{n_rr} raw_record-files in the runs-database. This might be an '
-                    f'essential copy of the data!')
+                message = (f'Trying to delete {folder} but we only have '
+                           f'{n_live} live- and {n_rr} raw_record-files in the '
+                           f'runs-database. This might be an essential copy of '
+                           f'the data!')
+                log_warning(message, run_id=run_id, priority='fatal')
+                raise ValueError(message)
 
             # OK, we still have live_data somewhere or we have raw_records (elsewhere)
             if args.execute:
-                _rmtree(base_folder + folder)
+                shutil.move(os.path.join(base_folder, folder),
+                            os.path.join(non_registered_folder, folder))
             else:
-                log.info(f'TEST\tdeleting {base_folder + folder}')
+                log.info(f'TEST\tmoving {base_folder + folder}')
             deleted_data = True
 
     if not deleted_data:
-        raise FileNotFoundError(f'No data registered on {hostname} for {run_id}')
+        message = f'No data registered on {hostname} for {run_id}'
+        log_warning(message, priority='fatal')
+        raise FileNotFoundError(message)
 
 ##
 # Helper functions
@@ -719,6 +737,38 @@ def wait_on_delete_thread():
                     wait = True
     log.info(f'wait_on_delete_thread::\tChecked that all {thread_prefix}* finished')
 
+
+def log_warning(message, priority='warning', run_id=None):
+    """Report a warning to the terminal (using the logging module)
+    and the DAQ log DB.
+    :param message: insert string into log_coll
+    :param priority: severity of warning. Can be:
+        info: 1,
+        warning: 2,
+        <any other valid python logging level, e.g. error or fatal>: 3
+    :param run_id: optional run id.
+    """
+    if not args.execute:
+        return
+    getattr(log, priority)(message)
+    # Log according to redax rules
+    # https://github.com/coderdj/redax/blob/master/MongoLog.hh#L22
+    warning_message = {
+        'message': message,
+        'user': f'ajax_{hostname}',
+        'priority':
+            dict(debug=0,
+                 info=1,
+                 warning=2,
+                 error=3,
+                 fatal=4,
+                 ).get(priority.lower(), 3)}
+    if run_id is not None:
+        warning_message.update({'runid': run_id})
+    if args.execute:
+        # Only upload warning if we would actually execute the script
+        log_coll.insert_one(warning_message)
+    log.info(message)
 
 ##
 # Main
@@ -768,7 +818,7 @@ if __name__ == '__main__':
     if args.clean == 'raw_records_nv':
         log.info(f'main::\tDelete neutron veto data from {hostname} older than '
                  f'{ajax_thresholds["remove_raw_records_nv"]} s')
-        raise NotImplementedError("I dont know what to do with the raw_records of the NV")
+        raise NotImplementedError("I don't know what to do with the raw_records of the NV")
     if args.delete_live:
         if not args.number:
             raise ValueError("Specify which number with --number")
@@ -787,7 +837,7 @@ if __name__ == '__main__':
             exit(-1)
         if args.clean != 'abandoned' and not args.number:
             raise NotImplementedError(
-                'main::\tI dont want to have this option enabled (yet).')
+                "main::\tI don't want to have this option enabled (yet).")
 
     if args.clean in ['all', 'old_hash']:
         # Need the context for the latest hash
@@ -796,19 +846,29 @@ if __name__ == '__main__':
     # Set the folders
     ceph_folder = '/live_data/xenonnt/'
     output_folder = '/data/xenonnt_processed/'
-    if os.access(output_folder, os.W_OK) is not True:
-        raise IOError(f'main::\tNo writing access to {output_folder}')
+    non_registered_folder = '/data/xenonnt_unregistered/'
+    for f in (output_folder, non_registered_folder):
+        if os.access(f, os.W_OK) is not True:
+            log_warning(f'main::\tNo writing access to {f}', property='fatal')
+            raise IOError(f'main::\tNo writing access to {f}')
 
     # Runs database
     run_dbname = 'xenonnt'
     run_collname = 'runs'
-
-    run_db_username = os.environ['MONGO_RDB_USERNAME']
-    run_db_password = os.environ['MONGO_RDB_PASSWORD']
+    run_db_username = straxen.get_secret('RUNDB_USERNAME'.lower())
+    run_db_password = straxen.get_secret('RUNDB_PASSWORD'.lower())
     run_client = pymongo.MongoClient(
         f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017,old-gw:27017/admin")
     run_db = run_client[run_dbname]
     run_coll = run_db[run_collname]
+
+    # DAQ database
+    daq_db_name = 'daq'
+    daq_db_password = straxen.get_secret('MONGO_DAQ_PASSWORD'.lower())
+    daq_db_username = straxen.get_secret('MONGO_DAQ_USERNAME'.lower())
+    daq_client = pymongo.MongoClient(f"mongodb://{daq_db_username}:{daq_db_password}@xenon1t-daq:27017/admin")
+    daq_db = daq_client[daq_db_name]
+    log_coll = daq_db['log']
 
     try:
         main_ajax()

--- a/bin/ajax
+++ b/bin/ajax
@@ -853,9 +853,10 @@ if __name__ == '__main__':
     run_db_username = straxen.get_secret('RUNDB_USERNAME'.lower())
     run_db_password = straxen.get_secret('RUNDB_PASSWORD'.lower())
     run_client = pymongo.MongoClient(
-        f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017,old-gw:27017/admin")
+        f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017/xenonnt")
     run_db = run_client[run_dbname]
     run_coll = run_db[run_collname]
+    run_db.command('ping')
 
     # DAQ database
     daq_db_name = 'daq'
@@ -864,6 +865,7 @@ if __name__ == '__main__':
     daq_client = pymongo.MongoClient(f"mongodb://{daq_db_username}:{daq_db_password}@xenon1t-daq:27017/admin")
     daq_db = daq_client[daq_db_name]
     log_coll = daq_db['log']
+    daq_db.command('ping')
 
     try:
         main_ajax()

--- a/bin/ajax
+++ b/bin/ajax
@@ -183,11 +183,7 @@ def clean_high_level_data():
 
     for rd in rds:
         # First check that we actually have raw_records stored somewhere
-        have_raw_records = False
-        for dd in rd['data']:
-            if dd['type'] == 'raw_records' and dd['location'] != 'deleted':
-                have_raw_records = True
-                break
+        _, have_raw_records = check_rundoc_for_live_and_raw(rd)
         if not have_raw_records:
             break
 
@@ -232,7 +228,6 @@ def clean_non_latest():
         have_raw_records = False
         for dd in rd['data']:
             if (dd['type'] == 'raw_records' and
-                    dd['location'] != 'deleted' and
                     dd['host'] != hostname):
                 have_raw_records = True
                 break
@@ -545,9 +540,9 @@ def check_rundoc_for_live_and_raw(rd):
     """
     n_live_data, n_raw_records = 0, 0
     for dd in rd['data']:
-        if dd['type'] == 'live' and dd['location'] != 'deleted':
+        if dd['type'] == 'live':
             n_live_data += 1
-        if dd['type'] == 'raw_records' and dd['location'] != 'deleted':
+        if dd['type'] == 'raw_records':
             n_raw_records += 1
     return n_live_data, n_raw_records
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -320,7 +320,7 @@ def main():
         number = args.process
         rd = consider_run({'number': number})
         if rd is None:
-            message = f"Trying to process single rung but no run numbered {number} exists"
+            message = f"Trying to process single run but no run numbered {number} exists"
             log_warning(message, priority='fatal')
             raise ValueError(message)
         process_run(rd)

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -222,8 +222,6 @@ hostname = socket.getfqdn()
 
 # Set the output folder
 output_folder = '/data/xenonnt_processed/'
-if os.access(output_folder, os.W_OK) is not True:
-    raise IOError(f'No writing access to {output_folder}')
 
 if not args.production:
     # This means we are in some test mode
@@ -296,6 +294,12 @@ if not args.undying:
 
 
 def main():
+    # Check that writing access is OK, otherwise report to the database and die
+    if os.access(output_folder, os.W_OK) is not True:
+        message = f'No writing access to {output_folder}'
+        log_warning(message, priority='fatal')
+        raise IOError(message)
+
     if args.cores == -1:
         # Use all of the available cores on this machine
         args.cores = multiprocessing.cpu_count()
@@ -316,7 +320,9 @@ def main():
         number = args.process
         rd = consider_run({'number': number})
         if rd is None:
-            raise ValueError(f"No run numbered {number} exists")
+            message = f"Trying to process single rung but no run numbered {number} exists"
+            log_warning(message, priority='fatal')
+            raise ValueError(message)
         process_run(rd)
         log.info(f'bootstrax ({hostname}) finished run {number} in {(now() - t_start).seconds} seconds')
         wait_on_delete_thread()
@@ -422,7 +428,9 @@ def kill_process(pid, wait_time=None):
         if not pid_exists(pid):
             return
         if signal == 'die':
-            raise RuntimeError(f"Could not kill process {pid}")
+            message = f"Could not kill process {pid}"
+            log_warning(message, priority='fatal')
+            raise RuntimeError(message)
         os.kill(pid, sig)
 
 
@@ -504,12 +512,20 @@ def log_warning(message, priority='warning', run_id=None):
     if not args.production:
         return
     getattr(log, priority)(message)
+    # Log according to redax rules
+    # https://github.com/coderdj/redax/blob/master/MongoLog.hh#L22
     warning_message = {
         'message': message,
         'user': f'bootstrax_{hostname}',
-        'priority': dict(warning=2, info=1).get(priority, 3)}
-    if run_id:
-        warning_message.update({'run_id': run_id})
+        'priority':
+            dict(debug=0,
+                 info=1,
+                 warning=2,
+                 error=3,
+                 fatal=4,
+                 ).get(priority.lower(), 3)}
+    if run_id is not None:
+        warning_message.update({'runid': run_id})
     log_coll.insert_one(warning_message)
 
 
@@ -532,7 +548,7 @@ def eb_can_process():
     if not args.production:
         return True
     elif 'eb2' in hostname:
-        log_warning('Why is eb2 alive?!')
+        log_warning('Why is eb2 alive?!', priority='error')
         return False
 
     # Check that there are runs that are waiting to be processed. If there are few, this
@@ -594,7 +610,7 @@ def infer_mode(rd):
         data_rate = sum([d['rate'] for d in docs])
     except Exception as e:
         log_warning(f'infer_mode ran into {e}. Cannot infer mode, using default mode.',
-                    run_id=f'{rd["number"]:06}')
+                    run_id=f'{rd["number"]:06}', priority='info')
         data_rate = None
 
     # Find out if eb is new (eb3-eb5):
@@ -667,7 +683,7 @@ def sufficient_diskspace():
             send_heartbeat(dict(state='disk full'))
     set_state(dead_state)
     message = f"No disk space to write to. Kill bootstrax on {hostname}"
-    log_warning(message, priority='Error')
+    log_warning(message, priority='fatal')
     raise RuntimeError(message)
 
 
@@ -711,7 +727,9 @@ def _delete_data(rd, path, data_type):
     ping_dbs()
 
     if data_type == 'live' and not args.delete_live and args.production:
-        raise ValueError('Unsafe operation. Trying to delete live data!')
+        message = 'Unsafe operation. Trying to delete live data!'
+        log_warning(message, priority='fatal')
+        raise ValueError(message)
     log.info(f'Deleting data at {path}')
     if os.path.exists(path):
         shutil.rmtree(path)
@@ -734,7 +752,9 @@ def _delete_data(rd, path, data_type):
                                            {"type": data_type,
                                             "host": {'$in': ['daq', hostname]}}}})
     else:
-        raise ValueError(f"Something went wrong we wanted to delete {path}!")
+        message = f"Something went wrong we wanted to delete {path}!"
+        log_warning(message, priority='fatal')
+        raise ValueError(message)
 
 
 def wait_on_delete_thread():
@@ -796,6 +816,7 @@ def get_run(*, mongo_id=None, number=None, full_doc=False):
     elif mongo_id is not None:
         query = {'_id': mongo_id}
     else:
+        # This means you are not running a normal bootstrax (no reason to report to rundb)
         raise ValueError("Please give mongo_id or number")
 
     return run_coll.find_one(query, projection=None if full_doc else bootstrax_projection)
@@ -877,7 +898,7 @@ def upload_file_metadata(rd):
         st_meta = new_context(cores=args.cores, max_messages=args.max_messages, timeout=100)
         st_meta.set_context_config({'forbid_creation_of': '*'})
     except Exception as e:
-        log_warning(f"Cannot create context to read the metadata: {e}", priority='info')
+        log_warning(f"Cannot create context to read the metadata: {e}", priority='warning')
         st_meta = None
 
     for ddoc in rd['data']:
@@ -899,6 +920,7 @@ def upload_file_metadata(rd):
                     lineage_hash = md['lineage_hash']
                 except Exception as e:
                     log_warning(f"Cannot load metadata of {ddoc['type']}: {e}",
+                                priority='warning',
                                 run_id=f'{rd["number"]:06}')
 
             run_coll.update_one(
@@ -938,11 +960,14 @@ def set_status_finished(rd):
         # This is strange, bootstrax already finished this run before
         log_warning('WARNING: bootstax has already marked this run as ready '
                     'for upload. Doing nothing.',
+                    priority='warning',
                     run_id=f'{rd["number"]:06}')
     else:
         # Do not override this field for runs already uploaded in admix
-        raise ValueError(f'Trying to set set the status {rd.get("status")} to '
-                         f'{ready_to_upload}! One should not override this field.')
+        message = (f'Trying to set set the status {rd.get("status")} to '
+                   f'{ready_to_upload}! One should not override this field.')
+        log_warning(message, priority='fatal')
+        raise ValueError(message)
 
 
 def abandon(*, mongo_id=None, number=None):
@@ -1181,16 +1206,17 @@ def process_run(rd, send_heartbeats=args.production):
         if 'daq_config' not in rd:
             fail('No daq_config in the rundoc!')
         try:
-            # Fetch parameters from the rundoc. If not readably, let's use redax' default
+            # Fetch parameters from the rundoc. If not readable, let's use redax' default
             # values (that are hardcoded here).
             dq_conf = rd['daq_config']
             to_read = ('processing_threads', 'strax_chunk_length', 'strax_chunk_overlap',
                        'strax_fragment_payload_bytes')
-            for conf in to_read:
-                if conf not in dq_conf:
-                    log_warning(f'{conf} not in rundoc for {run_id}! Using default values.',
-                                priority='info',
-                                run_id=run_id)
+            report_missing_config = [conf for conf in to_read if conf not in dq_conf]
+            if report_missing_config:
+                log_warning(f'{", ".join(report_missing_config)} not in rundoc for '
+                            f'{run_id}! Using default values.',
+                            priority='info',
+                            run_id=run_id)
             thread_info = dq_conf.get('processing_threads', dict())
             n_readout_threads = sum([v for v in thread_info.values()])
             daq_chunk_duration = int(dq_conf.get('strax_chunk_length', 5) * 1e9)

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -839,6 +839,24 @@ def check_data_written(rd):
     return files_written > 0
 
 
+def all_files_saved(rd, wait_max=600, wait_per_cycle=10):
+    """
+    Check that all files are written. It might be that the savers are still in
+    the process of renaming from folder_temp to folder. Hence allow some wait
+    time to allow the savers to finish
+    :param rd: rundoc
+    :param wait_max: max seconds to wait for data to save
+    :param wait_per_cycle: wait this many seconds if the data is not yet there
+    """
+    start = time.time()
+    while not check_data_written(rd):
+        if time.time() - start > wait_max:
+            return False
+        send_heartbeat()
+        time.sleep(wait_per_cycle)
+    return True
+
+
 def upload_file_metadata(rd):
     """
     Update the data-field in the rundoc with a portion of the metadata. Also count the
@@ -897,14 +915,9 @@ def set_status_finished(rd):
         return
 
     # First check that all the data is available (that e.g. no _temp files
-    # are being renamed).
-    if not check_data_written(rd):
-        log_warning('Data not successfully written wait 30 s and check again')
-        time.sleep(30)
-        if check_data_written(rd):
-            log_warning('Data not successfully written do not mark this run '
-                        'ready for upload')
-            return
+    # are being renamed). This line should be over-redundant as we already
+    # check earlier.
+    all_files_saved(rd)
 
     # Only update the status if it does not exist or if it needs to be uploaded
     ready_to_upload = {'status': 'eb_ready_to_upload'}
@@ -1273,6 +1286,7 @@ def process_run(rd, send_heartbeats=args.production):
                 # (at least up to some fudge factor)
                 # Since chunks can be empty, and we don't want to crash,
                 # this has to be done with some care...
+                # Lets assume some ridiculous timestamp (in ns): 10e9*1e9
                 t_covered = timedelta(
                     seconds=(max([x.get('last_endtime', 0) for x in md['chunks']]) -
                              min([x.get('first_time', 10e9*1e9) for x in md['chunks']])) / 1e9)
@@ -1284,6 +1298,8 @@ def process_run(rd, send_heartbeats=args.production):
                         < timedelta(seconds=max_timetamp_diff)):
                     fail(f"Processing covered {t_covered.seconds}, "
                          f"but run lasted {run_duration.seconds}!")
+                if not all_files_saved(rd):
+                    fail("Not all files in the rundoc for this run are saved")
 
                 log.info(f"Run {run_id} processed successfully")
                 if args.production:

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -273,6 +273,7 @@ daq_client = pymongo.MongoClient(f"mongodb://{daq_db_username}:{daq_db_password}
 daq_db = daq_client[daq_db_name]
 bs_coll = daq_db['eb_monitor']
 ag_stat_coll = daq_db['aggregate_status']
+log_coll = daq_db['log']
 
 # Runs database
 run_dbname = 'xenonnt'
@@ -287,7 +288,6 @@ else:
         f"mongodb://{run_db_username}:{run_db_password}@xenon1t-daq:27017/xenonnt")
     run_db = run_client[run_dbname]
 run_coll = run_db[run_collname]
-log_coll = run_db['log']
 
 # Ping the databases to ensure the mongo connections are working
 if not args.undying:
@@ -490,22 +490,27 @@ def send_heartbeat(update_fields=None):
     set_state(None, update_fields=update_fields)
 
 
-def log_warning(message, priority='warning'):
+def log_warning(message, priority='warning', run_id=None):
     """Report a warning to the terminal (using the logging module)
     and the DAQ log DB.
+    :param message: insert string into log_coll
     :param priority: severity of warning. Can be:
         info: 1,
         warning: 2,
         <any other valid python logging level, e.g. error or fatal>: 3
+    :param run_id: optional run id.
     """
     ping_dbs()
     if not args.production:
         return
     getattr(log, priority)(message)
-    log_coll.insert_one({
+    warning_message = {
         'message': message,
         'user': f'bootstrax_{hostname}',
-        'priority': dict(warning=2, info=1).get(priority, 3)})
+        'priority': dict(warning=2, info=1).get(priority, 3)}
+    if run_id:
+        warning_message.update({'run_id': run_id})
+    log_coll.insert_one(warning_message)
 
 
 def eb_can_process():
@@ -588,7 +593,8 @@ def infer_mode(rd):
                 ])
         data_rate = sum([d['rate'] for d in docs])
     except Exception as e:
-        log_warning(f'infer_mode ran into {e}. Cannot infer mode, using default mode.')
+        log_warning(f'infer_mode ran into {e}. Cannot infer mode, using default mode.',
+                    run_id=f'{rd["number"]:06}')
         data_rate = None
 
     # Find out if eb is new (eb3-eb5):
@@ -635,7 +641,9 @@ def infer_mode(rd):
                       timeout=min(1000, result['timeout']* 1.5)
                       )
         log_warning(f'infer_mode::\tRepeated failures. Lowering mode to {result}. This '
-                    f'may indicated a sub-optimal state of {hostname}!')
+                    f'may indicated a sub-optimal state of {hostname}!',
+                    priority='warning',
+                    run_id=f'{rd["number"]:06}')
 
     return result
 
@@ -659,7 +667,7 @@ def sufficient_diskspace():
             send_heartbeat(dict(state='disk full'))
     set_state(dead_state)
     message = f"No disk space to write to. Kill bootstrax on {hostname}"
-    log_warning(message, priority='warning')
+    log_warning(message, priority='Error')
     raise RuntimeError(message)
 
 
@@ -869,7 +877,7 @@ def upload_file_metadata(rd):
         st_meta = new_context(cores=args.cores, max_messages=args.max_messages, timeout=100)
         st_meta.set_context_config({'forbid_creation_of': '*'})
     except Exception as e:
-        log_warning(f"Cannot create context to read the metadata: {e}")
+        log_warning(f"Cannot create context to read the metadata: {e}", priority='info')
         st_meta = None
 
     for ddoc in rd['data']:
@@ -890,7 +898,8 @@ def upload_file_metadata(rd):
                     avg_data_size_mb = int(np.average(chunk_mb))
                     lineage_hash = md['lineage_hash']
                 except Exception as e:
-                    log_warning(f"Cannot load metadata if {ddoc['type']}: {e}")
+                    log_warning(f"Cannot load metadata of {ddoc['type']}: {e}",
+                                run_id=f'{rd["number"]:06}')
 
             run_coll.update_one(
                     {'_id': rd['_id'],
@@ -928,7 +937,8 @@ def set_status_finished(rd):
     elif rd.get('status') == ready_to_upload.get('status'):
         # This is strange, bootstrax already finished this run before
         log_warning('WARNING: bootstax has already marked this run as ready '
-                    'for upload. Doing nothing.')
+                    'for upload. Doing nothing.',
+                    run_id=f'{rd["number"]:06}')
     else:
         # Do not override this field for runs already uploaded in admix
         raise ValueError(f'Trying to set set the status {rd.get("status")} to '
@@ -1014,7 +1024,8 @@ def fail_run(rd, reason):
 
     # Report to DAQ log and screen
     log_warning(f"{fail_name} on {long_run_id}: {reason}",
-                priority=failure_message_level)
+                priority=failure_message_level,
+                run_id=f'{rd["number"]:06}')
 
 
 def manual_fail(*, mongo_id=None, number=None, reason=''):
@@ -1030,7 +1041,9 @@ def get_compressor(rd, default_compressor="lz4"):
         return rd["daq_config"]["compressor"]
     except KeyError:
         log_warning(f"Bootstrax couldn't read the compressor form the run_doc. "
-                    f"Assuming 'lz4' for now")
+                    f"Assuming 'lz4' for now",
+                    priority='info',
+                    run_id=f'{rd["number"]:06}')
         return default_compressor
 
 
@@ -1091,7 +1104,9 @@ def run_strax(run_id, input_dir, target, n_readout_threads, compressor,
                 #  - Are fixing the target (this is useful for testing but normally not used)
                 for sub_d_target in args.sub_d_targets:
                     if sub_d_target not in st._plugin_class_registry:
-                        log_warning(f'Trying to make unknown data type {sub_d_target}')
+                        log_warning(f'Trying to make unknown data type {sub_d_target}',
+                                    priority='info',
+                                    run_id=run_id)
                         continue
                     elif not st.is_stored(run_id, sub_d_target):
                         st.make(run_id, sub_d_target,
@@ -1173,7 +1188,9 @@ def process_run(rd, send_heartbeats=args.production):
                        'strax_fragment_payload_bytes')
             for conf in to_read:
                 if conf not in dq_conf:
-                    log_warning(f'{conf} not in rundoc for {run_id}! Using default values.')
+                    log_warning(f'{conf} not in rundoc for {run_id}! Using default values.',
+                                priority='info',
+                                run_id=run_id)
             thread_info = dq_conf.get('processing_threads', dict())
             n_readout_threads = sum([v for v in thread_info.values()])
             daq_chunk_duration = int(dq_conf.get('strax_chunk_length', 5) * 1e9)
@@ -1495,7 +1512,7 @@ if __name__ == '__main__':
                 log.error(f'Fatal warning:\tran into {fatal_error}')
                 try:
                     log_warning(f'Fatal warning:\tran into {fatal_error}',
-                                priority='warning')
+                                priority='error')
                 except Exception as warning_error:
                     log.error(f'Fatal warning:\tcould not log {warning_error}')
                 log.warning('Restarting main loop')

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -46,7 +46,7 @@ Additionally, bootstrax tracks information with each run in the 'bootstrax' fiel
 Finally, bootstrax outputs the load on the eventbuilder machine(s) whereon it is running to a collection in the DAQ database into the capped collection 'eb_monitor'. This collection contains information on what bootstrax is thinking of at the moment
   - **disk_used**: used part of the disk whereto this bootstrax instance is writing to (in percent)
 """
-__version__ = '0.5.6'
+__version__ = '0.5.7'
 
 import argparse
 from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
The issue is detailed in #205 . Although the error is[ only in a single line ](https://github.com/XENONnT/straxen/blob/fd7c2c9301408056c05b8e17ea44ed4a548fc712/bin/ajax#L518) it's of such severity that we should safeguard ourselfs from making the same mistake again.

Furthermore in this PR we re-base the logging of error messages by `bootstrax ` to the same collection as the readers. 
Input would be appreciated if [these kind of levels ](https://github.com/XENONnT/straxen/blob/8ec44042d6dd54833e2ad0377fc45c94e74d59a4/bin/bootstrax#L510) are in line with the readers and if not what would be appropriate levels.


**Can you briefly describe how it works?**
- Disable multiple modes that shouldn't be run on a regular basis.
- Add checks (even if they don't make any sense at the moment) to doubly check that it's okay to delete data.
- Redirect warning messages to the daq_db collection and add a run_id wherever possible.

