### PR TITLE
updates for seperate waveforms

### DIFF
--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -502,8 +502,6 @@ FAKE_MERGED_S2_TYPE = -42
 
 @export
 @strax.takes_config(
-    strax.Option('n_top_pmts', type=int,
-                 help='Number of PMTs in the top array'),
     strax.Option('s2_merge_max_area', default=5000.,
                  help="Merge peaklet cluster only if area < this [PE]"),
     strax.Option('s2_merge_max_gap', default=3500,

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -95,11 +95,7 @@ class Peaklets(strax.Plugin):
     __version__ = '0.3.7'
 
     def infer_dtype(self):
-        peaklet_dtype= strax.peak_dtype(n_channels=self.config['n_tpc_pmts'])
-        if self.config['store_top_waveform']:
-            peaklet_dtype +=[(('Waveform data from the top array in PE/sample (not PE/ns!)',
-                         'data_top'), np.float32, 200)]
-        return dict(peaklets=peaklet_dtype,
+        return dict(peaklets=strax.peak_dtype(n_channels=self.config['n_tpc_pmts']),
                     lone_hits=strax.hit_dtype)
 
     def setup(self):


### PR DESCRIPTION
Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible

**What is the problem / what does the code in this PR do**
This PR add the top and bottom array waveforms to peaklets and beyond. For this small changes to the arguments of some peak_building/splitting functions where needed. Do not merge before, or much later than https://github.com/AxFoundation/strax/pull/393

**Can you briefly describe how it works?**
See https://github.com/AxFoundation/strax/pull/393
**Can you give a minimal working example (or illustrate with a figure)?**
`st.make(run_id,'peaks')

![Waveforms](https://user-images.githubusercontent.com/29707907/107048732-90c74d00-67c9-11eb-920f-0bb8b61eeecb.png)

Ps tests fail untill the strax pr is merged