### PR TITLE
n_veto and mu_veto gains into corrections

### DIFF
--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -166,14 +166,14 @@ class CorrectionsManagementServices():
 
             if global_version in cacheable_versions:
                 # Try to load from cache, if it does not exist it will be created below
-                cache_name = cacheable_naming(run_id, model_type, global_version, target_detector)
+                cache_name = cacheable_naming(run_id, model_type, global_versionr)
                 try:
                     to_pe = straxen.get_resource(cache_name, fmt='npy')
                 except (ValueError, FileNotFoundError):
                     pass
 
-                if to_pe is None:
-                    to_pe = self._get_correction(run_id, target_detector, global_version)
+            if to_pe is None:
+                to_pe = self._get_correction(run_id, target_detector, global_version)
 
             # be cautious with very early runs, check that not all are None
             if np.isnan(to_pe).all():

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -35,12 +35,7 @@ def get_to_pe(run_id, gain_model, n_pmts):
         is_nt = n_pmts == straxen.n_tpc_pmts or n_pmts == straxen.n_nveto_pmts or n_pmts == straxen.n_mveto_pmts
 
         corrections = straxen.CorrectionsManagementServices(is_nt=is_nt)
-        if n_pmts == straxen.n_tpc_pmts:
-            to_pe = corrections.get_corrections_config(run_id, 'pmt_gains', model_conf)
-        elif n_pmts == straxen.n_nveto_pmts:
-            to_pe = corrections.get_corrections_config(run_id, 'n_veto_pmt_gains', model_conf)
-        elif n_pmts == straxen.n_mveto_pmts:
-            to_pe = corrections.get_corrections_config(run_id, 'mu_veto_pmt_gains', model_conf)
+        to_pe = corrections.get_corrections_config(run_id, model_conf)
 
         return to_pe
 
@@ -86,6 +81,7 @@ FIXED_TO_PE = {
     'adc_nv': np.ones(straxen.n_nveto_pmts)
 }
 
+
 @export
 def get_elife(run_id, elife_conf):
     if isinstance(elife_conf, tuple) and len(elife_conf) == 3:
@@ -93,8 +89,7 @@ def get_elife(run_id, elife_conf):
         is_nt = elife_conf[-1]
         cmt = straxen.CorrectionsManagementServices(is_nt=is_nt)
 
-        e = cmt.get_corrections_config(run_id, 'elife',
-                                       elife_conf[:2])
+        e = cmt.get_corrections_config(run_id, elife_conf[:2])
 
     elif isinstance(elife_conf, str):
         warn("get_elife will be replaced by CorrectionsManagementSevices",

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -32,10 +32,7 @@ def get_to_pe(run_id, gain_model, n_pmts):
                              '("CMT_model", ("to_pe_model", "v1"). Instead got:'
                              f'{model_conf}')
         # is this the best way to do this?
-        if n_pmts == straxen.n_tpc_pmts or n_pmts == straxen.n_nveto_pmts or n_pmts == straxen.n_mveto_pmts:
-            is_nt = True
-        else:
-            is_nt = False
+        is_nt = n_pmts == straxen.n_tpc_pmts or n_pmts == straxen.n_nveto_pmts or n_pmts == straxen.n_mveto_pmts
 
         corrections = straxen.CorrectionsManagementServices(is_nt=is_nt)
         if n_pmts == straxen.n_tpc_pmts:

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -98,7 +98,7 @@ class Peaklets(strax.Plugin):
     def setup(self):
         self.to_pe = straxen.get_to_pe(self.run_id,
                                        self.config['gain_model'],
-                                       n_tpc_pmts=self.config['n_tpc_pmts'])
+                                       self.config['n_tpc_pmts'])
 
     def compute(self, records, start, end):
         r = records

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -412,7 +412,7 @@ class PeakletsHighEnergy(Peaklets):
     def setup(self):
         self.to_pe = straxen.get_to_pe(self.run_id,
                                        self.config['gain_model'],
-                                       n_tpc_pmts=self.config['n_tpc_pmts'])
+                                       self.config['n_tpc_pmts'])
 
         buffer_pmts = np.zeros(self.config['he_channel_offset'])
         self.to_pe = np.concatenate((buffer_pmts, self.to_pe))

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -142,7 +142,7 @@ class PulseProcessing(strax.Plugin):
         if self.hev_enabled:
             self.to_pe = straxen.get_to_pe(self.run_id,
                                            self.config['hev_gain_model'],
-                                           n_tpc_pmts=self.config['n_tpc_pmts'])
+                                           self.config['n_tpc_pmts'])
         
     def compute(self, raw_records, start, end):
         if self.config['check_raw_record_overlaps']:

--- a/straxen/plugins/veto_hitlets.py
+++ b/straxen/plugins/veto_hitlets.py
@@ -79,7 +79,7 @@ class nVETOHitlets(strax.Plugin):
     def setup(self):
         to_pe = straxen.get_to_pe(self.run_id,
                                   self.config['gain_model_nv'],
-                                  n_tpc_pmts= self.config['n_nveto_pmts'])
+                                  self.config['n_nveto_pmts'])
         self.channel_range = self.config['channel_map']['nveto']
         
         # Create to_pe array of size max channel:
@@ -224,7 +224,7 @@ class muVETOHitlets(nVETOHitlets):
     def setup(self):
         to_pe = straxen.get_to_pe(self.run_id,
                                   self.config['gain_model_mv'],
-                                  n_tpc_pmts=straxen.n_mveto_pmts)
+                                  straxen.n_mveto_pmts)
         self.channel_range = self.config['channel_map']['mv']
         
         # Create to_pe array of size max channel:


### PR DESCRIPTION
Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible

**What is the problem / what does the code in this PR do**
Adding n_veto and mu_veto gains into corrections
**Can you briefly describe how it works?**
We can access the same way as we do for the tpc pmt gains via the function to_pe
**Can you give a minimal working example (or illustrate with a figure)?**
Please look at 
https://github.com/XENONnT/analysiscode/blob/master/corrections/get_gains_for_any_det.ipynb
Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
