### PR TITLE
Replace json with commentjson

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ immutabledict
 numba>=0.50.0
 strax>=0.13.4
 requests
+commentjson

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -3,7 +3,7 @@ import configparser
 import gzip
 import inspect
 import io
-import json
+import commentjson as json
 import os
 import os.path as osp
 import pickle


### PR DESCRIPTION
**Can you briefly describe how it works?**

Some of the external configurations are saved in JSON format, however, comments are not allowed in it. This can be solved by using [commentjson](https://pypi.org/project/commentjson/) package.
