### PR TITLE
Context-changes

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -103,8 +103,7 @@ def xenonnt_online(output_folder='./strax_data',
         st.storage += [straxen.OnlineMonitor(
             readonly=not we_are_the_daq,
             take_only=('veto_intervals',
-                       'online_peak_monitor',
-                       'online_veto_monitor',))]
+                       'online_monitor',))]
 
     # Remap the data if it is before channel swap (because of wrongly cabled
     # signal cable connectors) These are runs older than run 8797. Runs

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -40,7 +40,10 @@ xnt_common_config = dict(
         nveto=(2000, 2119),
         nveto_blank=(2999, 2999)),
     nn_architecture=straxen.aux_repo + 'f0df03e1f45b5bdd9be364c5caefdaf3c74e044e/fax_files/mlp_model.json',
-    nn_weights=straxen.aux_repo + 'f0df03e1f45b5bdd9be364c5caefdaf3c74e044e/fax_files/mlp_model.h5', )
+    nn_weights=straxen.aux_repo + 'f0df03e1f45b5bdd9be364c5caefdaf3c74e044e/fax_files/mlp_model.h5', 
+    # Clustering/classification parameters
+    s1_max_rise_time=100,
+)
 
 # Plugins in these files have nT plugins, E.g. in pulse&peak(let)
 # processing there are plugins for High Energy plugins. Therefore do not


### PR DESCRIPTION
**S1-risetime**
Change `s1_max_rise_time` from `60` to `100` 

_why_
Based on the notes by @BarbaraPa and @jingqiangye:
https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:analysis:waveforms_team:20201112#featured_notes

We see that a rise-time of 82 ns would be optimal. As discussed today, we see that the simulator used might be slightly underestimating the rise time. To be on the safe side, we may increase it some more. The black population in figure 1:
https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:barbara:xenonnt:finetuning will not be affecting the classification much.

**online monitor**
Instead of writing online_peak_monitor and veto_intervals separately, write them together in the online_monitor.

I will change scripts where needed