### PR TITLE
Add get_correction_from_cmt to corrections_services.py

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -242,7 +242,8 @@ x1t_common_config = dict(
         ((2, 1), (4.5, 0.4))),
     left_event_extension=int(1e6),
     right_event_extension=int(1e6),
-    elife_conf=("elife", "ONLINE", False),
+    elife_conf = ('elife_constant', 700000., False)
+       
 )
 
 

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -46,7 +46,7 @@ xnt_common_config = dict(
     # Clustering/classification parameters
     s1_max_rise_time=100,
     s2_xy_correction_map=("CMT_model", ('s2_xy_map', "ONLINE"), True),
-    elife_file=("elife_model", "ONLINE",True),
+    elife_file=("elife", "ONLINE", True),
 )
 
 # Plugins in these files have nT plugins, E.g. in pulse&peak(let)

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -46,7 +46,7 @@ xnt_common_config = dict(
     # Clustering/classification parameters
     s1_max_rise_time=100,
     s2_xy_correction_map=("CMT_model", ('s2_xy_map', "ONLINE"), True),
-    elife_file=("elife", "ONLINE", True),
+    elife_conf=("elife", "ONLINE", True),
 )
 
 # Plugins in these files have nT plugins, E.g. in pulse&peak(let)

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -242,6 +242,7 @@ x1t_common_config = dict(
         ((2, 1), (4.5, 0.4))),
     left_event_extension=int(1e6),
     right_event_extension=int(1e6),
+    elife_conf=("elife", "ONLINE", False),
 )
 
 

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -79,8 +79,6 @@ class CorrectionsManagementServices():
             return self.get_pmt_gains(run_id, model_type, global_version)
         elif model_type in single_value_corrections:
             return self._get_correction(run_id, model_type, global_version)
-        #elif 'elife' in model_type:
-        #    return self.get_elife(run_id, model_type, global_version)
         elif model_type in corrections_w_file:
             return self.get_config_from_cmt(run_id, model_type, global_version)
         else:

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -13,8 +13,9 @@ export, __all__ = strax.exporter()
 corrections_w_file = ['mlp_model', 'gcn_model', 'cnn_model',
                       's2_xy_map', 's1_xy_map', 'fdc_map']
 
-single_value_corrections =['elife', 'baseline_samples_nv',
-                           'electron_drift_velocity']
+single_value_corrections = ['elife', 'baseline_samples_nv',
+                            'electron_drift_velocity']
+
 
 @export
 class CorrectionsManagementServices():
@@ -82,9 +83,9 @@ class CorrectionsManagementServices():
         elif model_type in corrections_w_file:
             return self.get_config_from_cmt(run_id, model_type, global_version)
         else:
-            raise ValueError(f'{config_model} not found, currently these are '
-                             f'available {single_value_corrections} and '
-                             f'{corrections_w_file} ')
+            raise ValueError(f"{config_model} not found, currently these are "
+                             f"available {single_value_corrections} and "
+                             f"{corrections_w_file} ")
 
     # TODO add option to extract 'when'. Also, the start time might not be the best
     # entry for e.g. for super runs
@@ -120,7 +121,7 @@ class CorrectionsManagementServices():
                     values.append(df.loc[df.index == when, version].values[0])
             corrections = np.asarray(values)
         except KeyError:
-            raise ValueError(f'Global version {global_version} not found for correction {correction}')
+            raise ValueError(f"Global version {global_version} not found for correction {correction}")
 
         else:
             return corrections
@@ -164,13 +165,13 @@ class CorrectionsManagementServices():
             # be cautious with very early runs, check that not all are None
             if np.isnan(to_pe).all():
                 raise ValueError(
-                    f'to_pe(PMT gains) values are NaN, no data available'
-                    f' for {run_id} in the gain model with version '
-                    f'{global_version}, please set constant values for '
-                    f'{run_id}')
+                    f"to_pe(PMT gains) values are NaN, no data available "
+                    f"for {run_id} in the gain model with version "
+                    f"{global_version}, please set constant values for "
+                    f"{run_id}")
 
         else:
-            raise ValueError(f'{model_type} not implemented for to_pe values')
+            raise ValueError(f"{model_type} not implemented for to_pe values")
 
         # Double check the dtype of the gains
         to_pe = np.array(to_pe, dtype=gain_dtype)
