### PR TITLE
Add check for daq-reader processing threads

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1169,10 +1169,10 @@ def manual_fail(*, mongo_id=None, number=None, reason=''):
 # Processing
 ##
 
-def run_strax(run_id, input_dir, targets, n_readout_threads, compressor,
+def run_strax(run_id, input_dir, targets, readout_threads, compressor,
               run_start_time, samples_per_record, cores, max_messages, timeout,
               daq_chunk_duration, daq_overlap_chunk_duration, post_processing,
-              readout_names, debug=False):
+              debug=False):
     # Check mongo connection
     ping_dbs()
     # Clear the swap memory used by npshmmex
@@ -1206,9 +1206,8 @@ def run_strax(run_id, input_dir, targets, n_readout_threads, compressor,
                                 record_length=samples_per_record,
                                 daq_chunk_duration=daq_chunk_duration,
                                 daq_overlap_chunk_duration=daq_overlap_chunk_duration,
-                                n_readout_threads=n_readout_threads,
+                                readout_threads=readout_threads,
                                 check_raw_record_overlaps=False,
-                                thread_names=readout_names,
                                 )
 
             for i, c in enumerate(st.get_iter(run_id,

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -534,7 +534,7 @@ def infer_target(rd):
             _pp = [__pp for __pp in _pp if (_rm_t not in __pp and n_fails < _rm_t_after)]
     if n_fails >= remove_target_after_fails['ALL']:
         _t = 'raw_records'
-        _pp = None
+        _pp = 'raw_records'
         return {'targets': strax.to_str_tuple(_t),
                 'post_processing': strax.to_str_tuple(_pp)}
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1307,7 +1307,7 @@ def process_run(rd, send_heartbeats=args.production):
                             run_id=run_id)
             thread_info = dq_conf.get('processing_threads', dict())
             run_strax_config['n_readout_threads'] = sum([v for v in thread_info.values()])
-            run_strax_config['readout_names'] = strax.to_str_tuple(thread_info.keys())
+            run_strax_config['readout_names'] = strax.to_str_tuple(list(thread_info.keys()))
             run_strax_config['daq_chunk_duration'] = int(dq_conf.get('strax_chunk_length', 5) * 1e9)
             run_strax_config['daq_overlap_chunk_duration'] = int(dq_conf.get('strax_chunk_overlap', 0.5) * 1e9)
             # note that value in rd in bytes hence //2

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1305,9 +1305,7 @@ def process_run(rd, send_heartbeats=args.production):
                             f'{run_id}! Using default values.',
                             priority='warning',
                             run_id=run_id)
