### PR TITLE
Use GitHub Actions to update context collection

### DIFF
--- a/.github/scripts/create-utilix-config.sh
+++ b/.github/scripts/create-utilix-config.sh
@@ -6,3 +6,4 @@ rundb_api_url = $RUNDB_API_URL
 rundb_api_user = $RUNDB_API_USER
 rundb_api_password = $RUNDB_API_PASSWORD
 EOF
+

--- a/.github/scripts/create-utilix-config.sh
+++ b/.github/scripts/create-utilix-config.sh
@@ -5,5 +5,9 @@ cat > $HOME/.xenon_config <<EOF
 rundb_api_url = $RUNDB_API_URL
 rundb_api_user = $RUNDB_API_USER
 rundb_api_password = $RUNDB_API_PASSWORD
+pymongo_url = $PYMONGO_URL
+pymongo_user = $PYMONGO_USER
+pymongo_password = $PYMONGO_PASSWORD
+pymongo_database = $PYMONGO_DATABASE
 EOF
 

--- a/.github/scripts/install_straxen.sh
+++ b/.github/scripts/install_straxen.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
 cd straxen/straxen
-ls
-
 python setup.py install
-
 cd ~

--- a/.github/scripts/install_straxen.sh
+++ b/.github/scripts/install_straxen.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
-cd straxen
+cd straxen/straxen
+ls
+
 python setup.py install
+
+cd ~

--- a/.github/scripts/install_straxen.sh
+++ b/.github/scripts/install_straxen.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd straxen
+python setup.py install

--- a/.github/scripts/update-context-collection.py
+++ b/.github/scripts/update-context-collection.py
@@ -1,3 +1,5 @@
+import strax
+import straxen
 from straxen.contexts import *
 from utilix import db
 import datetime

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -22,6 +22,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Install python dependencies
       uses: py-actions/py-dependency-install@v2
+    - name: Install straxen
+      run: bash .github/scripts/install_straxen.sh
     # writes a utilix configuration file. Uses the secret functionality of GitHub.
     - name: Write utilix config
       run: | 

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -32,6 +32,10 @@ jobs:
         RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
         RUNDB_API_USER: ${{ secrets.RUNDB_API_USER }}
         RUNDB_API_PASSWORD: ${{ secrets.RUNDB_API_PASSWORD }}
+	PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
+	PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
+	PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
+	PYMONGO_DATABSE: ${{ secrets.PYMONGO_DATABASE }}
     - name: Update context
       run: |
            python .github/scripts/update-context-collection.py

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -35,7 +35,7 @@ jobs:
         PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
         PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
         PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
-        PYMONGO_DATABSE: ${{ secrets.PYMONGO_DATABASE }}
+        PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
     - name: Update context
       run: |
            python .github/scripts/update-context-collection.py

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -36,7 +36,6 @@ jobs:
         PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
         PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
         PYMONGO_DATABSE: ${{ secrets.PYMONGO_DATABASE }}
-	
     - name: Update context
       run: |
            python .github/scripts/update-context-collection.py

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -6,8 +6,9 @@ name: Update context collection
 
 # Trigger this code when a new release is published
 on:
+  workflow_dispatch:
   release:
-    types: [published]
+    types: [created]
  
 jobs:
   update:

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -32,10 +32,11 @@ jobs:
         RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
         RUNDB_API_USER: ${{ secrets.RUNDB_API_USER }}
         RUNDB_API_PASSWORD: ${{ secrets.RUNDB_API_PASSWORD }}
-	PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
-	PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
-	PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
-	PYMONGO_DATABSE: ${{ secrets.PYMONGO_DATABASE }}
+        PYMONGO_URL: ${{ secrets.PYMONGO_URL }}
+        PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
+        PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
+        PYMONGO_DATABSE: ${{ secrets.PYMONGO_DATABASE }}
+	
     - name: Update context
       run: |
            python .github/scripts/update-context-collection.py


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Straxen is updated frequently, but Evan has not been good about updating the context collection so that tools like `admix-download` work properly. This PR automates the update of the context collection so that it happens whenever there is a new straxen release. There is also a button for dispatching the workflow manually.

**Can you briefly describe how it works?**
Github Actions is a competitor of Travis CI, allowing for automating of a variety of tests and other tasks. Actions is nice because you can attach encrypted "secrets" to your repo that can then be accessed while the workflow is running. In our case, we include runDB information as a secret so that our job can update the context collection, while keeping the sensitive info private. 

**Can you give a minimal working example (or illustrate with a figure)?**
No -- I have not found a way to debug these actions without just trying it. I tested it on my personal fork and it works for manual dispatch. We should test it more when we have another straxen release. 

This should address #280. 

Github Actions (though not this PR) may also be a solution for #277 if we moved  away from Travis, though it sounds like there might be options within Travis as well (Chris knows more).

