### PR TITLE
Update Pulse processing for baseline handling

### DIFF
--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -34,7 +34,7 @@ class nVETORecorder(strax.Plugin):
     properties for monitoring purposes. Depending on the setting also
     a fixed number of the lone_records per channel are stored.
     """
-    __version__ = '0.0.5'
+    __version__ = '0.0.6'
     parallel = 'process'
 
     rechunk_on_save = True

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -107,7 +107,7 @@ class PulseProcessing(strax.Plugin):
     overlap with any other pulse), or mean values of baseline and
     baseline rms channel.
     """
-    __version__ = '0.2.2'
+    __version__ = '0.2.3'
 
     parallel = 'process'
     rechunk_on_save = immutabledict(

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -31,7 +31,7 @@ class nVETOPulseProcessing(strax.Plugin):
         2. Find hits and apply ZLE
         3. Remove empty fragments.
     """
-    __version__ = '0.0.5'
+    __version__ = '0.0.6'
 
     parallel = 'process'
     rechunk_on_save = False


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
As pointed out by @FaroutYLq, there is a bug in the `baselineing`. If we merge https://github.com/AxFoundation/strax/pull/367, it should be reflected in the PulseProcessing and the functions that use `strax.baseline`.

**Can you briefly describe how it works?**
The baseline was wrongly calculated for record_i > 0 because it was type-cased to an integer. This causes the following behavoir:
![Picture1](https://user-images.githubusercontent.com/22295914/102522358-6c3ad880-4096-11eb-84a1-6d837b37840a.png)


**Why not for acqmon processing**
@AlexElykov may correct me, but I don't think there is any decimal precision dependency of this routine:
https://github.com/XENONnT/straxen/blob/correct_base_line/straxen/plugins/acqmon_processing.py#L36