-            thread_info = dq_conf.get('processing_threads', dict())
-            run_strax_config['n_readout_threads'] = sum([v for v in thread_info.values()])
-            run_strax_config['readout_names'] = strax.to_str_tuple(list(thread_info.keys()))
+            run_strax_config['readout_threads'] = dq_conf['processing_threads']  # Assume no default
             run_strax_config['daq_chunk_duration'] = int(dq_conf.get('strax_chunk_length', 5) * 1e9)
             run_strax_config['daq_overlap_chunk_duration'] = int(dq_conf.get('strax_chunk_overlap', 0.5) * 1e9)
             # note that value in rd in bytes hence //2

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -73,7 +73,7 @@ what bootstrax is thinking of at the moment.
   - **disk_used**: used part of the disk whereto this bootstrax instance
    is writing to (in percent).
 """
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 import argparse
 from datetime import datetime, timedelta, timezone
@@ -1304,7 +1304,7 @@ def process_run(rd, send_heartbeats=args.production):
                             f'{run_id}! Using default values.',
                             priority='warning',
                             run_id=run_id)
-            run_strax_config['readout_threads'] = dq_conf['processing_threads']  # Assume no default
+            run_strax_config['readout_threads'] = dq_conf.get('processing_threads', None)
             run_strax_config['daq_chunk_duration'] = int(dq_conf.get('strax_chunk_length', 5) * 1e9)
             run_strax_config['daq_overlap_chunk_duration'] = int(dq_conf.get('strax_chunk_overlap', 0.5) * 1e9)
             # note that value in rd in bytes hence //2
@@ -1313,7 +1313,7 @@ def process_run(rd, send_heartbeats=args.production):
         except Exception as e:
             fail(f"Could not find {to_read} in rundoc: {str(e)}")
 
-        if not run_strax_config['n_readout_threads']:
+        if run_strax_config['readout_threads'] is None:
             fail(f"Run doc for {run_id} has no readout thread count info")
 
         # Remove any previous processed data

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1172,7 +1172,7 @@ def manual_fail(*, mongo_id=None, number=None, reason=''):
 def run_strax(run_id, input_dir, targets, n_readout_threads, compressor,
               run_start_time, samples_per_record, cores, max_messages, timeout,
               daq_chunk_duration, daq_overlap_chunk_duration, post_processing,
-              debug=False):
+              readout_names, debug=False):
     # Check mongo connection
     ping_dbs()
     # Clear the swap memory used by npshmmex
@@ -1208,6 +1208,7 @@ def run_strax(run_id, input_dir, targets, n_readout_threads, compressor,
                                 daq_overlap_chunk_duration=daq_overlap_chunk_duration,
                                 n_readout_threads=n_readout_threads,
                                 check_raw_record_overlaps=False,
+                                thread_names=readout_names,
                                 )
 
             for i, c in enumerate(st.get_iter(run_id,
@@ -1306,6 +1307,7 @@ def process_run(rd, send_heartbeats=args.production):
                             run_id=run_id)
             thread_info = dq_conf.get('processing_threads', dict())
             run_strax_config['n_readout_threads'] = sum([v for v in thread_info.values()])
+            run_strax_config['readout_names'] = list(thread_info.keys())
             run_strax_config['daq_chunk_duration'] = int(dq_conf.get('strax_chunk_length', 5) * 1e9)
             run_strax_config['daq_overlap_chunk_duration'] = int(dq_conf.get('strax_chunk_overlap', 0.5) * 1e9)
             # note that value in rd in bytes hence //2

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1307,7 +1307,7 @@ def process_run(rd, send_heartbeats=args.production):
                             run_id=run_id)
             thread_info = dq_conf.get('processing_threads', dict())
             run_strax_config['n_readout_threads'] = sum([v for v in thread_info.values()])
-            run_strax_config['readout_names'] = list(thread_info.keys())
+            run_strax_config['readout_names'] = strax.to_str_tuple(thread_info.keys())
             run_strax_config['daq_chunk_duration'] = int(dq_conf.get('strax_chunk_length', 5) * 1e9)
             run_strax_config['daq_overlap_chunk_duration'] = int(dq_conf.get('strax_chunk_overlap', 0.5) * 1e9)
             # note that value in rd in bytes hence //2

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -102,7 +102,7 @@ class DAQReader(strax.Plugin):
     def setup(self):
         self.t0 = int(self.config['run_start_time']) * int(1e9)
         self.dt_max = self.config['max_digitizer_sampling_time']
-        self.n_readout_treads = sum(self.config['readout_threads'].values())
+        self.n_readout_threads = sum(self.config['readout_threads'].values())
         if (self.config['safe_break_in_pulses']
                 > min(self.config['daq_chunk_duration'],
                       self.config['daq_overlap_chunk_duration'])):
@@ -123,7 +123,7 @@ class DAQReader(strax.Plugin):
         for q in [p + '_pre', p, p + '_post']:
             if os.path.exists(q):
                 n_files = self._count_files_per_chunk(q)
-                if n_files >= self.n_readout_treads:
+                if n_files >= self.n_readout_threads:
                     result.append(q)
                 else:
                     print(f"Found incomplete folder {q}: "
@@ -146,7 +146,7 @@ class DAQReader(strax.Plugin):
     @staticmethod
     def _partial_chunk_to_thread_name(partial_chunk):
         """Convert name of part of the chunk to the thread_name that wrote it"""
-        return '_'.join(partial_chunk.split('_')[-1])
+        return '_'.join(partial_chunk.split('_')[:-1])
 
     def _count_files_per_chunk(self, path_chunk_i):
         """
@@ -168,7 +168,7 @@ class DAQReader(strax.Plugin):
         if not os.path.exists(end_dir):
             return False
         else:
-            return self._count_files_per_chunk(end_dir) >= self.n_readout_treads
+            return self._count_files_per_chunk(end_dir) >= self.n_readout_threads
 
     def is_ready(self, chunk_i):
         ended = self.source_finished()

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -156,8 +156,8 @@ class DAQReader(strax.Plugin):
         counted_files = Counter(
             [self._partial_chunk_to_thread_name(p) for p in os.listdir(path_chunk_i)])
         for thread, n_counts in counted_files.items():
-            if thread in self.config['readout_threads']:
-                raise ValueError(f'Bad data for {path_chunk_i}. Got {thread} ')
+            if thread not in self.config['readout_threads']:
+                raise ValueError(f'Bad data for {path_chunk_i}. Got {thread}')
             if n_counts > self.config['readout_threads'][thread]:
                 raise ValueError(f'{thread} wrote {n_counts}, expected'
                                  f'{self.config["readout_threads"][thread]}')

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -2,7 +2,7 @@ import glob
 import os
 import shutil
 import warnings
-
+from collections import Counter
 from immutabledict import immutabledict
 import numpy as np
 import numba
@@ -43,10 +43,9 @@ class ArtificialDeadtimeInserted(UserWarning):
                  help="Duration of intermediate/overlap chunks in ns"),
     strax.Option('daq_compressor', default="lz4", track=False,
                  help="Algorithm used for (de)compressing the live data"),
-    strax.Option('n_readout_threads', type=int, track=False,
-                 help="Number of readout threads producing strax data files"),
-    strax.Option('thread_names', type=tuple, track=False,
-                 help="Names of the threads producing strax data files"),
+    strax.Option('readout_threads', type=dict, track=False,
+                 help="Dictionary of the readout threads where the keys "
+                      "specify the reader and value the number of threads"),
     strax.Option('daq_input_dir', type=str, track=False,
                  help="Directory where readers put data"),
 
