### PR TITLE
thread out queries for multiple corrections in CMT

### DIFF
--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -5,6 +5,7 @@ import pymongo
 import numpy as np
 from warnings import warn
 from functools import lru_cache
+from threading import Thread
 
 import strax
 import straxen
@@ -83,7 +84,8 @@ class CorrectionsManagementServices():
     #  entry for e.g. for super runs
     # cache results, this would help when looking at the same gains
     @lru_cache(maxsize=None)
-    def _get_correction(self, run_id, correction, global_version):
+    def _get_correction(self, run_id, correction, global_version,
+                        correction_dtype=np.float64):
         """
         Smart logic to get correction from DB
         :param run_id: run id from runDB
@@ -95,13 +97,31 @@ class CorrectionsManagementServices():
         df_global = self.interface.read('global' if self.is_nt else 'global_xenon1t')
 
         try:
-            values = []
-            for it_correction, version in df_global.iloc[-1][global_version].items():
-                if correction in it_correction:
-                    df = self.interface.read(it_correction)
-                    df = self.interface.interpolate(df, when)
-                    values.append(df.loc[df.index == when, version].values[0])
-            corrections = np.asarray(values)
+            items = df_global.iloc[-1][global_version].items()
+            # Remove all corrections that do not contain the string
+            # correction (e.g. 'pmt' in 'pmt_209_gain_xenon1t')
+            items = [(k, v) for (k, v) in items if correction in k]
+
+            if len(items) == 1:
+                # For a single item we don't use multi-threading.
+                value_buffer = np.asarray([self._read_and_interpolate(*items[0], when)])
+            else:
+                # Let's thread out multiple queries. Each of the threads
+                # fills it's associated index in the buffer.
+                value_buffer = np.zeros(len(items), dtype=correction_dtype)
+                threads = []
+                for c_idx, (it_correction, version) in enumerate(items):
+                    t = Thread(target=self._read_and_interpolate,
+                               args=(it_correction, version,  when),
+                               kwargs=dict(buffer=value_buffer,
+                                           buffer_idx=c_idx),
+                               name=f'get_{it_correction}_{version}',)
+                    t.start()
+                    threads.append(t)
+                # Wait for all of the threads to finish
+                [t.join() for t in threads]
+            # just making the correction explicit here
+            corrections = value_buffer
         except KeyError:
             raise ValueError(f'Global version {global_version} not found for correction {correction}')
 
@@ -111,12 +131,32 @@ class CorrectionsManagementServices():
         else:
             return corrections
 
+    def _read_and_interpolate(self, it_correction, version,  when, buffer=None, buffer_idx = None):
+        """
+
+        :param it_correction: correction item e.g. pmt_209_gain_xenon1t
+        :param version: version of correction e.g. ONLINE or v1
+        :param when: datetime object at which to interpolate
+        :param buffer: optional, if provided will fill value at buffer_idx
+        :param buffer_idx: index where tho store result in the buffer
+        :return: single value (if no buffer is specified, if there is a
+        buffer, fill it).
+        """
+        df = self.interface.read(it_correction)
+        df = self.interface.interpolate(df, when)
+        if buffer is None:
+            return df.loc[df.index == when, version].values[0]
+        elif buffer_idx is not None:
+            buffer[buffer_idx] = (df.loc[df.index == when, version].values[0])
+        else:
+            raise ValueError('Provided "buffer" but no "buffer_idx" to fill at')
+
     def get_elife(self, run_id, model_type, global_version):
         """
         Smart logic to return electron lifetime correction
         :param run_id: run id from runDB
         :param model_type: choose either elife_model or elife_constant
-        :param global_version: global version, or float (if model_type == elife_constant) 
+        :param global_version: global version, or float (if model_type == elife_constant)
         :return: electron lifetime correction value
         """
         if model_type == 'elife_model':


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
On some machines with no direct access to the corrections database, loading the PMT gains might take a while with the CMT.
This PR is inspired by @jmosbacher 's idea on slac.

**Can you briefly describe how it works?**
For each of the values that CMT  loads that is cast into an array, make a different tread to load the value from the correction.

**Can you give a minimal working example (or illustrate with a figure)?**
Below I give the exemplary speed improvement I achieve on my own laptop.
```python
corrections = straxen.CorrectionsManagementServices(is_nt=True)
def get_to_pe(run_id, gain_model = ("CMT_model", ("to_pe_model", "ONLINE")), ntpc_pmts = 494):
    model_type, model_conf = gain_model
    to_pe = corrections.get_corrections_config(run_id, 'pmt_gains', model_conf)
    return to_pe
%%time
get_to_pe('008658')
```
Takes before: Wall time: Wall time: 3min 13s
Takes after this PR: Wall time: 8.82 s

_Edit_
On dali the time difference is much smaller:
Wall time: 8.3 s (not-threaded) vs. Wall time: 5.01 s (threaded)

_Edit2_
I also tested it on the event builders (much more important than my laptop)
Wall time: 2min 19s (not-threaded) vs. Wall time: 14.1 s (threaded)
