### PR TITLE
fix commentjson

### DIFF
--- a/straxen/common.py
+++ b/straxen/common.py
@@ -3,7 +3,8 @@ import configparser
 import gzip
 import inspect
 import io
-import commentjson as json
+import commentjson
+import json
 import os
 import os.path as osp
 import pickle
@@ -112,7 +113,7 @@ def open_resource(file_name: str, fmt='text'):
             result = json.load(f)
     elif fmt == 'json':
         with open(file_name, mode='r') as f:
-            result = json.load(f)
+            result = commentjson.load(f)
     elif fmt == 'binary':
         with open(file_name, mode='rb') as f:
             result = f.read()


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
#384 does not work for zipped json files.

**Can you briefly describe how it works?**
Don't use #384 for json.gz
