### PR TITLE
fix lone hit cut for online monitor

### DIFF
--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -52,7 +52,7 @@ export, __all__ = strax.exporter()
     strax.Option(
         'lone_hits_cut_string',
         type=str,
-        default='(area > 0.2) & (area < 2.0)',
+        default='(area >= 50) & (area <= 250)',
         help='Selection (like selection_str) applied to data for '
              '"lone-hits", cuts should be separated using "&")'),
     strax.Option(
@@ -166,7 +166,8 @@ class OnlinePeakMonitor(strax.Plugin):
         del sel
 
         # -- Lone hit properties --
-        # Make a mask with the cuts
+        # Make a mask with the cuts.
+        # NB: LONE HITS AREA ARE IN ADC!
         mask = self._config_as_selection_str(
             self.config['lone_hits_cut_string'], lone_hits)
         # Now only take lone hits that are separated in time.


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Lone hits area is in ADC

**Can you briefly describe how it works?**
Fix this PR:
https://github.com/XENONnT/straxen/pull/294

I'm opening a new issue to change this