### PR TITLE
Readonly vs read_only typo in onlinemonitor

### DIFF
--- a/straxen/online_monitor.py
+++ b/straxen/online_monitor.py
@@ -18,7 +18,7 @@ class OnlineMonitor(MongoFrontend):
                  take_only=None,
                  database=default_mongo_dbname,
                  col_name=default_online_collection,
-                 read_only=True,
+                 readonly=True,
                  *args, **kwargs):
         if take_only is None:
             raise ValueError(f'Specify which data_types to accept! Otherwise '
@@ -32,4 +32,4 @@ class OnlineMonitor(MongoFrontend):
                          take_only=take_only,
                          col_name=col_name,
                          *args, **kwargs)
-        self.readonly = read_only
+        self.readonly = readonly


### PR DESCRIPTION
Strax uses `readonly` not `read_only` let's make it so in the online monitor backend