@@ -195,11 +196,11 @@ class CorrectionsManagementServices():
 
     def get_config_from_cmt(self, run_id, model_type, global_version='ONLINE'):
         """
-        Smart logic to return NN weights file name to be downloader by 
+        Smart logic to return NN weights file name to be downloader by
         straxen.MongoDownloader()
         :param run_id: run id from runDB
-        :param model_type: model type and neural network type; model_mlp, 
-        or model_gcn or model_cnn 
+        :param model_type: model type and neural network type; model_mlp,
+        or model_gcn or model_cnn
         :param global_version: global version
         :param return: NN weights file name
         """

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -82,7 +82,9 @@ class CorrectionsManagementServices():
         elif model_type in corrections_w_file:
             return self.get_config_from_cmt(run_id, model_type, global_version)
         else:
-            raise ValueError(f'{config_model} not found')
+            raise ValueError(f'{config_model} not found, currently these are '
+                             f'available {single_value_corrections} and '
+                             f'{corrections_w_file} ')
 
     # TODO add option to extract 'when'. Also, the start time might not be the best
     # entry for e.g. for super runs

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -13,6 +13,8 @@ export, __all__ = strax.exporter()
 corrections_w_file = ['mlp_model', 'gcn_model', 'cnn_model',
                       's2_xy_map', 's1_xy_map', 'fdc_map']
 
+single_value_corrections =['elife', 'baseline_samples_nv',
+                           'electron_drift_velocity']
 
 @export
 class CorrectionsManagementServices():
@@ -75,8 +77,10 @@ class CorrectionsManagementServices():
 
         if 'to_pe_model' in model_type:
             return self.get_pmt_gains(run_id, model_type, global_version)
-        elif 'elife' in model_type:
-            return self.get_elife(run_id, model_type, global_version)
+        elif model_type in single_value_corrections:
+            return self._get_correction(run_id, model_type, global_version)
+        #elif 'elife' in model_type:
+        #    return self.get_elife(run_id, model_type, global_version)
         elif model_type in corrections_w_file:
             return self.get_config_from_cmt(run_id, model_type, global_version)
         else:
@@ -120,27 +124,6 @@ class CorrectionsManagementServices():
 
         else:
             return corrections
-
-    def get_elife(self, run_id, model_type, global_version):
-        """
-        Smart logic to return electron lifetime correction
-        :param run_id: run id from runDB
-        :param model_type: choose either elife_model or elife_constant
-        :param global_version: global version, or float (if model_type == elife_constant)
-        :return: electron lifetime correction value
-        """
-        if model_type == 'elife_model':
-            return self._get_correction(run_id, 'elife', global_version)
-
-        elif model_type == 'elife_constant':
-            # This is nothing more than just returning the value we put in
-            if not isinstance(global_version, float):
-                raise ValueError(f'User specify a model type {model_type} '
-                                 f'and should provide a float. Got: '
-                                 f'{type(global_version)}')
-            return float(global_version)
-        else:
-            raise ValueError(f'model type {model_type} not implemented for electron lifetime')
 
     def get_pmt_gains(self, run_id, model_type, global_version,
                       cacheable_versions=('ONLINE',),

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -92,9 +92,12 @@ def get_correction_from_cmt(run_id, conf):
         if 'constant' in model_type:
             if not isinstance(global_version, float):
                 raise ValueError(f'User specify a model type {model_type} '
-                                 f'and should provide a float. Got: '
+                                 f'and should provide a number. Got: '
                                  f'{type(global_version)}')
-            return float(global_version)
+            if 'samples' in model_type:  # samples are int others are float 
+                return int(global_version)
+            else:
+                return float(global_version)
         else:
             cmt = straxen.CorrectionsManagementServices(is_nt=is_nt)
             correction = cmt.get_corrections_config(run_id, conf[:2])
@@ -103,7 +106,10 @@ def get_correction_from_cmt(run_id, conf):
                                  f'please check it is implemented in CMT. '
                                  f'for nT = {is_nt}')
 
-            return float(correction)
+            if 'samples' in model_type:  # samples are int others are float 
+                return int(correction)
+            else:
+                return float(correction)
 
 
 @export

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -60,7 +60,7 @@ def get_to_pe(run_id, gain_model, n_pmts):
             to_pe = np.ones(n_pmts, dtype=np.float32) * model_conf
         except np.core._exceptions.UFuncTypeError as e:
             raise (str(e) +
-                   f'\nTried multiplying by {model_conf}. Insert a number instead.')
+                   f"\nTried multiplying by {model_conf}. Insert a number instead.")
     else:
         raise NotImplementedError(f"Gain model type {model_type} not implemented")
 
