### PR TITLE
fix abandonning

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1643,16 +1643,15 @@ def cleanup_db():
     # there is no point in retrying them
     abandon_queries = [
         ({'tags.name': 'abandon',
-          'bootstrax.state':'done',
+          'bootstrax.state': 'done',
           'start': {'$gt': now(-timeouts['abandoning_allowed'])}},
          "Run has an 'abandon' tag"),
         ({'tags.name': 'abandon', 
-          'bootstrax.state': {'$in': ['busy', 'failed']}},
-         "Run has an 'abandon' tag and was failing/busy"),
+          'bootstrax.state': 'failed'},
+         "Run has an 'abandon' tag and was failing"),
         ]
 
     for query, failure_message in abandon_queries:
-        query['bootstrax.state'] = {'$ne': 'abandoned'}
         failure_message += ' -- run has been abandoned'
         while True:
             send_heartbeat()


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Don't create race conditions where a run is processing a run while processing. If the run fails, the status gets updated with failed again, we then need to re-abandon the run. As such only allow `done` or `failed` runs to be abandoned.
