### PR TITLE
Add backup mongo URLs 

### DIFF
--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -113,7 +113,6 @@ class RunDB(strax.StorageFrontend):
                             raise pymongo.errors.ServerSelectionTimeoutError(
                                 'Cannot connect to any mongo url')
 
-
         self.client = pymongo.MongoClient(mongo_url)
 
         if mongo_dbname is None:

--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -12,8 +12,9 @@ import straxen
 export, __all__ = strax.exporter()
 
 
-default_mongo_url = 'fried.rice.edu:27017/xenonnt'
-backup_mongo_url = 'xenon-rundb.grid.uchicago.edu:27017,xenon1t-daq.lngs.infn.it:27017/xenonnt'
+default_mongo_url = 'xenon-rundb.grid.uchicago.edu:27017/xenonnt'
+backup_mongo_urls = ('fried.rice.edu:27017/xenonnt',
+                     'xenon1t-daq.lngs.infn.it:27017/xenonnt')
 default_mongo_dbname = 'xenonnt'
 default_mongo_collname = 'runs'
 
@@ -99,7 +100,7 @@ class RunDB(strax.StorageFrontend):
                 password = straxen.get_secret('rundb_password')
 
                 # try connection to the mongo database in this order
-                mongo_connections = [default_mongo_url, backup_mongo_url]
+                mongo_connections = [default_mongo_url, *backup_mongo_urls]
                 for url_base in mongo_connections:
                     try:
                         mongo_url = f"mongodb://{username}:{password}@{url_base}"
@@ -111,7 +112,7 @@ class RunDB(strax.StorageFrontend):
                         warn(f'Cannot connect to to Mongo url: {url_base}')
                         if url_base == mongo_connections[-1]:
                             raise pymongo.errors.ServerSelectionTimeoutError(
-                                'Cannot connect to any mongo url')
+                                'Cannot connect to any Mongo url')
 
         self.client = pymongo.MongoClient(mongo_url)
 

--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -93,6 +93,7 @@ class RunDB(strax.StorageFrontend):
                 username = straxen.get_secret('mongo_rdb_username')
                 password = straxen.get_secret('mongo_rdb_password')
                 url_base = 'xenon1t-daq:27017,old-gw:27017/admin'
+                mongo_url = f"mongodb://{username}:{password}@{url_base}"
             else:
                 username = straxen.get_secret('rundb_username')
                 password = straxen.get_secret('rundb_password')
@@ -111,6 +112,7 @@ class RunDB(strax.StorageFrontend):
                         if url_base == mongo_connections[-1]:
                             raise pymongo.errors.ServerSelectionTimeoutError(
                                 'Cannot connect to any mongo url')
+
 
         self.client = pymongo.MongoClient(mongo_url)
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Use Chicago and xenon1t-daq.lngs.infn.it as backup mongo instances for fried-rice.

Use fried-rice always as the first default as that is accessible outside dali

**Can you briefly describe how it works?**
Try to connect to fried-rice, if it doesn't use a ```backup_mongo_url``` 

**Can you give a minimal working example (or illustrate with a figure)?**
```python
import strax
import straxen

RunDB = <see PR>

st = strax.Context(
        config=straxen.contexts.xnt_common_config,
        **straxen.contexts.common_opts)
username = straxen.get_secret('rundb_username')
password = straxen.get_secret('rundb_password')
st.storage = [RunDB(
        readonly=True,
        runid_field='number',
        new_data_path='./strax_data',
)
             ]
st.storage[0].client['xenonnt'].command('ping')
```

**Difference with #212**
Rather than having all tree in a single URL we split it to a to stage initialization. Otherwise if not on dali it cannot find the primary host.