### PR TITLE
Infer-target

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -260,7 +260,13 @@ max_queue_new_runs = 2
 # this many times. If high level data is hitting some edge case, we
 # might want to be able to keep the intermediate level data.
 # NB: string match so events applies e.g. to event_basics, peak to e.g. peaklets
-remove_target_after_fails = dict(events=2, hitlets=2, peak=3, online=4, ALL=5)
+remove_target_after_fails = dict(events=2,
+                                 hitlets=2,
+                                 peaks=3,
+                                 peak_basics=3,
+                                 peaklets=4,
+                                 online=4,
+                                 ALL=5)
 
 ##
 # Initialize globals (e.g. rundb connection)
@@ -538,11 +544,19 @@ def infer_target(rd):
 
     n_fails = rd['bootstrax'].get('n_failures', 0)
     if n_fails:
-        log.debug(f'override_target::\tdeleting targets')
+        log.debug(f'Deleting targets')
         for _rm_t, _rm_t_after in remove_target_after_fails.items():
-            _t = [__t for __t in _t if (_rm_t not in __t and n_fails < _rm_t_after)]
-            _pp = [__pp for __pp in _pp if (_rm_t not in __pp and n_fails < _rm_t_after)]
+            for __i, __t in enumerate(_t):
+                if __t in _rm_t and n_fails > _rm_t_after:
+                    log.debug(f'Remove {__t}')
+                    del _t[__i]
+            for __pi, __p  in enumerate(_pp):
+                if __p in _rm_t and n_fails > _rm_t_after:
+                    log.debug(f'Remove {__p}')
+                    del _pp[__pi]
+    log.debug(f'{_t} and {_pp} remaining')
     if n_fails >= remove_target_after_fails['ALL']:
+        log.debug(f'Overwriting to raw-records only')
         _t = 'raw_records'
         _pp = 'raw_records'
         return {'targets': strax.to_str_tuple(_t),
@@ -556,9 +570,11 @@ def infer_target(rd):
 
     log.debug(f'override_target::\tmode is {mode}, changing target if needed')
     if np.any([m in mode for m in led_modes]):
+        log.debug('led-mode')
         _t = 'led_calibration'
         _pp = 'raw_records'
     elif np.any([m in mode for m in diagnostic_modes]):
+        log.debug('diagnostic-mode')
         _t = 'raw_records'
         _pp = 'raw_records'
 
@@ -582,6 +598,7 @@ def infer_target(rd):
         _pp = 'raw_records'
     _t = strax.to_str_tuple(_t)
     _pp = strax.to_str_tuple(_pp)
+    log.info(f'Inferring modes done, writing {_t} and {_pp}')
     for __check in (_t, _pp):
         if not len(set(__check)) == len(__check):
             log_warning(f'Duplicates in (post) targets {__check}',

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -568,7 +568,7 @@ def infer_target(rd):
     mode = str(rd.get('mode'))
     detectors = list(rd.get('detectors'))
 
-    log.debug(f'override_target::\tmode is {mode}, changing target if needed')
+    log.debug(f'mode is {mode}, changing target if needed')
     if np.any([m in mode for m in led_modes]):
         log.debug('led-mode')
         _t = 'led_calibration'
@@ -718,8 +718,8 @@ def eb_can_process():
                     '$lt': now(-timeouts['eb3-5_max_busy_time'])}})
             if running_eb:
                 n_ebs_busy += 1
-                log.debug(f'eb_can_process::\t eb{eb_i} is busy')
-    log.info(f'eb_can_process::\trunning: {n_ebs_running}\t'
+                log.debug(f'eb{eb_i} is busy')
+    log.info(f'running: {n_ebs_running}\t'
              f'busy: {n_ebs_busy}\tqueue: {n_untouched_runs}')
     if (not n_ebs_running or
             (n_ebs_running == n_ebs_busy and
@@ -763,7 +763,7 @@ def infer_mode(rd):
 
     # Find out if eb is new (eb3-eb5):
     is_new_eb = int(hostname[2]) >= 3  # ebX.xenon.local
-    log.info(f'infer_mode::\tData rate: {data_rate} MB/s. New_eb: {is_new_eb}')
+    log.info(f'Data rate: {data_rate} MB/s. New_eb: {is_new_eb}')
     benchmark = {
         'mbs': [0, 70, 90, 110, 150, 220, 290, 360, 390, 420, 500, 550],
         'cores_old': [39, 35, 35, 30, 30, 20, 12, 12, 10, 10, 10, 8],
@@ -795,14 +795,14 @@ def infer_mode(rd):
             max_messages=np.clip(result['max_messages']/(1.1**n_fails), 4, 100).astype(int),
             timeout=np.clip(result['timeout']*(1.1**n_fails), 500, 3600).astype(int),
         )
-        log_warning(f'infer_mode::\tRepeated failures on {rd["number"]}@{hostname}. '
+        log_warning(f'Repeated failures on {rd["number"]}@{hostname}. '
                     f'Lowering to {result}',
                     priority='info',
                     run_id=f'{rd["number"]:06}')
     else:
         result = {k: int(v) for k, v in result.items()}
     result['records_compressor'] = infer_records_compressor(rd, data_rate, n_fails)
-    log.info(f'infer_mode::\tInferred mode for {rd["number"]}\t{result}')
+    log.info(f'Inferred mode for {rd["number"]}\t{result}')
     return result
 
 
@@ -954,7 +954,7 @@ def clear_shm():
 
     if not len(shm_files):
         return
-    log.info(f'clear_shm:: clearing {len(shm_files)} files')
+    log.info(f'Clearing {len(shm_files)} files')
     for f in shm_files:
         os.remove(shm_dir + f)
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Online_peak_monitor was removed from the target list because of the str match with 'peak'. Fix that.

While at it, also add some more logging statements and go for a little simpler syntax.

Honestly, this is not the prettiest part of the code. Will do some work on it when we add some new infer-logic for the linked mode as well as NV/MV processing.