### PR TITLE
Remove duplicate call to 1T sim config

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -365,7 +365,6 @@ def xenon1t_simulation(output_folder='./strax_data'):
         config=dict(
             fax_config='fax_config_1t.json',
             detector='XENON1T',
-            check_raw_record_overlaps=False,
             **straxen.contexts.x1t_common_config),
         **straxen.contexts.common_opts)
     st.register(wfsim.RawRecordsFromFax1T)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
```python
st = straxen.contexts.xenon1t_simulation()
```
did not work because this option was specified twice (also in the common opts)