@@ -91,16 +91,16 @@ def get_correction_from_cmt(run_id, conf):
         correction = global_version  # in case is a single value
         if 'constant' in model_type:
             if not isinstance(global_version, (float, int)):
-                raise ValueError(f'User specify a model type {model_type} '
-                                 f'and should provide a number. Got: '
-                                 f'{type(global_version)}')
+                raise ValueError(f"User specify a model type {model_type} "
+                                 "and should provide a number. Got: "
+                                 f"{type(global_version)}")
         else:
             cmt = straxen.CorrectionsManagementServices(is_nt=is_nt)
             correction = cmt.get_corrections_config(run_id, conf[:2])
             if correction.size == 0:
-                raise ValueError(f'Could not find a value for {model_type} '
-                                 f'please check it is implemented in CMT. '
-                                 f'for nT = {is_nt}')
+                raise ValueError(f"Could not find a value for {model_type} "
+                                 "please check it is implemented in CMT. "
+                                 f"for nT = {is_nt}")
 
         if 'samples' in model_type:
             return int(correction)
@@ -108,10 +108,11 @@ def get_correction_from_cmt(run_id, conf):
             return float(correction)
 
     else:
-        raise ValueError(f'Wrong configuration.'
-                         f'Please use the following format: '
-                         f'(model_type->str, model_config->str or number, is_nT->bool)'
-                         f'User specify {conf} please modify')
+        raise ValueError("Wrong configuration. "
+                         "Please use the following format: "
+                         "(model_type->str, model_config->str or number, is_nT->bool) "
+                         f"User specify {conf} please modify")
+
 
 @export
 def get_config_from_cmt(run_id, conf):
@@ -119,11 +120,11 @@ def get_config_from_cmt(run_id, conf):
         # Legacy support for pax files
         return conf
     if not isinstance(conf, tuple):
-        raise ValueError(f'conf must be a tuple')
+        raise ValueError("conf must be a tuple")
     if not len(conf) == 3:
-        raise ValueError(f'conf must have three elements: '
-                         f'the model type, its specific configuration '
-                         f'and detector (True = nT)')
+        raise ValueError("conf must have three elements: "
+                         "the model type, its specific configuration "
+                         "and detector (True = nT)")
     model_type, model_conf, is_nt = conf
     if model_type == 'CMT_model':
         cmt = straxen.CorrectionsManagementServices(is_nt=is_nt)
@@ -131,7 +132,7 @@ def get_config_from_cmt(run_id, conf):
         this_file = ' '.join(map(str, this_file))
 
     else:
-        raise ValueError(f'Wrong NN configuration, please look at this {nn_config} '
-                         'and modify it accordingly')
+        raise ValueError(f"Wrong NN configuration, please look at this {nn_config} "
+                         "and modify it accordingly")
 
     return this_file

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -106,10 +106,12 @@ def get_correction_from_cmt(run_id, conf):
             return int(correction)
         else:
             return float(correction)
+
     else:
         raise ValueError(f'Wrong configuration.'
                          f'Please use the following format: '
-                         f'(model_type->str, model_config->str, is_nT->bool)')
+                         f'(model_type->str, model_config->str or number, is_nT->bool)'
+                         f'User specify {conf} please modify')
 
 @export
 def get_config_from_cmt(run_id, conf):

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -87,17 +87,13 @@ def get_correction_from_cmt(run_id, conf):
     if isinstance(conf, tuple) and len(conf) == 3:
         is_nt = conf[-1]
 
-        # check you are not asking for a cte value....
         model_type, global_version = conf[:2]
+        correction = global_version  # in case is a single value
         if 'constant' in model_type:
-            if not isinstance(global_version, float):
+            if not isinstance(global_version, (float, int)):
                 raise ValueError(f'User specify a model type {model_type} '
                                  f'and should provide a number. Got: '
                                  f'{type(global_version)}')
-            if 'samples' in model_type:  # samples are int others are float 
-                return int(global_version)
-            else:
-                return float(global_version)
         else:
             cmt = straxen.CorrectionsManagementServices(is_nt=is_nt)
             correction = cmt.get_corrections_config(run_id, conf[:2])
@@ -106,11 +102,14 @@ def get_correction_from_cmt(run_id, conf):
                                  f'please check it is implemented in CMT. '
                                  f'for nT = {is_nt}')
 
