### PR TITLE
upload compressor from metadata to rundoc

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -73,7 +73,7 @@ what bootstrax is thinking of at the moment.
   - **disk_used**: used part of the disk whereto this bootstrax instance
    is writing to (in percent).
 """
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 import argparse
 from datetime import datetime, timedelta, timezone
@@ -1076,7 +1076,7 @@ def upload_file_metadata(rd):
         if os.path.exists(loc):
             file_count = len(os.listdir(loc))
             # Can also get the latter from st.lineage_for but too lazy for that
-            data_size_mb, avg_data_size_mb, lineage_hash = None, None, None
+            data_size_mb, avg_data_size_mb, lineage_hash, compressor = None, None, None, None
             run_id = '%06d' % rd['number']
             if st_meta is not None:
                 try:
@@ -1085,6 +1085,7 @@ def upload_file_metadata(rd):
                     data_size_mb = int(np.sum(chunk_mb))
                     avg_data_size_mb = int(np.average(chunk_mb))
                     lineage_hash = md['lineage_hash']
+                    compressor = md['compressor']
                 except Exception as e:
                     log_warning(f"Cannot load metadata of {ddoc['type']}: {e}",
                                 priority='warning',
@@ -1099,7 +1100,9 @@ def upload_file_metadata(rd):
                       'data.$.meta.straxen_version': straxen.__version__,
                       'data.$.meta.size_mb': data_size_mb,
                       'data.$.meta.avg_chunk_mb': avg_data_size_mb,
-                      'data.$.meta.lineage_hash': lineage_hash}
+                      'data.$.meta.lineage_hash': lineage_hash,
+                      'data.$.meta.compressor': compressor,
+                      }
                  })
 
 


### PR DESCRIPTION
## Upload compressor from metadata to rundoc
When uploading several details about the compressor used for a given entry in the rundoc, also include the compressor