### PR TITLE
add conditions to avoid zero division

### DIFF
--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -88,7 +88,7 @@ class Peaklets(strax.Plugin):
     parallel = 'process'
     compressor = 'zstd'
 
-    __version__ = '0.3.6'
+    __version__ = '0.3.7'
 
     def infer_dtype(self):
         return dict(peaklets=strax.peak_dtype(


### PR DESCRIPTION
Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible

**What is the problem / what does the code in this PR do**
Encountered zero division during desaturation

**Can you briefly describe how it works?**
The `min_reference_length` should be checking on the number of samples exceeding 1 PE with the reference region. And both the saturated pulse and the summed wf model should be checked.