### PR TITLE
cache CMT values

### DIFF
--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -140,9 +140,6 @@ class CorrectionsManagementServices():
         else:
             raise ValueError(f'model type {model_type} not implemented for electron lifetime')
 
-    # TODO create a propper dict for 'to_pe_constant' and 'global_version' as
-    #  the 'global_version' is not a version but an array/float for
-    #  model_type = 'to_pe_constant'
     def get_pmt_gains(self, run_id, model_type, global_version,
                       cacheable_versions=('ONLINE',),
                       gain_dtype=np.float32):
@@ -151,7 +148,8 @@ class CorrectionsManagementServices():
         :param run_id: run id from runDB
         :param model_type: to_pe_model (gain model)
         :param global_version: global version
-        :param cacheable_versions: versions that are allowed to be cached in ./resource_cache
+        :param cacheable_versions: versions that are allowed to be
+        cached in ./resource_cache
         :param gain_dtype: dtype of the gains to be returned as array
         :return: array of pmt gains to PE values
         """

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -7,6 +7,7 @@ import configparser
 import strax
 import straxen
 from straxen import uconfig
+import os
 
 export, __all__ = strax.exporter()
 
@@ -148,18 +149,35 @@ class CorrectionsManagementServices():
     # TODO create a propper dict for 'to_pe_constant' and 'global_version' as
     #  the 'global_version' is not a version but an array/float for
     #  model_type = 'to_pe_constant'
-    def get_pmt_gains(self, run_id, model_type, global_version, gain_dtype = np.float32):
+    def get_pmt_gains(self, run_id, model_type, global_version,
+                      cacheable_versions=('ONLINE',),
+                      gain_dtype=np.float32):
         """
         Smart logic to return pmt gains to PE values.
         :param run_id: run id from runDB
         :param model_type: Choose either to_pe_model or to_pe_constant
         :param global_version: global version or a constant value or an array (if
         model_type == to_pe_constant)
+        :param cacheable_versions: versions that are allowed to be cashed in ./resource_cache
         :param gain_dtype: dtype of the gains to be returned as array
         :return: array of pmt gains to PE values
         """
+        to_pe = None
+        cache_name = None
+
         if model_type == 'to_pe_model':
-            to_pe = self._get_correction(run_id, 'pmt', global_version)
+            if global_version in cacheable_versions:
+                # Try to load from cache, if it does not exist it will be created below
+                cache_name = cacheable_naming(run_id, model_type, global_version)
+                try:
+                    to_pe = straxen.get_resource(cache_name, fmt='npy')
+                    print(f'using {cache_name}')
+                except (ValueError, FileNotFoundError):
+                    pass
+
+            if to_pe is None:
+                to_pe = self._get_correction(run_id, 'pmt', global_version)
+
             # be cautious with very early runs, check that not all are None
             if np.isnan(to_pe).all():
                 raise ValueError(
@@ -200,6 +218,14 @@ class CorrectionsManagementServices():
             raise GainsNotFoundError(
                 f'Gains returned by CMT are None for PMT_i = {pmts_affected}. '
                 f'Cannot proceed with processing. Report to CMT-maintainers.')
+
+        if (cache_name is not None
+                and global_version in cacheable_versions
+                and not os.path.exists(cache_name)):
+            # This is an array we can save since it's in the cacheable
+            # versions but it has not been saved yet. Next time we need
+            # it, we can get it from our cache.
+            np.save(cache_name, to_pe, allow_pickle=False)
         return to_pe
 
     def get_lce(self, run_id, s, position, global_version='v1'):
@@ -240,6 +266,19 @@ class CorrectionsManagementServices():
             raise ValueError(f'run_id = {run_id} not found')
         time = rundoc['start']
         return time.replace(tzinfo=pytz.utc)
+
+
+def cacheable_naming(*args, format='.npy', base='./resource_cache/'):
+    """Convert args to consistent naming convention for array to be cashed"""
+    if not os.path.exists(base):
+        try:
+            os.mkdir(base)
+        except (FileExistsError, PermissionError):
+            pass
+    for arg in args:
+        if not type(arg) == str:
+            raise TypeError(f'One or more args of {args} are not strings')
+    return base + '_'.join(args) + format
 
 
 class GainsNotFoundError(Exception):

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -158,7 +158,7 @@ class CorrectionsManagementServices():
         :param model_type: Choose either to_pe_model or to_pe_constant
         :param global_version: global version or a constant value or an array (if
         model_type == to_pe_constant)
-        :param cacheable_versions: versions that are allowed to be cashed in ./resource_cache
+        :param cacheable_versions: versions that are allowed to be cached in ./resource_cache
         :param gain_dtype: dtype of the gains to be returned as array
         :return: array of pmt gains to PE values
         """
@@ -171,7 +171,6 @@ class CorrectionsManagementServices():
                 cache_name = cacheable_naming(run_id, model_type, global_version)
                 try:
                     to_pe = straxen.get_resource(cache_name, fmt='npy')
-                    print(f'using {cache_name}')
                 except (ValueError, FileNotFoundError):
                     pass
 
@@ -269,7 +268,7 @@ class CorrectionsManagementServices():
 
 
 def cacheable_naming(*args, format='.npy', base='./resource_cache/'):
-    """Convert args to consistent naming convention for array to be cashed"""
+    """Convert args to consistent naming convention for array to be cached"""
     if not os.path.exists(base):
         try:
             os.mkdir(base)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Store the CMT values in ./resource_cache for specific versions in CMT.

**Can you briefly describe how it works?**
Just run CMT, the first time it will do like normally, the next time it will just load

**Why/how long do we need this**
Outside of dali CMT-gains take a long time to load. If you are developing straxen (like me) and need to reprocess peaklets, this becomes a bottleneck. This might be an interim solution until CMT experts get a nice aggregation working.

