### PR TITLE
use utilix for client

### DIFF
--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -7,7 +7,7 @@ import configparser
 import strax
 import straxen
 from straxen import uconfig
-
+import utilix
 export, __all__ = strax.exporter()
 
 
@@ -29,34 +29,26 @@ class CorrectionsManagementServices():
         :param password: DB password
         :param is_nt: bool if True we are looking at nT if False we are looking at 1T
         """
-        # TODO avoid duplicated code with the RunDB.py?
-        # Basic setup
-        if username is not None:
-            self.username = username
-        else:
-            self.username = uconfig.get('RunDB', 'pymongo_user')
-        if password is not None:
-            self.password = password
-        else:
-            self.password = uconfig.get('RunDB', 'pymongo_password')
 
-        if mongo_url is None:
-            mongo_url = uconfig.get('RunDB', 'pymongo_url')
+        mongo_kwargs = {'url': mongo_url,
+                        'user': username,
+                        'password': password,
+                        'database': 'corrections'}
+        corrections_collection = utilix.rundb.pymongo_collection(**mongo_kwargs)
+
+        # Do not delete the client!
+        self.client = corrections_collection.database.client
 
         # Setup the interface
         self.interface = strax.CorrectionsInterface(
-            host=f'mongodb://{mongo_url}',
-            username=self.username,
-            password=self.password,
+            self.client,
             database_name='corrections')
-        # Use the same client as the CorrectionsInterface
-        client = self.interface.client
 
         self.is_nt = is_nt
         if self.is_nt:
-            self.collection = client['xenonnt']['runs']
+            self.collection = self.client['xenonnt']['runs']
         else:
-            self.collection = client['run']['runs_new']
+            self.collection = self.client['run']['runs_new']
 
     def __str__(self):
         return self.__repr__()

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -3,11 +3,12 @@
 import pytz
 import numpy as np
 from functools import lru_cache
-import configparser
 import strax
-import straxen
-from straxen import uconfig
-import utilix
+try:
+    import utilix
+except (RuntimeError, FileNotFoundError):
+    # We might be on a travis job
+    pass
 export, __all__ = strax.exporter()
 
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
We are getting this error due to the readpreference of the mirrors:
https://xenonnt.slack.com/archives/C016DM0JPK9/p1605866361323700


Therefore we change the way we init the pymongo client for the corrections. NB: the init is now done here, on the `straxen` side (makes more sense to do it in the nT specific package). This PR requires:
https://github.com/AxFoundation/strax/pull/356


**Can you briefly describe how it works?**
Given recent changes (https://github.com/XENONnT/straxen/pull/163), it makes more sense to use a centralized initiation for the pymongo client (i.e. `utilix`). 

**Can you give a minimal working example (or illustrate with a figure)?**
All should work just as before. we now just don't run into https://xenonnt.slack.com/archives/C016DM0JPK9/p1605866361323700.

