### PR TITLE
fix issue 233

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -5,11 +5,10 @@ import numpy as np
 
 common_opts = dict(
     register_all=[
-        # straxen.pulse_processing,
-        # straxen.peaklet_processing,
-        # straxen.peak_processing,
         straxen.event_processing,
         straxen.double_scatter],
+    # Register all peak/pulse processing by hand as 1T does not need to have
+    # the high-energy plugins.
     register=[
         straxen.PulseProcessing,
         straxen.Peaklets,
@@ -44,7 +43,8 @@ xnt_common_config = dict(
     nn_architecture=straxen.aux_repo + 'f0df03e1f45b5bdd9be364c5caefdaf3c74e044e/fax_files/mlp_model.json',
     nn_weights=straxen.aux_repo + 'f0df03e1f45b5bdd9be364c5caefdaf3c74e044e/fax_files/mlp_model.h5', )
 
-# Plugins in these files are nT only
+# Plugins in these files are nT only (NB: pulse&peak(let) processing are
+# registered for High Energy plugins.)
 xnt_only_plugins = [straxen.nveto_recorder,
                     straxen.nveto_pulse_processing,
                     straxen.nveto_hitlets,
@@ -52,10 +52,6 @@ xnt_only_plugins = [straxen.nveto_recorder,
                     straxen.pulse_processing,
                     straxen.peaklet_processing,
                     ]
-
-# Some datakinds are only available for the nT context. Remove any datakinds
-# from the 1T contexts if a plugin contains any of the following strings:
-nt_only_datakinds_contain = ('_he',)
 
 ##
 # XENONnT

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -1,7 +1,6 @@
 from immutabledict import immutabledict
 import strax
 import straxen
-import numpy as np
 
 common_opts = dict(
     register_all=[

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -9,11 +9,7 @@ common_opts = dict(
         straxen.peaklet_processing,
         straxen.peak_processing,
         straxen.event_processing,
-        straxen.double_scatter,
-        straxen.nveto_recorder,
-        straxen.nveto_pulse_processing,
-        straxen.nveto_hitlets,
-        straxen.acqmon_processing],
+        straxen.double_scatter],
     check_available=('raw_records', 'peak_basics'),
     store_run_fields=(
         'name', 'number', 'tags.name',
@@ -39,9 +35,16 @@ xnt_common_config = dict(
     nn_architecture=straxen.aux_repo + 'f0df03e1f45b5bdd9be364c5caefdaf3c74e044e/fax_files/mlp_model.json',
     nn_weights=straxen.aux_repo + 'f0df03e1f45b5bdd9be364c5caefdaf3c74e044e/fax_files/mlp_model.h5', )
 
+# Plugins in these files are nT only
+xnt_only_plugins = [straxen.nveto_recorder,
+                    straxen.nveto_pulse_processing,
+                    straxen.nveto_hitlets,
+                    straxen.acqmon_processing,
+                    ]
+
 # Some datakinds are only available for the nT context. Remove any datakinds
 # from the 1T contexts if a plugin contains any of the following strings:
-nt_only_datakind = ('_he', '_nv', 'aqmon', 'veto_intervals')
+nt_only_datakinds_contain = ('_he',)
 
 ##
 # XENONnT
@@ -60,6 +63,7 @@ def xenonnt_online(output_folder='./strax_data',
     st = strax.Context(
         config=straxen.contexts.xnt_common_config,
         **context_options)
+    st.register_all(xnt_only_plugins)
     st.register([straxen.DAQReader, straxen.LEDCalibration])
 
     st.storage = [straxen.RunDB(
@@ -126,7 +130,7 @@ def xenonnt_simulation(output_folder='./strax_data'):
 def strip_nt_plugins(st):
     """Remove nt datakinds from 1T contexts"""
     for plugin in list(st._plugin_class_registry.keys()):
-        if np.any([nt in plugin for nt in nt_only_datakind]):
+        if np.any([nt in plugin for nt in nt_only_datakinds_contain]):
             del st._plugin_class_registry[plugin]
     return st
 

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -39,8 +39,8 @@ xnt_common_config = dict(
     nn_architecture=straxen.aux_repo + 'f0df03e1f45b5bdd9be364c5caefdaf3c74e044e/fax_files/mlp_model.json',
     nn_weights=straxen.aux_repo + 'f0df03e1f45b5bdd9be364c5caefdaf3c74e044e/fax_files/mlp_model.h5', )
 
-# Some datakinds are only available for the nT context. Remove any plugins that
-# contain any of the following strings:
+# Some datakinds are only available for the nT context. Remove any datakinds
+# from the 1T contexts if a plugin contains any of the following strings:
 nt_only_datakind = ('_he', '_nv', 'aqmon', 'veto_intervals')
 
 ##

--- a/straxen/plugins/x1t_cuts.py
+++ b/straxen/plugins/x1t_cuts.py
@@ -216,7 +216,7 @@ class S1LowEnergyRange(strax.CutPlugin):
 
 
 class SR1Cuts(strax.MergeOnlyPlugin):
-    depends_on = ['fiducial_cylinder_1t', 'cut_s1_max_pmt', 'cut_s1_low_energy_range']
+    depends_on = ['cut_fiducial_cylinder_1t', 'cut_s1_max_pmt', 'cut_s1_low_energy_range']
     save_when = strax.SaveWhen.ALWAYS
 
 

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -1,0 +1,60 @@
+"""For all of the context, do a quick check to see that we are able to search
+a field (i.e. can build the dependencies in the context correctly)"""
+from straxen.contexts import *
+
+
+def import_wfsim():
+    try:
+        import wfsim
+        return True
+    except ImportError:
+        # We cannot test the wfsim as it is not installed.
+        return False
+
+##
+# XENONnT
+##
+
+
+def test_xenonnt_online():
+    st = xenonnt_online(_database_init=False)
+    st.search_field('time')
+
+
+def test_xenonnt_led():
+    st = xenonnt_led(_database_init=False)
+    st.search_field('time')
+
+
+def xenon_xenonnt_simulation():
+    if import_wfsim():
+        st = xenonnt_simulation()
+        st.search_field('time')
+
+
+##
+# XENON1T
+##
+
+def test_xenon1t_dali():
+    st = xenon1t_dali()
+    st.search_field('time')
+
+
+def test_demo():
+    st = demo()
+    st.search_field('time')
+
+def test_fake_daq():
+    st = fake_daq()
+    st.search_field('time')
+
+
+def test_xenon1t_led():
+    st = xenon1t_led()
+    st.search_field('time')
+
+def xenon_xenon1t_simulation():
+    if import_wfsim():
+        st = xenon1t_simulation()
+        st.search_field('time')

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -1,5 +1,6 @@
 """For all of the context, do a quick check to see that we are able to search
-a field (i.e. can build the dependencies in the context correctly)"""
+a field (i.e. can build the dependencies in the context correctly)
+See issue #233 and PR #236"""
 from straxen.contexts import *
 
 

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -4,6 +4,8 @@ from straxen.contexts import *
 
 
 def import_wfsim():
+    """Check if we can test the wfsim-related contexts. This is not the case
+    for e.g. travis checks as we don't install wfsim by default."""
     try:
         import wfsim
         return True
@@ -45,6 +47,7 @@ def test_demo():
     st = demo()
     st.search_field('time')
 
+
 def test_fake_daq():
     st = fake_daq()
     st.search_field('time')
@@ -53,6 +56,7 @@ def test_fake_daq():
 def test_xenon1t_led():
     st = xenon1t_led()
     st.search_field('time')
+
 
 def xenon_xenon1t_simulation():
     if import_wfsim():

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -126,6 +126,8 @@ def test_1T(ncores=1):
     # Register the 1T plugins for this test as well
     st.register_all(straxen.plugins.x1t_cuts)
     _run_plugins(st, make_all=False, max_wokers=ncores)
+    # Test issue #233
+    st.search_field('cs1')
     print(st.context_config)
 
 
@@ -135,6 +137,8 @@ def test_nT(ncores=1):
     st = straxen.contexts.xenonnt_online(_database_init=False)
     _update_context(st, ncores)
     _run_plugins(st, make_all=True, max_wokers=ncores)
+    # Test issue #233
+    st.search_field('cs1')
     print(st.context_config)
 
 
@@ -142,7 +146,8 @@ def test_nT_mutlticore():
     print('nT multicore')
     test_nT(2)
 
-
-def test_1T_mutlticore():
-    print('1T multicore')
-    test_1T(2)
+# Disable the test below as it saves some time in travis and gives limited new
+# information as most development is on nT-plugins.
+# def test_1T_mutlticore():
+#     print('1T multicore')
+#     test_1T(2)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
See https://github.com/XENONnT/straxen/issues/233

The problem is that there were plugins in the 1T contexts that were depending on data-kinds that were not provided by the RecordsFromPax.

I considered fixing the `register_all` in the common_opts and registering all the 'nT' datakinds by hand (as we do with the DAQreader). However, as we need to do this anyway because of the High Energy plugins, I opted for removing it from the 1T contexts.



**Edit 12-10**
In the end I decided it's cleaner to do d5e2007 where I split out the nT only files like the neutron-veto associated plugins. I do keep the function `strip_nt_plugins` as the peaks/peakltes/pulses-processing are in the same files as their High Energy counterparts. Here I now rely on our naming convention to keep the plugins with `provides == *_he` out of the 1T contexts.
