### PR TITLE
Check raw-record overlaps at veto pulse processing

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1261,7 +1261,7 @@ def run_strax(run_id, input_dir, targets, readout_threads, compressor,
                                 daq_chunk_duration=daq_chunk_duration,
                                 daq_overlap_chunk_duration=daq_overlap_chunk_duration,
                                 readout_threads=readout_threads,
-                                check_raw_record_overlaps=False,
+                                check_raw_record_overlaps=True,
                                 )
 
             for i, c in enumerate(st.get_iter(run_id,

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -26,6 +26,10 @@ export, __all__ = strax.exporter()
     strax.Option('channel_map', track=False, type=immutabledict,
                  help="frozendict mapping subdetector to (min, max) "
                       "channel number."),
+    strax.Option('check_raw_record_overlaps',
+                 default=True, track=False,
+                 help='Crash if any of the pulses in raw_records overlap with others '
+                      'in the same channel'),
 )
 class nVETORecorder(strax.Plugin):
     """
@@ -67,6 +71,8 @@ class nVETORecorder(strax.Plugin):
         return {k: v for k, v in zip(self.provides, dtypes)}
 
     def compute(self, raw_records_nv, start, end):
+        if self.config['check_raw_record_overlaps']:
+            straxen.check_overlaps(raw_records_nv, n_channels=3000)
         # Cover the case if we do not want to have any coincidence:
         if self.config['coincidence_level_recorder_nv'] <= 1:
             rr = raw_records_nv

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -1,6 +1,7 @@
 import strax
 import numpy as np
 import numba
+import straxen
 export, __all__ = strax.exporter()
 
 MV_PREAMBLE = 'Muno-Veto Plugin: Same as the corresponding nVETO-PLugin.\n'
@@ -27,6 +28,12 @@ MV_PREAMBLE = 'Muno-Veto Plugin: Same as the corresponding nVETO-PLugin.\n'
         default=None, track=True,
         help='Min. length of pulse before alternative baselineing via '
              'pulse median is applied.'),
+    strax.Option(
+        'check_raw_record_overlaps',
+        default=True, track=False,
+        help='Crash if any of the pulses in raw_records overlap with others '
+             'in the same channel'),
+
 )
 class nVETOPulseProcessing(strax.Plugin):
     """
@@ -56,6 +63,8 @@ class nVETOPulseProcessing(strax.Plugin):
         return dtype
 
     def compute(self, raw_records_coin_nv):
+        if self.config['check_raw_record_overlaps']:
+            straxen.check_overlaps(raw_records_coin_nv, n_channels=3000)
         # Do not trust in DAQ + strax.baseline to leave the
         # out-of-bounds samples to zero.
         r = strax.raw_to_records(raw_records_coin_nv)

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -228,6 +228,11 @@ def clean_up_empty_records(records, record_links, only_last=True):
         child_option=True, parent_option_name='hit_min_amplitude_nv',
         help='Minimum hit amplitude in ADC counts above baseline. '
              'Specify as a tuple of length n_nveto_pmts, or a number.'),
+    strax.Option(
+        'check_raw_record_overlaps',
+        default=True, track=False,
+        help='Crash if any of the pulses in raw_records overlap with others '
+             'in the same channel'),
 )
 class muVETOPulseProcessing(nVETOPulseProcessing):
     __doc__ = MV_PREAMBLE + nVETOPulseProcessing.__doc__
@@ -244,4 +249,6 @@ class muVETOPulseProcessing(nVETOPulseProcessing):
         return dtype
 
     def compute(self, raw_records_mv):
+        if self.config['check_raw_record_overlaps']:
+            straxen.check_overlaps(raw_records_mv, n_channels=3000)
         return super().compute(raw_records_mv)

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -28,12 +28,6 @@ MV_PREAMBLE = 'Muno-Veto Plugin: Same as the corresponding nVETO-PLugin.\n'
         default=None, track=True,
         help='Min. length of pulse before alternative baselineing via '
              'pulse median is applied.'),
-    strax.Option(
-        'check_raw_record_overlaps',
-        default=True, track=False,
-        help='Crash if any of the pulses in raw_records overlap with others '
-             'in the same channel'),
-
 )
 class nVETOPulseProcessing(strax.Plugin):
     """
@@ -63,8 +57,6 @@ class nVETOPulseProcessing(strax.Plugin):
         return dtype
 
     def compute(self, raw_records_coin_nv):
-        if self.config['check_raw_record_overlaps']:
-            straxen.check_overlaps(raw_records_coin_nv, n_channels=3000)
         # Do not trust in DAQ + strax.baseline to leave the
         # out-of-bounds samples to zero.
         r = strax.raw_to_records(raw_records_coin_nv)


### PR DESCRIPTION
## What is the problem / what does the code in this PR do
Similar to the TPC raw-records (#387), we should check that the raw-records of our veto systems are non-overlapping. 

~We could do this also at the rr-nv-coincidence but this would lead to problems. If we fail this check (hopefully not) we would get the error during the building of rr-nv-coincidence. This leads to issues at the DAQ because we will delete rr-nv and only keep rr-nv-coincidence.~

After discussing with Daniel, he convinced me to do this at the rr-nv-coincidence step as otherwise the damage is already done. This further complicates the rr-nv cleaning step but let's hope we are indeed never running into this issue.
