### PR TITLE
Change config file for nT sims context

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -152,7 +152,7 @@ def xenonnt_simulation(output_folder='./strax_data'):
     st = strax.Context(
         storage=strax.DataDirectory(output_folder),
         config=dict(detector='XENONnT',
-                    fax_config='fax_config_nt.json',
+                    fax_config='fax_config_nt_design.json',
                     check_raw_record_overlaps=False,
                     **straxen.contexts.xnt_common_config,
                     ),


### PR DESCRIPTION
This flash PR simply replaces the default fax configuration file to load in the nT simulations context. The previous default will be deteled after https://github.com/XENONnT/private_nt_aux_files/pull/24 is merged (see explanation [here](https://github.com/XENONnT/private_nt_aux_files/pull/24#issuecomment-788732974)).