### PR TITLE
Check for overlapping raw_records in nT sims

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -183,7 +183,7 @@ def xenonnt_simulation(output_folder='./strax_data'):
         storage=strax.DataDirectory(output_folder),
         config=dict(detector='XENONnT',
                     fax_config='fax_config_nt_design.json',
-                    check_raw_record_overlaps=False,
+                    check_raw_record_overlaps=True,
                     **straxen.contexts.xnt_common_config,
                     ),
         **straxen.contexts.xnt_common_opts)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

I could be mistaken, but I though the `check_raw_record_overlaps=False` in the default nT sims context was there to prevent some bug now resolved. Could someone confirm?