### PR TITLE
Update contexts.py

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -147,7 +147,7 @@ def xenonnt_led(**kwargs):
 # This gain model is a temporary solution until we have a nice stable one
 def xenonnt_simulation(output_folder='./strax_data'):
     import wfsim
-    xnt_common_config['gain_model'] = ('to_pe_per_run', 'to_pe_nt.npy')
+    xnt_common_config['gain_model'] = ('to_pe_constant', 0.01)
     st = strax.Context(
         storage=strax.DataDirectory(output_folder),
         config=dict(detector='XENONnT',

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -144,7 +144,7 @@ def xenonnt_led(**kwargs):
     return st
 
 
-# This gain model is a temporary solution until we have a nice stable one
+# This gain model is the average to_pe. For something more fancy use the CMT
 def xenonnt_simulation(output_folder='./strax_data'):
     import wfsim
     xnt_common_config['gain_model'] = ('to_pe_constant', 0.01)


### PR DESCRIPTION
This pull request:

- removes the to_pe_nt file from the gain model and replaces it with the actual value used. 0.01 is the average to_pe value. If you want a more fancy gain model use the CMT