### PR TITLE
remove nones and replace with nans

### DIFF
--- a/straxen/itp_map.py
+++ b/straxen/itp_map.py
@@ -133,6 +133,7 @@ class InterpolatingMap:
 
         for map_name in self.map_names:
             map_data = np.array(self.data[map_name])
+            map_data = none_to_float_nan(map_data)
             array_valued = len(map_data.shape) == self.dimensions + 1
             if self.dimensions == 0:
                 # 0 D -- placeholder maps which take no arguments
@@ -154,3 +155,17 @@ class InterpolatingMap:
         :param map_name: Name of the map to use. Default is 'map'.
         """
         return self.interpolators[map_name](positions)
+
+
+def none_to_float_nan(arr):
+    """Remove Nones from array and replace with float nans"""
+    res = []
+    for r in arr:
+        if r is None:
+            res.append(float('nan'))
+        else:
+            res.append(r)
+    if isinstance(arr, np.ndarray):
+        res = np.array(res)
+
+    return res

--- a/straxen/itp_map.py
+++ b/straxen/itp_map.py
@@ -132,8 +132,8 @@ class InterpolatingMap:
         log.debug("Map names found: %s" % self.map_names)
 
         for map_name in self.map_names:
-            map_data = np.array(self.data[map_name])
-            map_data = none_to_float_nan(map_data)
+            # Specify dtype float to set Nones to nan
+            map_data = np.array(self.data[map_name], dtyp=np.float)
             array_valued = len(map_data.shape) == self.dimensions + 1
             if self.dimensions == 0:
                 # 0 D -- placeholder maps which take no arguments
@@ -155,17 +155,3 @@ class InterpolatingMap:
         :param map_name: Name of the map to use. Default is 'map'.
         """
         return self.interpolators[map_name](positions)
-
-
-def none_to_float_nan(arr):
-    """Remove Nones from array and replace with float nans"""
-    res = []
-    for r in arr:
-        if r is None:
-            res.append(float('nan'))
-        else:
-            res.append(r)
-    if isinstance(arr, np.ndarray):
-        res = np.array(res)
-
-    return res

--- a/straxen/itp_map.py
+++ b/straxen/itp_map.py
@@ -133,7 +133,7 @@ class InterpolatingMap:
 
         for map_name in self.map_names:
             # Specify dtype float to set Nones to nan
-            map_data = np.array(self.data[map_name], dtyp=np.float)
+            map_data = np.array(self.data[map_name], dtype=np.float)
             array_valued = len(map_data.shape) == self.dimensions + 1
             if self.dimensions == 0:
                 # 0 D -- placeholder maps which take no arguments


### PR DESCRIPTION
**What is the problem **
`commentjson` (#384) does not like `float('nan')` in json files. Therefore, I replaced it with `null` which is the JSON equivalent of `None` [in this PR](https://github.com/XENONnT/private_nt_aux_files/pull/36). However, the interpolation function on the other hand does not like `Nones`.

**what does the code in this PR do**
Add a line replace `None` by `float('nan')`. 

A review including sanity check that nothing is affected would be appreciated