### PR TITLE
Use more realistic range for area vs width

### DIFF
--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -14,7 +14,7 @@ export, __all__ = strax.exporter()
              'NB: this is a 2D histogram'),
     strax.Option(
         'area_vs_width_bounds',
-        type=tuple, default=((0, 6), (0, 6)),
+        type=tuple, default=((0, 5), (0, 5)),
         help='Boundaries of log-log histogram of area vs width'),
     strax.Option(
         'area_vs_width_min_gap',


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In the OM, we are using quite a large log-log area-width range. We don't expect many 1^6 PE ms long peaks. Therefore, drop one order of magnitude 

**Note to reviewer**
If you approve, please let me merge it such that I can also add it to the eventbuilders.
