### PR TITLE
Prevent abandonment of done runs

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1643,6 +1643,7 @@ def cleanup_db():
     # there is no point in retrying them
     abandon_queries = [
         ({'tags.name': 'abandon',
+          'bootstrax.state': {'$ne', 'done'},
           'start': {'$gt': now(-timeouts['abandoning_allowed'])}},
          "Run has an 'abandon' tag"),
         ({'tags.name': 'abandon', 'bootstrax.state': 'failed'},


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Don't allow runs to be abandoned unless they are done (e.g. busy or failed are fine).

**Why not simplify even further and merge it with the query just below the one edited here?**
Not sure how often it will be occurring that after a week we are still trying to process a run, but if we do, it's probably something special.
