### PR TITLE
Change left/right extension for event processing

### DIFF
--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -16,10 +16,10 @@ export, __all__ = strax.exporter()
     strax.Option('trigger_max_competing', default=7,
                  help='Peaks must have FEWER nearby larger or slightly smaller'
                       ' peaks to cause events'),
-    strax.Option('left_event_extension', default=int(2.5e6),
+    strax.Option('left_event_extension', default=int(2.7e6),
                  help='Extend events this many ns to the left from each '
                       'triggering peak'),
-    strax.Option('right_event_extension', default=int(2.5e6),
+    strax.Option('right_event_extension', default=int(0.5e6),
                  help='Extend events this many ns to the right from each '
                       'triggering peak'),
 )


### PR DESCRIPTION
As discussed in this [note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:event_pile_up_commissioning), we should reduce the right extension to decrease the pile-up. Also as @jpienaar13 pointed out, we should increase the left extension a bit.