@@ -103,6 +102,7 @@ class DAQReader(strax.Plugin):
     def setup(self):
         self.t0 = int(self.config['run_start_time']) * int(1e9)
         self.dt_max = self.config['max_digitizer_sampling_time']
+        self.n_readout_treads = sum(self.config['readout_threads'].values())
         if (self.config['safe_break_in_pulses']
                 > min(self.config['daq_chunk_duration'],
                       self.config['daq_overlap_chunk_duration'])):
@@ -122,13 +122,13 @@ class DAQReader(strax.Plugin):
         result = []
         for q in [p + '_pre', p, p + '_post']:
             if os.path.exists(q):
-                n_files = len(os.listdir(q))
-                if n_files >= self.config['n_readout_threads']:
+                n_files = self._count_files_per_chunk(q)
+                if n_files >= self.n_readout_treads:
                     result.append(q)
                 else:
                     print(f"Found incomplete folder {q}: "
                           f"contains {n_files} files but expected "
-                          f"{self.config['n_readout_threads']}. "
+                          f"{self.n_readout_threads}. "
                           f"Waiting for more data.")
                     if self.source_finished():
                         # For low rates, different threads might end in a
@@ -143,12 +143,32 @@ class DAQReader(strax.Plugin):
                 result.append(False)
         return tuple(result)
 
+    @staticmethod
+    def _partial_chunk_to_thread_name(partial_chunk):
+        """Convert name of part of the chunk to the thread_name that wrote it"""
+        return '_'.join(partial_chunk.split('_')[-1])
+
+    def _count_files_per_chunk(self, path_chunk_i):
+        """
+        Check that the files in the chunks have names consistent with
+        the readout threads
+        """
+        counted_files = Counter(
+            [self._partial_chunk_to_thread_name(p) for p in os.listdir(path_chunk_i)])
+        for thread, n_counts in counted_files.items():
+            if thread in self.config['readout_threads']:
+                raise ValueError(f'Bad data for {path_chunk_i}. Got {thread} ')
+            if n_counts > self.config['readout_threads'][thread]:
+                raise ValueError(f'{thread} wrote {n_counts}, expected'
+                                 f'{self.config["readout_threads"][thread]}')
+        return sum(counted_files.values())
+
     def source_finished(self):
         end_dir = self.config["daq_input_dir"] + '/THE_END'
         if not os.path.exists(end_dir):
             return False
         else:
-            return len(os.listdir(end_dir)) >= self.config['n_readout_threads']
+            return self._count_files_per_chunk(end_dir) >= self.n_readout_treads
 
     def is_ready(self, chunk_i):
         ended = self.source_finished()
@@ -168,12 +188,6 @@ class DAQReader(strax.Plugin):
                 compressor=self.config["daq_compressor"],
                 dtype=self.dtype_for('raw_records'))
             for fn in sorted(glob.glob(f'{path}/*'))]
-        for chunk_part in os.listdir(path):
-            thread_name = '_'.join(chunk_part.split('_')[-1])
-            if thread_name not in self.config['thread_names']:
-                raise ValueError(
-                    f'Bad data for {path}. Expected '
-                    f'{self.config["thread_names"]} but got {thread_name}')
         records = np.concatenate(records)
         records = strax.sort_by_time(records)
 

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -45,6 +45,8 @@ class ArtificialDeadtimeInserted(UserWarning):
                  help="Algorithm used for (de)compressing the live data"),
     strax.Option('n_readout_threads', type=int, track=False,
                  help="Number of readout threads producing strax data files"),
+    strax.Option('thread_names', type=tuple, track=False,
+                 help="Names of the threads producing strax data files"),
     strax.Option('daq_input_dir', type=str, track=False,
                  help="Directory where readers put data"),
 
@@ -166,6 +168,10 @@ class DAQReader(strax.Plugin):
                 compressor=self.config["daq_compressor"],
                 dtype=self.dtype_for('raw_records'))
             for fn in sorted(glob.glob(f'{path}/*'))]
+        for chunk_part in os.listdir(path):
+            thread_name = '_'.join(chunk_part.split('_')[-1])
+            if thread_name not in self.config['thread_names']:
+                raise ValueError(f'Bad data for {path}')
         records = np.concatenate(records)
         records = strax.sort_by_time(records)
 

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -171,7 +171,9 @@ class DAQReader(strax.Plugin):
         for chunk_part in os.listdir(path):
             thread_name = '_'.join(chunk_part.split('_')[-1])
             if thread_name not in self.config['thread_names']:
-                raise ValueError(f'Bad data for {path}')
+                raise ValueError(
+                    f'Bad data for {path}. Expected '
+                    f'{self.config["thread_names"]} but got {thread_name}')
         records = np.concatenate(records)
         records = strax.sort_by_time(records)
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Check that redax / dispatcher is not writing wrong threads to wrong runs.

**Can you briefly describe how it works?**
Each of the readers is registered, let's check that we don't get reader_6 for non NV data, etc.

