### PR TITLE
Added fixed minimal length for temp_hitlets.

### DIFF
--- a/straxen/plugins/veto_hitlets.py
+++ b/straxen/plugins/veto_hitlets.py
@@ -100,10 +100,10 @@ class nVETOHitlets(strax.Plugin):
         hits = strax.sort_by_time(hits)
 
         # Now convert hits into temp_hitlets including the data field:
+        nsamples = 200
         if len(hits):
-            nsamples = hits['length'].max()
-        else:
-            nsamples = 0
+            nsamples = max(hits['length'].max(), nsamples)
+
         temp_hitlets = np.zeros(len(hits), strax.hitlet_with_data_dtype(n_samples=nsamples))
     
         # Generating hitlets and copying relevant information from hits to hitlets.


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Super quick bug fix for the numba "cannot unbox PyObject as array bug". 

I do not fully understand the problem. But to me it look like some sort of race condition during the caching of numba functions. This seem to occur if the data-types change to frequently, leading to a too frequent recompilation of the code. 
As a side effect processing speed increase by almost a factor 2. 