### PR TITLE
Use multiple targets for better online support

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -73,7 +73,7 @@ what bootstrax is thinking of at the moment.
   - **disk_used**: used part of the disk whereto this bootstrax instance
    is writing to (in percent).
 """
-__version__ = '1.0.5'
+__version__ = '1.1.0'
 
 import argparse
 from datetime import datetime, timedelta, timezone
@@ -319,20 +319,10 @@ if os.access(output_folder, os.W_OK) is not True:
 def new_context(cores=args.cores,
                 max_messages=args.max_messages,
                 timeout=500,
-                targets=strax.to_str_tuple(args.targets),
                 ):
     """Create strax context that can access the runs db"""
     # We use exactly the same logic of straxen to access the runs DB;
     # this avoids duplication, and ensures strax can access the runs DB if we can
-    class MergeTargets(strax.Plugin):
-        """Mergeonly plugin to allow a single endpoint for st.make"""
-        depends_on = targets
-        provides = 'multiple'
-        save_when = strax.SaveWhen.NEVER
-        dtype = strax.time_fields
-
-        def compute(self, **kwargs):
-            return np.empty(0, dtype=self.dtype)
 
     context = straxen.contexts.xenonnt_online(
         output_folder=output_folder,
@@ -342,8 +332,12 @@ def new_context(cores=args.cores,
         max_messages=max_messages,
         timeout=timeout)
     if not args.production:
-        context.storage = [strax.DataDirectory(output_folder)]
-    context.register(MergeTargets)
+        # Keep the rundb but set it to readonly and local only, delete
+        # all other storage frontends except fo the test folder.
+        context.storage = [context.storage[0],
+                           strax.DataDirectory(output_folder)]
+        context.storage[0].readonly = True
+        context.storage[0].local_only = True
     return context
 
 
@@ -1281,12 +1275,10 @@ def run_strax(run_id, input_dir, targets, readout_threads, compressor,
                                 check_raw_record_overlaps=True,
                                 )
 
-            for i, c in enumerate(st.get_iter(run_id,
-                                              'multiple',
-                                              config=strax_config,
-                                              max_workers=cores)):
-                if not i % 10:
-                    log.info(f'Target plugin - chunk {i}\n\t{c}')
+            st.make(run_id, targets,
+                    allow_multiple=True,
+                    config=strax_config,
+                    max_workers=cores)
 
             if len(post_processing):
                 for post_target in post_processing:


### PR DESCRIPTION
# Better online processing for multiple targets
Increase online processing capabilities by allowing multiple targets to compute without asking for the data. Stop having an extra plugin to merge the input of multiple targets because it's both complicated and convoluted. This PR is a huge improvement and will very much improve the reliability of bootstrax.

See https://github.com/AxFoundation/strax/pull/408 for more info.