### PR TITLE
fix test to use tempdir

### DIFF
--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -52,6 +52,11 @@ def test_xenon1t_dali():
 
 
 def test_demo():
+    """
+    Test the demo context. Since we download the folder to the current
+        working directory, make sure we are in a tempfolder where we
+        can write the data to
+    """
     with tempfile.TemporaryDirectory() as temp_dir:
         try:
             print("Temporary directory is ", temp_dir)

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -2,6 +2,8 @@
 a field (i.e. can build the dependencies in the context correctly)
 See issue #233 and PR #236"""
 from straxen.contexts import *
+import tempfile
+import os
 
 
 def import_wfsim():
@@ -50,8 +52,16 @@ def test_xenon1t_dali():
 
 
 def test_demo():
-    st = demo()
-    st.search_field('time')
+    with tempfile.TemporaryDirectory() as temp_dir:
+        try:
+            print("Temporary directory is ", temp_dir)
+            os.chdir(temp_dir)
+            st = demo()
+            st.search_field('time')
+        # On windows, you cannot delete the current process'
+        # working directory, so we have to chdir out first.
+        finally:
+            os.chdir('..')
 
 
 def test_fake_daq():


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
On dali, this test was failing because the tempdir was occupied by files used by others. The demo context download the data to the current working directory.

**Can you briefly describe how it works?**
To fix this, make sure that we are at an available space on dali to store it.

**Can you give a minimal working example (or illustrate with a figure)?**
```bash
cd straxen
pytest
```
