### PR TITLE
Update contexts.py

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -138,6 +138,7 @@ def xenonnt_simulation(output_folder='./strax_data'):
         storage=strax.DataDirectory(output_folder),
         config=dict(detector='XENONnT',
                     fax_config=straxen.aux_repo + '4e71b8a2446af772c83a8600adc77c0c3b7e54d1/fax_files/fax_config_nt.json',
+                    check_raw_record_overlaps=False,
                     **straxen.contexts.xnt_common_config,
                     ),
         **straxen.contexts.common_opts)
@@ -280,6 +281,7 @@ def xenon1t_simulation(output_folder='./strax_data'):
         config=dict(
             fax_config=straxen.aux_repo + '1c5793b7d6c1fdb7f99a67926ee3c16dd3aa944f/fax_files/fax_config_1t.json',
             detector='XENON1T',
+            check_raw_record_overlaps=False,
             **straxen.contexts.x1t_common_config),
         **straxen.contexts.common_opts)
     st.register(wfsim.RawRecordsFromFax1T)


### PR DESCRIPTION
This pull requests:
  *Adds a needed configuration value to skip checking overlapping raw records in the simulation contexts. This is needed from waveform simulation

Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible

**What is the problem / what does the code in this PR do**
Wfsim does not know what pulses are generated by previous instructions. For example an S2 can cause a afterpulse to be generated before the S2 is fully finished. The afterpulse does not know the S2 happened since the data is already written out.
So we can get two records from the same channel who overlap

This skips the check if overlapping records are generated

