### PR TITLE
Online events monitor

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -120,7 +120,7 @@ def xenonnt_online(output_folder='./strax_data',
             readonly=not we_are_the_daq,
             take_only=('veto_intervals',
                        'online_peak_monitor',
-                       'online_event_monitor',))]
+                       'event_basics',))]
 
     # Remap the data if it is before channel swap (because of wrongly cabled
     # signal cable connectors) These are runs older than run 8797. Runs

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -119,7 +119,8 @@ def xenonnt_online(output_folder='./strax_data',
         st.storage += [straxen.OnlineMonitor(
             readonly=not we_are_the_daq,
             take_only=('veto_intervals',
-                       'online_monitor',))]
+                       'online_peak_monitor',
+                       'online_event_monitor',))]
 
     # Remap the data if it is before channel swap (because of wrongly cabled
     # signal cable connectors) These are runs older than run 8797. Runs

--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -34,7 +34,6 @@ export, __all__ = strax.exporter()
              'for: '
              'lone_hits_area-histogram, '
              'area_fraction_top-histogram, '
-             'near_s1_hists, '
              'online_se_gain estimate (histogram is not stored), '
     ),
     strax.Option(
@@ -49,15 +48,6 @@ export, __all__ = strax.exporter()
         default=15_000,
         help='Minimal gap [ns] between consecutive lone-hits. To turn off '
              'this cut, set to 0.'),
-    strax.Option(
-        'near_s1_hists_bounds',
-        type=tuple,
-        default=(0, 1000),
-        help='Bounds for the near s1-peaks in PE'),
-    strax.Option(
-        'near_s1_max_time_diff',
-        type=int, default=2_000,
-        help='Max gap between two peaks for the near-s1 area histogram [ns]'),
     strax.Option(
         'n_tpc_pmts', type=int,
         help='Number of TPC PMTs'),

--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -96,7 +96,7 @@ class OnlinePeakMonitor(strax.Plugin):
     depends_on = ('peak_basics', 'lone_hits')
     provides = 'online_peak_monitor'
     data_kind = 'online_peak_monitor'
-    __version__ = '0.0.4'
+    __version__ = '0.0.5'
     rechunk_on_save = False
 
     def infer_dtype(self):

--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -307,21 +307,20 @@ class OnlineEventMonitor(strax.Plugin):
         ]
         return dtype
     
-    def compute(self, event_basics, start, end):
+    def compute(self, events, start, end):
         # General setup
         res = np.zeros(1, dtype=self.dtype)
         res['time'] = start
         res['endtime'] = end
-        n_pmt = self.config['n_tpc_pmts']
-        n_bins = self.config['online_monitor_nbins']
+#         n_bins = self.config['online_monitor_nbins']
         
         
         # --- Drift time vs R^2 histogram ---
         res['drift_time_vs_R2_bounds'] = self.config['drift_time_vs_R2_bounds']
         
         mask = self._config_as_selection_str(
-            self.config['drift_time_vs_R2_cut_string'], event_basics)
-        res['drift_time_vs_R2_hist'] = self.drift_time_R2_hist(event_basics[mask])
+            self.config['drift_time_vs_R2_cut_string'], events)
+        res['drift_time_vs_R2_hist'] = self.drift_time_R2_hist(events[mask])
         # Make a new mask, don't re-use
         del mask
         
@@ -347,12 +346,14 @@ class OnlineEventMonitor(strax.Plugin):
 
     def drift_time_R2_hist(self, data):
         """Make area vs width 2D-hist"""
-        hist, _= np.histogram2d(
-            data['s2_x'] ** 2 + data['s2_y'] ** 2,
+        hist, _, _= np.histogram2d(
+            (data['s2_x'] ** 2 + data['s2_y'] ** 2),
             data['drift_time'],
             range=self.config['drift_time_vs_R2_bounds'],
             bins=self.config['online_monitor_nbins'])
         return hist.T
+
+
 
 
 

--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -246,8 +246,7 @@ class OnlinePeakMonitor(strax.Plugin):
     strax.Option(
         'drift_time_vs_R2_bounds',
         type=tuple, default=((0, 5e3), (0, 3e6)),
-        help='Boundaries of histogram of drift time vs R^2.'
-             'y_deges'),
+        help='Boundaries of histogram of drift time vs R^2.'),
     strax.Option(
         'online_monitor_nbins',
         type=int, default=100,


### PR DESCRIPTION
Per [issue \#36 in analysis code repo](https://github.com/XENONnT/analysiscode/issues/36), add drift time vs reconstructed R^2 to online monitor. Add information from event to online monitor. A new plugin `OnlineEventMonitor` and corresponding data type `online_event_monitor` are added to `straxen/plugins/online_monitor.py`

**Can you give a minimal working example (or illustrate with a figure)?**
See [this reply](https://github.com/XENONnT/analysiscode/issues/36#issuecomment-766662156).

`OnlineEventMonitor` has been tested on an old run, while the modified loop plugin `online_monitor` has not been tested yet. 
