### PR TITLE
check lineage hash for rucio

### DIFF
--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -165,17 +165,25 @@ class RunDB(strax.StorageFrontend):
             dq = {
                 'data': {
                     '$elemMatch': {
+                        # TODO can we query smart on the lineage_hash?
                         'type': key.data_type,
                         'protocol': 'rucio'}}}
             doc = self.collection.find_one({**run_query, **dq},
                                            projection=dq)
             if doc is not None:
                 datum = doc['data'][0]
-                return datum['protocol'], str(key.run_id) + '-' + datum['did'].split(':')[1]
-        
+                _type, _lineage_hash = datum['did'].split(':')[1].split('-')
+                if _lineage_hash == key.lineage_hash:
+                    backend_name, backend_key = datum['protocol'], f'{key.run_id}-{_type}-{_lineage_hash}'
+                    return backend_name, backend_key
+                else:
+                    # We don't have it stored in rucio, perhaps we have it in
+                    # our output-path? Explicit pass->look elsewhere.
+                    pass
+
         dq = self._data_query(key)
         doc = self.collection.find_one({**run_query, **dq},
-                                      projection=dq)
+                                       projection=dq)
 
         if doc is None:
             # Data was not found


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Fix rucio backend to check for the lineage hash. Fix https://github.com/XENONnT/straxen/issues/227

**Can you briefly describe how it works?**
We were not looking for the lineage hash. As such, rucio was eager to claim to have data it did not have.

**Can you give a minimal working example (or illustrate with a figure)?**
```
import straxen
st = straxen.contexts.xenonnt_online()
print(st.is_stored('009149','peak_basics'))
st.set_config(dict(s1_max_rise_time=50000,
                  peak_split_filter_wing_width=1000000))
print(st.is_stored('009149','peak_basics'))
```
 