-            if 'samples' in model_type:  # samples are int others are float 
-                return int(correction)
-            else:
-                return float(correction)
-
+        if 'samples' in model_type:
+            return int(correction)
+        else:
+            return float(correction)
+    else:
+        raise ValueError(f'Wrong configuration.'
+                         f'Please use the following format: '
+                         f'(model_type->str, model_config->str, is_nT->bool)')
 
 @export
 def get_config_from_cmt(run_id, conf):

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -374,13 +374,11 @@ class EventPositions(strax.Plugin):
             (0, pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json')),
             (170118_1327, pax_file('XENON1T_s2_xy_ly_SR1_v2.2.json'))]),
    strax.Option(
-        'elife_file',
+        'elife_conf',
         default=('elife_constant', 700000., True),
-        help='Electron lifetime model '
-             'To use a constant value, provide a link (as this default) To use'
-             'the corrections management tools specify the following:'
+        help='Electron lifetime '
              'Specify as (model_type->str, model_config->str, is_nT->bool) '
-             'where model_type can be "elife_model" or "elife_constant" '
+             'where model_type can be "elife" or "elife_constant" '
              'and model_config can be a version'
    ))
 class CorrectedAreas(strax.Plugin):
@@ -410,7 +408,7 @@ class CorrectedAreas(strax.Plugin):
                 get_resource(self.config['s1_relative_lce_map']))
         self.s2_map = InterpolatingMap(
                 get_resource(get_config_from_cmt(self.run_id, self.config['s2_xy_correction_map'])))
-        self.elife = get_correction_from_cmt(self.run_id, self.config['elife_file'])
+        self.elife = get_correction_from_cmt(self.run_id, self.config['elife_conf'])
 
     def compute(self, events):
         # S1 corrections depend on the actual corrected event position.

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -3,7 +3,7 @@ import strax
 import numpy as np
 
 from straxen.common import pax_file, get_resource, first_sr1_run, aux_repo
-from straxen.get_corrections import get_elife, get_config_from_cmt
+from straxen.get_corrections import get_correction_from_cmt, get_config_from_cmt
 from straxen.itp_map import InterpolatingMap
 export, __all__ = strax.exporter()
 
@@ -375,7 +375,7 @@ class EventPositions(strax.Plugin):
             (170118_1327, pax_file('XENON1T_s2_xy_ly_SR1_v2.2.json'))]),
    strax.Option(
         'elife_file',
-        default=aux_repo + '3548132b55f81a43654dba5141366041e1daaf01/strax_files/elife.npy',
+        default=('elife_constant', 700000., True),
         help='Electron lifetime model '
              'To use a constant value, provide a link (as this default) To use'
              'the corrections management tools specify the following:'
@@ -410,7 +410,7 @@ class CorrectedAreas(strax.Plugin):
                 get_resource(self.config['s1_relative_lce_map']))
         self.s2_map = InterpolatingMap(
                 get_resource(get_config_from_cmt(self.run_id, self.config['s2_xy_correction_map'])))
-        self.elife = get_elife(self.run_id, self.config['elife_file'])
+        self.elife = get_correction_from_cmt(self.run_id, self.config['elife_file'])
 
     def compute(self, events):
         # S1 corrections depend on the actual corrected event position.

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -116,7 +116,7 @@ class nVETORecorder(strax.Plugin):
         strax.zero_out_of_bounds(lr)
         baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['nbaseline_samples_lone_records_nv'])
         strax.baseline(lr,
-                       baseline_samples=int(baseline_samples),
+                       baseline_samples=baseline_samples,
                        flip=True)
         strax.integrate(lr)
         lrs, lr = compute_lone_records(lr, self.config['channel_map']['nveto'], self.config['n_lone_records_nv'])

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -17,7 +17,7 @@ export, __all__ = strax.exporter()
     strax.Option('resolving_time_recorder_nv', type=int, default=600,
                  help="Resolving time of the coincidence in ns."),
     strax.Option('nbaseline_samples_lone_records_nv', type=int,
-                 default_by_run=[(0, 10), (12684, 26)], track=True,
+                 default=('baseline_samples_nv', 'ONLINE', True), track=True,
                  help="Number of samples used in baseline rms calculation"),
     strax.Option('n_lone_records_nv', type=int, default=2, track=False,
                  help="Number of lone hits to be stored per channel for diagnostic reasons."),
