### PR TITLE
Include python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 python:
 - '3.6'
 - '3.7'
+- '3.8'
 install:
 - pip install -r requirements.txt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 - '3.7'
 - '3.8'
 install:
+- pip install tensorflow>=2.3
 - pip install -r requirements.txt
 script:
 - python setup.py test


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Like in https://github.com/AxFoundation/strax/pull/320, we can also test straxen for python 3.8 with travis. This has been shown to increase performance (see figure 5: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:daq:eb_speed_tests).
