### PR TITLE
allow pypi manually

### DIFF
--- a/.github/workflows/pypi_install.yml
+++ b/.github/workflows/pypi_install.yml
@@ -1,0 +1,31 @@
+# Pipy upload straxen manually. NB: Don't do this when it's not needed! This
+# should normally work fine with travis. However, sometimes something goes
+# wrong with travis upon uploading, then it will not continue until the next
+# release is made.
+# Mostly based on https://github.com/marketplace/actions/pypi-publish
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Setup steps
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: pip install wheel
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+      # Do the publish
+      - name: Publish a Python distribution to PyPI
+        # Might want to add but does not work on workflow_dispatch :
+        # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user:  ${{ secrets.token }}
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/pypi_install.yml
+++ b/.github/workflows/pypi_install.yml
@@ -3,6 +3,8 @@
 # wrong with travis upon uploading, then it will not continue until the next
 # release is made.
 # Mostly based on https://github.com/marketplace/actions/pypi-publish
+name: Manual pipy install
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Straxen v0.12.4 has been released but is not in pypi.

This is because there was some error on uploading because travis was failing. Therefore it does not upload a new real ease until we make one. However, there is nothing wrong with this release specifically, there was just some numpy dependency for python 3.6 that was causing issues in strax. Therefore I want to add a knob that allows one to make a release on pypi whenever needed.

As I aready made this available for some other packages (
https://github.com/XENONnT/utilix/blob/master/.github/workflows/Pipi.yml,
https://github.com/XENONnT/pema/blob/main/.github/workflows/pypi_install.yml) and Evan also copied this to admix (https://github.com/XENONnT/admix/blob/master/.github/workflows/Pipi.yml) I think we can safely also add it here.