@@ -114,8 +114,9 @@ class nVETORecorder(strax.Plugin):
 
         lr = strax.sort_by_time(lr)
         strax.zero_out_of_bounds(lr)
+        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['nbaseline_samples_lone_records_nv']) 
         strax.baseline(lr,
-                       baseline_samples=self.config['nbaseline_samples_lone_records_nv'],
+                       baseline_samples=baseline_samples,
                        flip=True)
         strax.integrate(lr)
         lrs, lr = compute_lone_records(lr, self.config['channel_map']['nveto'], self.config['n_lone_records_nv'])

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -16,7 +16,7 @@ export, __all__ = strax.exporter()
                  help="Pretrigger time before coincidence window in ns."),
     strax.Option('resolving_time_recorder_nv', type=int, default=600,
                  help="Resolving time of the coincidence in ns."),
-    strax.Option('nbaseline_samples_lone_records_nv', type=int,
+    strax.Option('nbaseline_samples_lone_records_nv', type=tuple,
                  default=('baseline_samples_nv', 'ONLINE', True), track=True,
                  help="Number of samples used in baseline rms calculation"),
     strax.Option('n_lone_records_nv', type=int, default=2, track=False,

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -114,7 +114,7 @@ class nVETORecorder(strax.Plugin):
 
         lr = strax.sort_by_time(lr)
         strax.zero_out_of_bounds(lr)
-        baseline_samples = int(straxen.get_correction_from_cmt(self.run_id, self.config['nbaseline_samples_lone_records_nv'])) 
+        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['nbaseline_samples_lone_records_nv']) 
         strax.baseline(lr,
                        baseline_samples=baseline_samples,
                        flip=True)

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -114,7 +114,7 @@ class nVETORecorder(strax.Plugin):
 
         lr = strax.sort_by_time(lr)
         strax.zero_out_of_bounds(lr)
-        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['nbaseline_samples_lone_records_nv']) 
+        baseline_samples = int(straxen.get_correction_from_cmt(self.run_id, self.config['nbaseline_samples_lone_records_nv'])) 
         strax.baseline(lr,
                        baseline_samples=baseline_samples,
                        flip=True)

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -114,9 +114,9 @@ class nVETORecorder(strax.Plugin):
 
         lr = strax.sort_by_time(lr)
         strax.zero_out_of_bounds(lr)
-        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['nbaseline_samples_lone_records_nv']) 
+        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['nbaseline_samples_lone_records_nv'])
         strax.baseline(lr,
-                       baseline_samples=baseline_samples,
+                       baseline_samples=int(baseline_samples),
                        flip=True)
         strax.integrate(lr)
         lrs, lr = compute_lone_records(lr, self.config['channel_map']['nveto'], self.config['n_lone_records_nv'])

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -56,6 +56,11 @@ class nVETORecorder(strax.Plugin):
 
     data_kind = {key: key for key in provides}
 
+    def setup(self):
+        
+        baseline_samples = straxen.get_correction_from_cmt(self.run_id,
+                                                           self.config['nbaseline_samples_lone_records_nv'])
+        
     def infer_dtype(self):
         self.record_length = strax.record_length_from_dtype(
             self.deps['raw_records_nv'].dtype_for('raw_records_nv'))
@@ -114,7 +119,6 @@ class nVETORecorder(strax.Plugin):
 
         lr = strax.sort_by_time(lr)
         strax.zero_out_of_bounds(lr)
-        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['nbaseline_samples_lone_records_nv'])
         strax.baseline(lr,
                        baseline_samples=baseline_samples,
                        flip=True)

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -58,7 +58,7 @@ class nVETORecorder(strax.Plugin):
 
     def setup(self):
         
-        baseline_samples = straxen.get_correction_from_cmt(self.run_id,
+        self.baseline_samples = straxen.get_correction_from_cmt(self.run_id,
                                                            self.config['nbaseline_samples_lone_records_nv'])
         
     def infer_dtype(self):
@@ -120,7 +120,7 @@ class nVETORecorder(strax.Plugin):
         lr = strax.sort_by_time(lr)
         strax.zero_out_of_bounds(lr)
         strax.baseline(lr,
-                       baseline_samples=baseline_samples,
+                       baseline_samples=self.baseline_samples,
                        flip=True)
         strax.integrate(lr)
         lrs, lr = compute_lone_records(lr, self.config['channel_map']['nveto'], self.config['n_lone_records_nv'])

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -58,9 +58,9 @@ class nVETORecorder(strax.Plugin):
     
     def setup(self):
 
-       self.baseline_samples = straxen.get_correction_from_cmt(self.run_id,
-                                                               self.config['baseline_samples_nv']) 
-     
+        self.baseline_samples = straxen.get_correction_from_cmt(self.run_id,
+                                                               self.config['baseline_samples_nv'])
+ 
     def infer_dtype(self):
         self.record_length = strax.record_length_from_dtype(
             self.deps['raw_records_nv'].dtype_for('raw_records_nv'))

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -16,7 +16,7 @@ export, __all__ = strax.exporter()
                  help="Pretrigger time before coincidence window in ns."),
     strax.Option('resolving_time_recorder_nv', type=int, default=600,
                  help="Resolving time of the coincidence in ns."),
