### PR TITLE
Reduce n-files/run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ docs/_build
 
 # coverage
 .coverage
+
+# Documentation files
+docs/source/reference/datastructure*

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -88,7 +88,15 @@ class DAQReader(strax.Plugin):
     data_kind = immutabledict(zip(provides, provides))
     depends_on = tuple()
     parallel = 'process'
-    rechunk_on_save = False
+    rechunk_on_save = immutabledict(
+        raw_records=False,
+        raw_records_he=False,
+        raw_records_aqmon=True,
+        raw_records_nv=False,
+        raw_records_aqmon_nv=True,
+        raw_records_aux_mv=True,
+        raw_records_mv=False,
+    )
     compressor = 'lz4'
     __version__ = '0.0.0'
 

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -466,6 +466,7 @@ class EnergyEstimates(strax.Plugin):
         ('e_charge', np.float32, 'Energy in charge signal [keVee]'),
         ('e_ces', np.float32, 'Energy estimate [keVee]')
     ] + strax.time_fields
+    save_when = strax.SaveWhen.TARGET
 
     def compute(self, events):
         el = self.cs1_to_e(events['cs1'])

--- a/straxen/plugins/led_calibration.py
+++ b/straxen/plugins/led_calibration.py
@@ -47,7 +47,8 @@ class LEDCalibration(strax.Plugin):
     data_kind = 'led_cal' 
     compressor = 'zstd'
     parallel = 'process'
-    
+    rechunk_on_save = False
+
     dtype = [('area', np.float32, 'Area averaged in integration windows'),
              ('amplitude_led', np.float32, 'Amplitude in LED window'),
              ('amplitude_noise', np.float32, 'Amplitude in off LED window'),

--- a/straxen/plugins/led_calibration.py
+++ b/straxen/plugins/led_calibration.py
@@ -47,7 +47,7 @@ class LEDCalibration(strax.Plugin):
     data_kind = 'led_cal' 
     compressor = 'zstd'
     parallel = 'process'
-    rechunk_on_save = False
+    rechunk_on_save = True
     
     dtype = [('area', np.float32, 'Area averaged in integration windows'),
              ('amplitude_led', np.float32, 'Amplitude in LED window'),

--- a/straxen/plugins/led_calibration.py
+++ b/straxen/plugins/led_calibration.py
@@ -47,7 +47,6 @@ class LEDCalibration(strax.Plugin):
     data_kind = 'led_cal' 
     compressor = 'zstd'
     parallel = 'process'
-    rechunk_on_save = True
     
     dtype = [('area', np.float32, 'Area averaged in integration windows'),
              ('amplitude_led', np.float32, 'Amplitude in LED window'),

--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -92,6 +92,7 @@ class OnlinePeakMonitor(strax.Plugin):
     # TODO make new datakind:
     # data_kind = 'online_monitor'
     rechunk_on_save = False
+    save_when = strax.SaveWhen.TARGET
 
     def infer_dtype(self):
         n_bins_area_width = self.config['area_vs_width_nbins']

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -412,6 +412,7 @@ class PeakletsHighEnergy(Peaklets):
     data_kind = 'peaklets_he'
     __version__ = '0.0.1'
     child_plugin = True
+    save_when = strax.SaveWhen.TARGET
 
     def infer_dtype(self):
         return strax.peak_dtype(n_channels=self.config['n_he_pmts'])

--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -125,6 +125,7 @@ class PulseProcessing(strax.Plugin):
 
     provides = ('records', 'veto_regions', 'pulse_counts')
     data_kind = {k: k for k in provides}
+    save_when = strax.SaveWhen.TARGET
 
     def infer_dtype(self):
         # Get record_length from the plugin making raw_records
@@ -240,6 +241,7 @@ class PulseProcessingHighEnergy(PulseProcessing):
     depends_on = 'raw_records_he'
     compressor = 'lz4'
     child_plugin = True
+    save_when = strax.SaveWhen.TARGET
 
     def infer_dtype(self):
         dtype = dict()

--- a/tests/test_several.py
+++ b/tests/test_several.py
@@ -60,6 +60,7 @@ def test_several():
             st = straxen.contexts.demo()
             # Ignore strax-internal warnings
             st.set_context_config({'free_options': tuple(st.config.keys())})
+            st.make(test_run_id, 'records')
 
             print("Get peaks")
             p = st.get_array(test_run_id, 'peaks')


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Create less files, store less intermediate data. Here I added some places where we could possibly take some shortcuts.

**Can you briefly describe how it works?**
Be more selective of what we store and what not

**What is the effect**
For an arbitrary short run, I processed which lead to the table below.
- with all the changes in this PR and 
- once with all the changes in this PR **except for PulseProcessing**. This means we would keep `records, pulsecounts, veto_intervals`.

|          | before               | after (saving PulseProcessing)  | after (not saving PulseProcessing) | 
| --      | ----------------- |  --------------------------------  | ------------------------------------  | 
| #files | 1267                 |  757                                           | 585                                                 |
| Total size | 88 GB         | 88 GB                                        | 61 GB                                              | 

**Consensus concerning this PR**
Let's wrap up what is being asked in this PR, we ask if we want to (checkbox should indicate consensus):
- [x] Rechunking raw_records (especially raw_records_aqmon)
- [x] set EnergyEstimates to `SaveWhen.Target` (this is a trivial plugin that just multiplies a handful of numbers)
- [x] Set `PulseProcessing` (records) to  `SaveWhen.Target`
- [x] Set `PulseProcessingHe` (records_he) to `SaveWhen.TARGET`
- [x] Set High energy processing (peaks, peaklets etc) to `SaveWhen.TARGET`

**Data-types (before changes)**
```corrected_areas-cjno725i32
energy_estimates-7ksels3aic
event_basics-jpnilkwbfr
event_info-allwalikwi
event_positions-jqknjp7gio
event_posrec_many-jpnilkwbfr
events-zf5ybclhvk
lone_hits-ioudwhzz4n
merged_s2s_he-zxpiwi3d5z
merged_s2s-4os2w32txl
online_monitor-z74bl33e5e
online_peak_monitor-kyas5n6t74
peak_basics_he-6yfhkyq57x
peak_basics-3k6xvmmrww
peak_positions_cnn-22yx74azrt
peak_positions_gcn-bojdxvz2sw
peak_positions_mlp-kuinlrzhsl
peak_proximity-npglcajfmc
peaklet_classification_he-4hu67ymbkf
peaklet_classification-nnlrqza4wr
peaklets_he-qriha2uzhs
peaklets-ioudwhzz4n
pulse_counts_he-uoteecjda5
pulse_counts-pamvninlop
raw_records_aqmon_nv-rfzvpzj4mf
raw_records_aqmon-rfzvpzj4mf
raw_records_aux_mv-rfzvpzj4mf
raw_records_he-rfzvpzj4mf
raw_records_mv-rfzvpzj4mf
raw_records_nv-rfzvpzj4mf
raw_records-rfzvpzj4mf
records_he-uoteecjda5
records-pamvninlop
veto_intervals-7q35r23nba
veto_regions-pamvninlop
```


