### PR TITLE
remove to_pe_constant option from CMT

### DIFF
--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -145,9 +145,6 @@ class CorrectionsManagementServices():
         else:
             raise ValueError(f'model type {model_type} not implemented for electron lifetime')
 
-    # TODO create a propper dict for 'to_pe_constant' and 'global_version' as
-    #  the 'global_version' is not a version but an array/float for
-    #  model_type = 'to_pe_constant'
     def get_pmt_gains(self, run_id, model_type, global_version, gain_dtype = np.float32):
         """
         Smart logic to return pmt gains to PE values.
@@ -167,24 +164,6 @@ class CorrectionsManagementServices():
                         f' for {run_id} in the gain model with version '
                         f'{global_version}, please set constant values for '
                         f'{run_id}')
-
-        elif model_type == 'to_pe_constant':
-            n_tpc_pmts = straxen.n_tpc_pmts
-            if not self.is_nt:
-                # TODO can we prevent these kind of hard codes using the context?
-                n_tpc_pmts = straxen.contexts.x1t_common_config['n_tpc_pmts']
-
-            if not isinstance(global_version, (float, np.ndarray, int)):
-                raise ValueError(f'User must specify a model type {model_type} '
-                                 f'and provide a float/array to be used. Got: '
-                                 f'{type(global_version)}')
-
-            # Generate an array of values and multiply by the 'global_version'
-            to_pe = np.ones(n_tpc_pmts, dtype=gain_dtype) * global_version
-            if len(to_pe) != n_tpc_pmts:
-                raise ValueError(f'to_pe length does not match {n_tpc_pmts}. '
-                                 f'Check that {global_version} is either of '
-                                 f'length {n_tpc_pmts} or a float')
 
         else:
             raise ValueError(f'{model_type} not implemented for to_pe values')

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -149,9 +149,8 @@ class CorrectionsManagementServices():
         """
         Smart logic to return pmt gains to PE values.
         :param run_id: run id from runDB
-        :param model_type: Choose either to_pe_model or to_pe_constant
-        :param global_version: global version or a constant value or an array (if
-        model_type == to_pe_constant)
+        :param model_type: to_pe_model (gain model)
+        :param global_version: global version
         :param gain_dtype: dtype of the gains to be returned as array
         :return: array of pmt gains to PE values
         """

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -49,8 +49,6 @@ def get_to_pe(run_id, gain_model, n_tpc_pmts):
         to_pe = x[run_index[0]]['to_pe']
 
     elif model_type == 'to_pe_constant':
-        warn("to_pe_constant_run will be replaced by CorrectionsManagementSevices",
-             DeprecationWarning, 2)
         if model_conf in FIXED_TO_PE:
             return FIXED_TO_PE[model_conf]
 
@@ -69,7 +67,7 @@ def get_to_pe(run_id, gain_model, n_tpc_pmts):
 
 FIXED_TO_PE = {
     # just some dummy placeholder for nT gains
-    'gain_placeholder': np.repeat(0.001, 494)
+    'gain_placeholder': np.repeat(0.0085, 494)
 }
 
 @export

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -52,9 +52,12 @@ def get_to_pe(run_id, gain_model, n_tpc_pmts):
         if model_conf in FIXED_TO_PE:
             return FIXED_TO_PE[model_conf]
 
-        # Uniform gain, specified as a to_pe factor
-        to_pe = np.ones(n_tpc_pmts, dtype=np.float32) * model_conf
-
+        try:
+            # Uniform gain, specified as a to_pe factor
+            to_pe = np.ones(n_tpc_pmts, dtype=np.float32) * model_conf
+        except np.core._exceptions.UFuncTypeError as e:
+            raise(str(e) +
+                  f'\nTried multiplying by {model_conf}. Insert a number instead.')
     else:
         raise NotImplementedError(f"Gain model type {model_type} not implemented")
 

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -70,7 +70,7 @@ def get_to_pe(run_id, gain_model, n_tpc_pmts):
 
 FIXED_TO_PE = {
     # just some dummy placeholder for nT gains
-    'gain_placeholder': np.repeat(0.0085, 494)
+    'gain_placeholder': np.repeat(0.0085, straxen.n_tpc_pmts)
 }
 
 @export


### PR DESCRIPTION
Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible

**What is the problem / what does the code in this PR do**
The option `st.set_config(dict(gain_model=('CMT_model',("to_pe_constant",my_gains ))))` throws an error `InvalidDocument: cannot encode object: array()`, the reason is straxen does not support arrays as option for the metadata, therefore this option should be removed from CMT <br>
**Can you briefly describe how it works?**
see this example https://github.com/ahiguera-mx/xenon/blob/master/Remove_to_pe_constant_from_CMT.ipynb
**Can you give a minimal working example (or illustrate with a figure)?**
see this example https://github.com/ahiguera-mx/xenon/blob/master/Remove_to_pe_constant_from_CMT.ipynb

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