-    strax.Option('nbaseline_samples_lone_records_nv', type=tuple,
+    strax.Option('baseline_samples_nv', type=tuple,
                  default=('baseline_samples_nv', 'ONLINE', True), track=True,
                  help="Number of samples used in baseline rms calculation"),
     strax.Option('n_lone_records_nv', type=int, default=2, track=False,
@@ -55,12 +55,12 @@ class nVETORecorder(strax.Plugin):
                 'lone_raw_record_statistics_nv')
 
     data_kind = {key: key for key in provides}
-
+    
     def setup(self):
-        
-        self.baseline_samples = straxen.get_correction_from_cmt(self.run_id,
-                                                           self.config['nbaseline_samples_lone_records_nv'])
-        
+
+       self.baseline_samples = straxen.get_correction_from_cmt(self.run_id,
+                                                               self.config['baseline_samples_nv']) 
+     
     def infer_dtype(self):
         self.record_length = strax.record_length_from_dtype(
             self.deps['raw_records_nv'].dtype_for('raw_records_nv'))

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -51,7 +51,7 @@ class nVETOPulseProcessing(strax.Plugin):
 
     def setup(self):
 
-        baseline_samples = straxen.get_correction_from_cmt(self.run_id,
+        self.baseline_samples = straxen.get_correction_from_cmt(self.run_id,
                                                            self.config['baseline_samples_nv'])
 
     def infer_dtype(self):
@@ -69,7 +69,7 @@ class nVETOPulseProcessing(strax.Plugin):
         r = strax.sort_by_time(r)
         strax.zero_out_of_bounds(r)
         strax.baseline(r,
-                       baseline_samples=baseline_samples,
+                       baseline_samples=self.baseline_samples,
                        flip=True)
 
         if self.config['min_samples_alt_baseline_nv']:

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -63,7 +63,7 @@ class nVETOPulseProcessing(strax.Plugin):
 
         r = strax.sort_by_time(r)
         strax.zero_out_of_bounds(r)
-        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['baseline_samples_nv']) 
+        baseline_samples = int(straxen.get_correction_from_cmt(self.run_id, self.config['baseline_samples_nv'])) 
         strax.baseline(r,
                        baseline_samples=baseline_samples,
                        flip=True)

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -63,9 +63,9 @@ class nVETOPulseProcessing(strax.Plugin):
 
         r = strax.sort_by_time(r)
         strax.zero_out_of_bounds(r)
-        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['baseline_samples_nv']) 
+        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['baseline_samples_nv'])
         strax.baseline(r,
-                       baseline_samples=baseline_samples,
+                       baseline_samples=int(baseline_samples),
                        flip=True)
 
         if self.config['min_samples_alt_baseline_nv']:

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -53,7 +53,7 @@ class nVETOPulseProcessing(strax.Plugin):
         
         self.baseline_samples = straxen.get_correction_from_cmt(self.run_id,
                                                                 self.config['baseline_samples_nv'])
- 
+
     def infer_dtype(self):
         record_length = strax.record_length_from_dtype(
             self.deps['raw_records_coin_nv'].dtype_for('raw_records_coin_nv'))

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -14,8 +14,7 @@ MV_PREAMBLE = 'Muno-Veto Plugin: Same as the corresponding nVETO-PLugin.\n'
         help='Save (left, right) samples besides hits; cut the rest'),
     strax.Option(
         'baseline_samples_nv',
-        default_by_run=[(0, 10),
-                        (12684, 26)], track=True,
+        default=('baseline_samples_nv', 'ONLINE', True), track=True,
         help='Number of samples to use at the start of the pulse to determine '
              'the baseline'),
     strax.Option(
@@ -64,8 +63,9 @@ class nVETOPulseProcessing(strax.Plugin):
 
         r = strax.sort_by_time(r)
         strax.zero_out_of_bounds(r)
+        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['baseline_samples_nv']) 
         strax.baseline(r,
-                       baseline_samples=self.config['baseline_samples_nv'],
+                       baseline_samples=baseline_samples,
                        flip=True)
 
         if self.config['min_samples_alt_baseline_nv']:

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -63,7 +63,7 @@ class nVETOPulseProcessing(strax.Plugin):
 
         r = strax.sort_by_time(r)
         strax.zero_out_of_bounds(r)
