### PR TITLE
Faster bootstrax queries for new runs

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -392,7 +392,7 @@ def main_loop():
         # Check resources are still OK, otherwise crash / reboot program
 
         # Process new runs
-        rd = consider_run({"bootstrax.state": {"$exists": False}},
+        rd = consider_run({"bootstrax.state": None},
                           test_counter=new_runs_seen)
         if rd is not None:
             new_runs_seen += 1


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

The `$exists` query operator in MongoDB is slow because it can't be satisfied in the usual `log(n)` time as a standard indexed query. As the runs database continues to grow in size inefficient queries will rapidly get slower and slower. Also, bootstrax should get patched to match https://github.com/coderdj/redax/pull/109

**Can you briefly describe how it works?**

Rather than continue to use slow operators, a minor change in the DB schema allows for more efficient index usage.

This partially implements #269, depending on the scope of changes necessary
