### PR TITLE
Nveto recorder updated

### DIFF
--- a/straxen/common.py
+++ b/straxen/common.py
@@ -23,7 +23,7 @@ import straxen
 
 export, __all__ = strax.exporter()
 __all__ += ['straxen_dir', 'first_sr1_run', 'tpc_r', 'tpc_z', 'aux_repo',
-            'n_tpc_pmts', 'n_top_pmts', 'n_hard_aqmon_start', 'ADC_TO_E', 
+            'n_tpc_pmts', 'n_top_pmts', 'n_hard_aqmon_start', 'ADC_TO_E',
             'n_nveto_pmts', 'n_mveto_pmts', 'tpc_pmt_radius']
 
 straxen_dir = os.path.dirname(os.path.abspath(
@@ -31,7 +31,7 @@ straxen_dir = os.path.dirname(os.path.abspath(
 
 aux_repo = 'https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/'
 
-tpc_r = 66.4   # [CM], Not really radius, but apothem: from MC paper draft 1.0
+tpc_r = 66.4  # [CM], Not really radius, but apothem: from MC paper draft 1.0
 tpc_z = 148.6515  # [CM], distance between the bottom of gate and top of cathode wires
 n_tpc_pmts = 494
 n_top_pmts = 253
@@ -40,7 +40,7 @@ n_hard_aqmon_start = 800
 n_nveto_pmts = 120
 n_mveto_pmts = 84
 
-tpc_pmt_radius = 7.62/2  # cm
+tpc_pmt_radius = 7.62 / 2  # cm
 
 # Convert from ADC * samples to electrons emitted by PMT
 # see pax.dsputils.adc_to_pe for calculation. Saving this number in straxen as
@@ -67,7 +67,7 @@ def pmt_positions(xenon1t=False):
             dict(x=q['position']['x'],
                  y=q['position']['y'],
                  i=q['pmt_position'],
-                 array=q.get('array','other'))
+                 array=q.get('array', 'other'))
             for q in pmt_config[:248]])
     else:
         return resource_from_url(
@@ -375,6 +375,9 @@ def remap_channels(data, verbose=True, safe_copy=False, _tqdm=False, ):
         for _rep in replace:
             if _rep not in data_keys:
                 # Apparently this data doesn't have the entry we want to replace
+                continue
+            if _dat['channel'].ndim != 1:
+                # Only convert channel if they are flat and not nested.
                 continue
             # Make a buffer we can overwrite and replace with an remapped array
             buff = np.array(_data[_rep])

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -336,7 +336,12 @@ def coincidence(records, nfold=4, resolving_time=300, pre_trigger=0):
          they will be merged into a single interval.
     """
     if len(records):
-        start_times = _coincidence(records, nfold, resolving_time)
+        if nfold > 1:
+            start_times = _coincidence(records, nfold, resolving_time)
+        else:
+            # In case of a "single-fold" coincidence every thing gives
+            # the start of a new interval:
+            start_times = records['time']
         intervals = _merge_intervals(start_times-pre_trigger, 
                                      resolving_time+pre_trigger)
     else:

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -31,8 +31,8 @@ export, __all__ = strax.exporter()
     strax.Option('channel_map', track=False, type=immutabledict,
                  help="frozendict mapping subdetector to (min, max) "
                       "channel number."),
-    strax.Option('check_raw_record_overlaps',
-                 default=True, track=False,
+    strax.Option('check_raw_record_overlaps_nv',
+                 default=False, track=False,
                  help='Crash if any of the pulses in raw_records overlap with others '
                       'in the same channel'),
 )

--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -83,7 +83,7 @@ class nVETORecorder(strax.Plugin):
         return {k: v for k, v in zip(self.provides, dtypes)}
 
     def compute(self, raw_records_nv, start, end):
-        if self.config['check_raw_record_overlaps']:
+        if self.config['check_raw_record_overlaps_nv']:
             straxen.check_overlaps(raw_records_nv, n_channels=3000)
         # Cover the case if we do not want to have any coincidence:
         if self.config['coincidence_level_recorder_nv'] <= 1:

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -38,7 +38,7 @@ class nVETOPulseProcessing(strax.Plugin):
         2. Find hits and apply ZLE
         3. Remove empty fragments.
     """
-    __version__ = '0.0.7'
+    __version__ = '0.0.8'
 
     parallel = 'process'
     rechunk_on_save = False

--- a/straxen/plugins/veto_pulse_processing.py
+++ b/straxen/plugins/veto_pulse_processing.py
@@ -84,8 +84,6 @@ class nVETOPulseProcessing(strax.Plugin):
         r = strax.cut_outside_hits(r, hits, left_extension=le, right_extension=re)
         strax.zero_out_of_bounds(r)
 
-        rlinks = strax.record_links(r)
-        r = clean_up_empty_records(r, rlinks, only_last=True)
         return r
     
     


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In this PR we make some modifications on the low level processing of the neutron veto. 

1. We change from a fragment based to a hit based coincidence software trigger. During the development of this algorithm I thought that the number of multiple hits per fragment would be negligible. I thought our waveform would only be 40 samples long and hence multiple hits would also be reflected by multiple fragments. The new hit based coincidence is about 2.5 % slower compared to the fragment based algorithm. The only mild performance loss is given by the fact that most of the processing time is spend for decompression. I can provide a more detailed profile if required. 
2. As requested by @mzks I added the support for single-fold coincidences to  `coincidence`.
3. I removed clean_up_empty_records from nVETOPulseProcessing. This function removes "empty" (= data complete filled with zeros) fragments from our data. As for the same reason as mentioned in 1. there are only very few fragments without any data, leading to a negligible reduction in the overall storage size. However, matching between `raw_records` and `records` becomes  much more complicated. Hence I removed the function. 

**Updated:**
* I also had to update _test_plugins and the PMT channel remapping to get the tests working.
* We decided to switch of the overlapping pulse test until the problem is solved. 