-        baseline_samples = int(straxen.get_correction_from_cmt(self.run_id, self.config['baseline_samples_nv'])) 
+        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['baseline_samples_nv']) 
         strax.baseline(r,
                        baseline_samples=baseline_samples,
                        flip=True)

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -65,7 +65,7 @@ class nVETOPulseProcessing(strax.Plugin):
         strax.zero_out_of_bounds(r)
         baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['baseline_samples_nv'])
         strax.baseline(r,
-                       baseline_samples=int(baseline_samples),
+                       baseline_samples=baseline_samples,
                        flip=True)
 
         if self.config['min_samples_alt_baseline_nv']:

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -14,7 +14,7 @@ MV_PREAMBLE = 'Muno-Veto Plugin: Same as the corresponding nVETO-PLugin.\n'
         help='Save (left, right) samples besides hits; cut the rest'),
     strax.Option(
         'baseline_samples_nv',
-        default=('baseline_samples_nv', 'ONLINE', True), track=True,
+        default=('baseline_samples_nv', 'ONLINE', True), type=tuple, track=True,
         help='Number of samples to use at the start of the pulse to determine '
              'the baseline'),
     strax.Option(
@@ -50,10 +50,10 @@ class nVETOPulseProcessing(strax.Plugin):
     ends_with = '_nv'
 
     def setup(self):
-
+        
         self.baseline_samples = straxen.get_correction_from_cmt(self.run_id,
-                                                           self.config['baseline_samples_nv'])
-
+                                                                self.config['baseline_samples_nv'])
+ 
     def infer_dtype(self):
         record_length = strax.record_length_from_dtype(
             self.deps['raw_records_coin_nv'].dtype_for('raw_records_coin_nv'))
@@ -245,6 +245,9 @@ class muVETOPulseProcessing(nVETOPulseProcessing):
     provides = 'records_mv'
     data_kind = 'records_mv'
     child_plugin = True
+
+    def setup(self):
+        self.baseline_samples = self.config['baseline_samples_mv']
 
     def infer_dtype(self):
         record_length = strax.record_length_from_dtype(

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -49,6 +49,11 @@ class nVETOPulseProcessing(strax.Plugin):
     data_kind = 'records_nv'
     ends_with = '_nv'
 
+    def setup(self):
+
+        baseline_samples = straxen.get_correction_from_cmt(self.run_id,
+                                                           self.config['baseline_samples_nv'])
+
     def infer_dtype(self):
         record_length = strax.record_length_from_dtype(
             self.deps['raw_records_coin_nv'].dtype_for('raw_records_coin_nv'))
@@ -63,7 +68,6 @@ class nVETOPulseProcessing(strax.Plugin):
 
         r = strax.sort_by_time(r)
         strax.zero_out_of_bounds(r)
-        baseline_samples = straxen.get_correction_from_cmt(self.run_id, self.config['baseline_samples_nv'])
         strax.baseline(r,
                        baseline_samples=baseline_samples,
                        flip=True)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -23,13 +23,14 @@ testing_config_nT = dict(
      straxen.aux_repo + '58e615f99a4a6b15e97b12951c510de91ce06045/fax_files/to_pe_nt.npy'),
     s2_xy_correction_map = straxen.pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json'),
     elife_conf = ('elife_constant', 700000., True),
-    baseline_samples_nv = ('baseline_samples_nv_constant', 10., True),
-    nbaseline_samples_lone_records_nv = ('baseline_samples_nv_constant', 10., True)
+    baseline_samples_nv = ('baseline_samples_nv_constant', 10, True),
+    nbaseline_samples_lone_records_nv = ('baseline_samples_nv_constant', 10, True)
 )
 
 testing_config_1T = dict(
     hev_gain_model=('to_pe_constant', 0.0085),
-    gain_model=('to_pe_constant', 0.0085)
+    gain_model=('to_pe_constant', 0.0085),
+    elife_conf = ('elife_constant', 700000., False)
 )
 
 test_run_id_nT = '008900'

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -21,15 +21,15 @@ testing_config_nT = dict(
     gain_model=
     ('to_pe_per_run',
      straxen.aux_repo + '58e615f99a4a6b15e97b12951c510de91ce06045/fax_files/to_pe_nt.npy'),
-    s2_xy_correction_map = straxen.pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json'),
-    elife_conf = ('elife_constant', 700000., True),
-    baseline_samples_nv = ('baseline_samples_nv_constant', 10, True),
+    s2_xy_correction_map=straxen.pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json'),
+    elife_conf=('elife_constant', 700000., True),
+    baseline_samples_nv=('baseline_samples_nv_constant', 10, True),
 )
 
 testing_config_1T = dict(
     hev_gain_model=('to_pe_constant', 0.0085),
     gain_model=('to_pe_constant', 0.0085),
-    elife_conf = ('elife_constant', 700000., False)
+    elife_conf=('elife_constant', 700000., False),
 )
 
 test_run_id_nT = '008900'

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -23,8 +23,8 @@ testing_config_nT = dict(
      straxen.aux_repo + '58e615f99a4a6b15e97b12951c510de91ce06045/fax_files/to_pe_nt.npy'),
     s2_xy_correction_map = straxen.pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json'),
     elife_file = ('elife_constant', 700000., True),
