### PR TITLE
Do save peaks

### DIFF
--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -437,14 +437,12 @@ class MergedS2sHighEnergy(MergedS2s):
 class Peaks(strax.Plugin):
     """
     Merge peaklets and merged S2s such that we obtain our peaks
-    (replacing all peaklets that were later re-merged as S2s). As this
-    step is computationally trivial, never save this plugin.
+    (replacing all peaklets that were later re-merged as S2s).
     """
     depends_on = ('peaklets', 'peaklet_classification', 'merged_s2s')
     data_kind = 'peaks'
     provides = 'peaks'
     parallel = True
-    save_when = strax.SaveWhen.NEVER
 
     __version__ = '0.1.1'
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -95,8 +95,8 @@ def _run_plugins(st,
                                  **proces_kwargs)
 
                     # Check for types that we want to save that they are stored.
-                    if (int(st._plugin_class_registry['peaks'].save_when) >
-                            int(strax.SaveWhen.TARGET)):
+                    if (int(st._plugin_class_registry[p].save_when) > int(
+                            strax.SaveWhen.TARGET)):
                         is_stored = st.is_stored(run_id, p)
                         assert is_stored, f"{p} did not save correctly!"
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Fix long outstanding issue https://github.com/XENONnT/straxen/issues/149

Don't be fooled by the simple appearance of this PR, it's been keeping me awake at night.

**Can you briefly describe how it works?**
So peaks is never saved, therefore the time-selection in the peak-plotting is tricky. Each of the plugins may have info that are distributed among asynchronous chunks. Therefore the simple operation of making a wf plot becomes hard. I therefore propose to remove this, there is storage-wise little sound argumentation for this as we are already 10 x smaller at peaks than at peaklets.

I think we should save our self the trouble and just store it.

**How to replicate**
I just ran the wf plot as in #149 just untill I hit this error, run the following two commands and you will see that you are now able to actually plot the wf:
```python
straxen.plugins.Peaks.save_when = strax.SaveWhen.ALWAYS 
st.make(run_id, 'peaks')
# where time_range=(9343216270, 9343224420) is a time range in simulated data 
# where from I figured out that I could run into this bug
st.plot_peaks(run_id,time_range=(9343216270, 9343224420)) 
```