### PR TITLE
Check for raw-record overlaps

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1256,7 +1256,7 @@ def run_strax(run_id, input_dir, targets, readout_threads, compressor,
                                 daq_chunk_duration=daq_chunk_duration,
                                 daq_overlap_chunk_duration=daq_overlap_chunk_duration,
                                 readout_threads=readout_threads,
-                                check_raw_record_overlaps=False,
+                                check_raw_record_overlaps=True,
                                 )
 
             for i, c in enumerate(st.get_iter(run_id,


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
I'm not sure why [we needed this for LED-calibrations](https://github.com/XENONnT/straxen/pull/42/commits/2a0b900a253aeb524f7cc83ac363ffa8b86b9b76) but I don't think we should have this option set to `False`.

**Can you briefly describe how it works?**
 - I will first have to test if this works on all runs, but perhaps we should only disable it for LED if needed. 

