### PR TITLE
HE veto length clipped at chunk end time

### DIFF
--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -176,7 +176,7 @@ class PulseProcessing(strax.Plugin):
 
         if len(r) and self.hev_enabled:
             r, r_vetoed, veto_regions = software_he_veto(
-                r, self.to_pe,
+                r, self.to_pe, end,
                 area_threshold=self.config['tail_veto_threshold'],
                 veto_length=self.config['tail_veto_duration'],
                 veto_res=self.config['tail_veto_resolution'],
@@ -257,7 +257,7 @@ class PulseProcessingHighEnergy(PulseProcessing):
 
 
 @export
-def software_he_veto(records, to_pe,
+def software_he_veto(records, to_pe, chunk_end,
                      area_threshold=int(1e5),
                      veto_length=int(3e6),
                      veto_res=int(1e3),
@@ -308,11 +308,10 @@ def software_he_veto(records, to_pe,
     #  - Have a fixed maximum length (else we can't use the strax hitfinder on them)
     #  - Never extend beyond the current chunk
     #  - Do not overlap
-    # TODO: pass the chunk endtime! For now we just use the last record endtime
     veto_start = peaks['time']
     veto_end = np.clip(peaks['time'] + veto_length,
                        None,
-                       strax.endtime(records[-1]))
+                       chunk_end)
     veto_end[:-1] = np.clip(veto_end[:-1], None, veto_start[1:])
 
     # 2b. Convert these into strax record-like objects

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -275,6 +275,7 @@ def software_he_veto(records, to_pe, chunk_end,
 
     :param records: PMT records
     :param to_pe: ADC to PE conversion factors for the channels in records.
+    :param chunk_end: Endtime of chunk to set as maximum ceiling for the veto period
     :param area_threshold: Minimum peak area to trigger the veto.
     Note we use a much rougher clustering than in later processing.
     :param veto_length: Time in ns to veto after the peak


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Software HE veto helps veto tails of large peaks to reduce unneeded data. The duration of this veto should be a configurable setting, which defaults to the end of the chunk if the length is larger than the chunk length. 

The issue is that the length is clipped at the end of records length right now, which is not always the same as the chunk endtime.

**Can you briefly describe how it works?**
np.clip used to clip values above chunk endtime. 

**Can you give a minimal working example (or illustrate with a figure)?**

```
    veto_end = np.clip(peaks['time'] + veto_length,
                       None,
                       chunk_end)
```
will return `peaks['time'] + veto_length` or `chunk_end` time, whichever is smaller.

Please include the following if applicable:
  - Update the docstring(s) DONE
  - Update the documentation DONE
  - Tests to check the (new) code is working as desired. TESTING WITH PR 
  - Does it solve one of the open issues on github? NO (but I refrained from opening one just to solve it!)

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