-    baseline_samples_nv = ('baseline_samples_nv', 10, False),
-    nbaseline_samples_lone_records_nv = ('baseline_samples_nv', 10, False)
+    baseline_samples_nv = ('baseline_samples_nv_constant', 10., False),
+    nbaseline_samples_lone_records_nv = ('baseline_samples_nv_constant', 10., False)
 )
 
 testing_config_1T = dict(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -21,8 +21,10 @@ testing_config_nT = dict(
     gain_model=
     ('to_pe_per_run',
      straxen.aux_repo + '58e615f99a4a6b15e97b12951c510de91ce06045/fax_files/to_pe_nt.npy'),
-    s2_xy_correction_map=straxen.pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json'),
-    elife_file=straxen.aux_repo + '3548132b55f81a43654dba5141366041e1daaf01/strax_files/elife.npy'
+    s2_xy_correction_map = straxen.pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json'),
+    elife_file = ('elife_constant', 700000., True),
+    baseline_samples_nv = ('baseline_samples_nv', 10, False),
+    nbaseline_samples_lone_records_nv = ('baseline_samples_nv', 10, False)
 )
 
 testing_config_1T = dict(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -22,9 +22,9 @@ testing_config_nT = dict(
     ('to_pe_per_run',
      straxen.aux_repo + '58e615f99a4a6b15e97b12951c510de91ce06045/fax_files/to_pe_nt.npy'),
     s2_xy_correction_map = straxen.pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json'),
-    elife_file = ('elife_constant', 700000., True),
-    baseline_samples_nv = ('baseline_samples_nv_constant', 10., False),
-    nbaseline_samples_lone_records_nv = ('baseline_samples_nv_constant', 10., False)
+    elife_conf = ('elife_constant', 700000., True),
+    baseline_samples_nv = ('baseline_samples_nv_constant', 10., True),
+    nbaseline_samples_lone_records_nv = ('baseline_samples_nv_constant', 10., True)
 )
 
 testing_config_1T = dict(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -24,7 +24,6 @@ testing_config_nT = dict(
     s2_xy_correction_map = straxen.pax_file('XENON1T_s2_xy_ly_SR0_24Feb2017.json'),
     elife_conf = ('elife_constant', 700000., True),
     baseline_samples_nv = ('baseline_samples_nv_constant', 10, True),
-    nbaseline_samples_lone_records_nv = ('baseline_samples_nv_constant', 10, True)
 )
 
 testing_config_1T = dict(


### PR DESCRIPTION
Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible

**What is the problem / what does the code in this PR do**
Add get_correction_from_cmt, this function would return any correction value, it replace get_elife and serves as a general purpose function for single values
**Can you briefly describe how it works?**
See https://github.com/XENONnT/corrections/blob/master/CMT/examples/CMT_user_guide.ipynb block [5]
`elife_file = ('elife','ONLINE',True)`
`straxen.get_correction_from_cmt('010126', elife_file)`
**Can you give a minimal working example (or illustrate with a figure)?**
see above
Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
