### PR TITLE
Abbreviated event display restructure #418

### DIFF
--- a/straxen/analyses/event_display.py
+++ b/straxen/analyses/event_display.py
@@ -8,7 +8,6 @@ import pytz
 
 export, __all__ = strax.exporter()
 
-
 # Default attributes to display in the event_display (looks little
 # complicated but just repeats same fields for S1 S1)
 # Should be of form as below where {v} wil be filled with the value of
@@ -36,33 +35,58 @@ EVENT_DISPLAY_DEFAULT_INFO = (('time', '{v} ns'),
                               )
 
 
-def _scatter_rec(_event,
-                 recs=None,
-                 scatter_kwargs=None):
-    """Convenient wrapper to show posrec of three algorithms for xenonnt"""
-    if recs is None:
-        recs = ('mlp', 'cnn', 'gcn')
-    elif len(recs) > 5:
-        raise ValueError("I only got five markers/colors")
-    if scatter_kwargs is None:
-        scatter_kwargs = {}
-    scatter_kwargs.setdefault('s', 100)
-    scatter_kwargs.setdefault('alpha', 0.8)
-    shapes = ('v', '^', '>', '<', '*', 'D', "P")
-    colors = ('brown', 'orange', 'lightcoral', 'gold', 'lime', 'crimson')
-    for _i, _r in enumerate(recs):
-        x, y = _event[f's2_x_{_r}'], _event[f's2_y_{_r}']
-        if np.isnan(x) or np.isnan(y):
-            continue
-        plt.scatter(x, y,
-                    marker=shapes[_i],
-                    c=colors[_i],
-                    label=_r.upper(),
-                    **scatter_kwargs
-                    )
-    plt.legend(loc='best', fontsize="x-small", markerscale=0.5)
+# Don't be smart with the arguments, since it is a minianalyses we
+# need to have all the arguments
+@straxen.mini_analysis(requires=('event_info', 'event_posrec_many'))
+def event_display_simple(context,
+                         run_id,
+                         events,
+                         to_pe,
+                         records_matrix=True,
+                         s2_fuzz=50,
+                         s1_fuzz=0,
+                         max_peaks=500,
+                         xenon1t=False,
+                         display_peak_info=PEAK_DISPLAY_DEFAULT_INFO,
+                         display_event_info=EVENT_DISPLAY_DEFAULT_INFO,
+                         s1_hp_kwargs=None,
+                         s2_hp_kwargs=None,
+                         event_time_limit=None,
+                         plot_all_positions=True,
+                         ):
+    f"""
+    {event_docs}
+    {event_returns}
+    """
+    fig = plt.figure(figsize=(12, 8), facecolor="white")
+    grid = plt.GridSpec(2, 3, hspace=0.5)
+    axes = dict()
+    axes["ax_s1"] = fig.add_subplot(grid[0, 0])
+    axes["ax_s2"] = fig.add_subplot(grid[0, 1])
+    axes["ax_s2_hp_t"] = fig.add_subplot(grid[0, 2])
+    axes["ax_ev"] = fig.add_subplot(grid[1, :])
+
+    return _event_display(context,
+                          run_id,
+                          events,
+                          to_pe,
+                          axes=axes,
+                          records_matrix=records_matrix,
+                          s2_fuzz=s2_fuzz,
+                          s1_fuzz=s1_fuzz,
+                          max_peaks=max_peaks,
+                          xenon1t=xenon1t,
+                          display_peak_info=display_peak_info,
+                          display_event_info=display_event_info,
+                          s1_hp_kwargs=s1_hp_kwargs,
+                          s2_hp_kwargs=s2_hp_kwargs,
+                          event_time_limit=event_time_limit,
+                          plot_all_positions=plot_all_positions,
+                          )
 
 
+# Don't be smart with the arguments, since it is a minianalyses we
+# need to have all the arguments
 @straxen.mini_analysis(requires=('event_info', 'event_posrec_many'))
 def event_display(context,
                   run_id,
@@ -77,123 +101,133 @@ def event_display(context,
                   display_event_info=EVENT_DISPLAY_DEFAULT_INFO,
                   s1_hp_kwargs=None,
                   s2_hp_kwargs=None,
-                  axes = None,
-                  event_time_limit = None,
-                  plot_all_positions = True,
+                  event_time_limit=None,
+                  plot_all_positions=True,
                   ):
+    f"""
+    {event_docs}
+    {event_returns}
     """
-    Make a waveform-display of a given event. Requires events, peaks and
-        peaklets (optionally: records). NB: time selection should return
-        only one event!
-
-    :param context: strax.Context provided by the minianalysis wrapper
-    :param run_id: run-id of the event
-    :param events: events, provided by the minianalysis wrapper
-    :param to_pe: gains, provided by the minianalysis wrapper
-    :param records_matrix: False (no record matrix), True, or "raw"
-        (show raw-record matrix)
-    :param s2_fuzz: extra time around main S2 [ns]
-    :param s1_fuzz: extra time around main S1 [ns]
-    :param max_peaks: max peaks for plotting in the wf plot
-    :param xenon1t: True: is 1T, False: is nT
-    :param display_peak_info: tuple, items that will be extracted from
-        event and displayed in the event info panel see above for format
-    :param display_event_info: tuple, items that will be extracted from
-        event and displayed in the peak info panel see above for format
-    :param s1_hp_kwargs: dict, optional kwargs for S1 hitpatterns
-    :param s2_hp_kwargs: dict, optional kwargs for S2 hitpatterns
-    :param axes: if a dict of matplotlib axes (w/ same keys as below,
-        and empty/None for panels not filled)
-    :param event_time_limit = overrides x-axis limits of event
-        plot
-    :param plot_all_positions if True, plot best-fit positions 
-        from all posrec algorithms
-    :return: axes used for plotting:
-        ax_s1, ax_s2, ax_s1_hp_t, ax_s1_hp_b,
-        ax_event_info, ax_peak_info, ax_s2_hp_t, ax_s2_hp_b,
-        ax_ev,
-        ax_rec
-        Where those panels (axes) are:
-            - ax_s1, main S1 peak
-            - ax_s2, main S2 peak
-            - ax_s1_hp_t, S1 top hit pattern
-            - ax_s1_hp_b, S1 bottom hit pattern
-            - ax_s2_hp_t, S2 top hit pattern
-            - ax_s2_hp_b, S2 bottom hit pattern
-            - ax_event_info, text info on the event
-            - ax_peak_info, text info on the main S1 and S2
-            - ax_ev, waveform of the entire event
-            - ax_rec, (raw)record matrix (if any otherwise None)
-    """
-    if len(events) != 1:
-        raise ValueError(f'Found {len(events)} only request one')
-    event = events[0]
     if records_matrix not in ('raw', True, False):
         raise ValueError('Choose either "raw", True or False for records_matrix')
     if ((records_matrix == 'raw' and not context.is_stored(run_id, 'raw_records')) or
-        (isinstance(records_matrix, bool) and not context.is_stored(run_id, 'records'))):   # noqa
+            (isinstance(records_matrix, bool) and not context.is_stored(run_id,
+                                                                        'records'))):  # noqa
         print("(raw)records not stored! Not showing records_matrix")
         records_matrix = False
-    if not context.is_stored(run_id, 'peaklets'):
-        raise strax.DataNotAvailable(f'peaklets not available for {run_id}')
-
     # Convert string to int to allow plots to be enlarged for extra panel
     _rr_resize_int = int(bool(records_matrix))
-    if axes is None:
-        fig = plt.figure(figsize=(25, 21 if _rr_resize_int else 16),
-                         facecolor='white')
-        grid = plt.GridSpec((2 + _rr_resize_int), 1, hspace=0.1+0.1*_rr_resize_int,
-                            height_ratios=[1.5, 0.5, 0.5][:2 + _rr_resize_int]
-                            )
 
-        # S1, S2, hitpatterns
-        gss_0 = gridspec.GridSpecFromSubplotSpec(2, 4, subplot_spec=grid[0], wspace=0.25, hspace=0.4)
-        ax_s1 = fig.add_subplot(gss_0[0])
-        ax_s2 = fig.add_subplot(gss_0[1])
-        ax_s1_hp_t = fig.add_subplot(gss_0[2])
-        ax_s1_hp_b = fig.add_subplot(gss_0[3])
-        ax_s2_hp_t = fig.add_subplot(gss_0[6])
-        ax_s2_hp_b = fig.add_subplot(gss_0[7])
+    fig = plt.figure(figsize=(25, 21 if _rr_resize_int else 16),
+                     facecolor='white')
+    grid = plt.GridSpec((2 + _rr_resize_int), 1, hspace=0.1 + 0.1 * _rr_resize_int,
+                        height_ratios=[1.5, 0.5, 0.5][:2 + _rr_resize_int]
+                        )
 
-        # Peak & event info
-        ax_event_info = fig.add_subplot(gss_0[4])
-        ax_peak_info = fig.add_subplot(gss_0[5])
+    # S1, S2, hitpatterns
+    gss_0 = gridspec.GridSpecFromSubplotSpec(2, 4, subplot_spec=grid[0], wspace=0.25, hspace=0.4)
+    ax_s1 = fig.add_subplot(gss_0[0])
+    ax_s2 = fig.add_subplot(gss_0[1])
+    ax_s1_hp_t = fig.add_subplot(gss_0[2])
+    ax_s1_hp_b = fig.add_subplot(gss_0[3])
+    ax_s2_hp_t = fig.add_subplot(gss_0[6])
+    ax_s2_hp_b = fig.add_subplot(gss_0[7])
 
-        # All peaks in event
-        gss_1 = gridspec.GridSpecFromSubplotSpec(1, 1, subplot_spec=grid[1])
-        ax_ev = fig.add_subplot(gss_1[0])
-        ax_rec = None
-    else:
-        ax_s1 = axes.get("ax_s1",None)
-        ax_s2 = axes.get("ax_s2",None)
-        ax_s1_hp_t = axes.get("ax_s1_hp_t",None)
-        ax_s1_hp_b = axes.get("ax_s1_hp_b",None)
-        ax_s2_hp_t = axes.get("ax_s2_hp_t",None)
-        ax_s2_hp_b = axes.get("ax_s2_hp_b",None)
-        ax_event_info = axes.get("ax_event_info",None)
-        ax_peak_info = axes.get("ax_peak_info",None)
-        ax_ev = axes.get("ax_ev",None)
-        ax_rec = axes.get("ax_rec",None)
-        fig = None
-        for _,ax in axes.items():
-            if ax is not None:
-                fig = ax.figure
+    # Peak & event info
+    ax_event_info = fig.add_subplot(gss_0[4])
+    ax_peak_info = fig.add_subplot(gss_0[5])
 
-    # titles
-    for ax, title in zip([ax_s1, ax_s1_hp_t, ax_s1_hp_b,
-                      ax_s2, ax_s2_hp_t, ax_s2_hp_b,
-                      ax_event_info, ax_peak_info],
-                      ["Main S1", "S1 top", "S1 bottom",
-                       "Main S2", "S2 top", "S2 bottom",
-                       "Event info", "Peak info"]):
-        if ax is not None:
-            ax.set_title(title)
-
+    # All peaks in event
+    gss_1 = gridspec.GridSpecFromSubplotSpec(1, 1, subplot_spec=grid[1])
+    ax_ev = fig.add_subplot(gss_1[0])
+    ax_rec = None
 
     # (raw)records matrix (optional)
     if records_matrix and ax_rec is not None:
         gss_2 = gridspec.GridSpecFromSubplotSpec(1, 1, subplot_spec=grid[2])
         ax_rec = fig.add_subplot(gss_2[0])
+    axes = dict(
+        ax_s1=ax_s1,
+        ax_s2=ax_s2,
+        ax_s1_hp_t=ax_s1_hp_t,
+        ax_s1_hp_b=ax_s1_hp_b,
+        ax_event_info=ax_event_info,
+        ax_peak_info=ax_peak_info,
+        ax_s2_hp_t=ax_s2_hp_t,
+        ax_s2_hp_b=ax_s2_hp_b,
+        ax_ev=ax_ev,
+        ax_rec=ax_rec)
+
+    return _event_display(context,
+                          run_id,
+                          events,
+                          to_pe,
+                          axes=axes,
+                          records_matrix=records_matrix,
+                          s2_fuzz=s2_fuzz,
+                          s1_fuzz=s1_fuzz,
+                          max_peaks=max_peaks,
+                          xenon1t=xenon1t,
+                          display_peak_info=display_peak_info,
+                          display_event_info=display_event_info,
+                          s1_hp_kwargs=s1_hp_kwargs,
+                          s2_hp_kwargs=s2_hp_kwargs,
+                          event_time_limit=event_time_limit,
+                          plot_all_positions=plot_all_positions,
+                          )
+
+
+def _event_display(context,
+                   run_id,
+                   events,
+                   to_pe,
+                   axes=None,
+                   records_matrix=True,
+                   s2_fuzz=50,
+                   s1_fuzz=0,
+                   max_peaks=500,
+                   xenon1t=False,
+                   display_peak_info=PEAK_DISPLAY_DEFAULT_INFO,
+                   display_event_info=EVENT_DISPLAY_DEFAULT_INFO,
+                   s1_hp_kwargs=None,
+                   s2_hp_kwargs=None,
+                   event_time_limit=None,
+                   plot_all_positions=True,
+                   ):
+    f"""{event_docs}
+    :param axes: if a dict of matplotlib axes (w/ same keys as below,
+        and empty/None for panels not filled)
+    {event_returns} 
+    """
+    if len(events) != 1:
+        raise ValueError(f'Found {len(events)} only request one')
+    event = events[0]
+
+    if not context.is_stored(run_id, 'peaklets'):
+        raise strax.DataNotAvailable(f'peaklets not available for {run_id}')
+
+    if axes is None:
+        raise ValueError(f'No axes provided')
+    ax_s1 = axes.get("ax_s1", None)
+    ax_s2 = axes.get("ax_s2", None)
+    ax_s1_hp_t = axes.get("ax_s1_hp_t", None)
+    ax_s1_hp_b = axes.get("ax_s1_hp_b", None)
+    ax_s2_hp_t = axes.get("ax_s2_hp_t", None)
+    ax_s2_hp_b = axes.get("ax_s2_hp_b", None)
+    ax_event_info = axes.get("ax_event_info", None)
+    ax_peak_info = axes.get("ax_peak_info", None)
+    ax_ev = axes.get("ax_ev", None)
+    ax_rec = axes.get("ax_rec", None)
+
+    # titles
+    for ax, title in zip([ax_s1, ax_s1_hp_t, ax_s1_hp_b,
+                          ax_s2, ax_s2_hp_t, ax_s2_hp_b,
+                          ax_event_info, ax_peak_info],
+                         ["Main S1", "S1 top", "S1 bottom",
+                          "Main S2", "S2 top", "S2 bottom",
+                          "Event info", "Peak info"]):
+        if ax is not None:
+            ax.set_title(title)
 
     # Parse the hit pattern options
     # Convert to dict (not at function definition because of mutable defaults)
@@ -286,15 +320,16 @@ def event_display(context,
                 _ = [s.set_visible(False) for s in ax.spines.values()]
 
     # Plot peaks in event
+    ev_range = None
     if ax_ev is not None:
         plt.sca(ax_ev)
         if event_time_limit is None:
-            time_range=(events['time'], events['endtime'])
+            time_range = (events['time'], events['endtime'])
         else:
             time_range = event_time_limit
 
         context.plot_peaks(run_id,
-                           time_range = time_range,
+                           time_range=time_range,
                            show_largest=max_peaks,
                            single_figure=False)
         ev_range = plt.xlim()
@@ -310,18 +345,19 @@ def event_display(context,
         if not xenon1t:
             # Top vs bottom division
             ax_rec.axhline(straxen.n_top_pmts, c='k')
-        plt.xlim(*ev_range)
+        if ev_range is not None:
+            plt.xlim(*ev_range)
 
     # Final tweaks
     if ax_s2 is not None:
         ax_s1.tick_params(axis='x', rotation=45)
     if ax_s2 is not None:
-        ax_s2.tick_params(axis='x', rotation=45)
+        ax_s1.tick_params(axis='x', rotation=45)
     if ax_ev is not None:
         ax_ev.tick_params(axis='x', rotation=0)
     title = (f'Run {run_id}. Time '
              f'{str(events["time"])[:-9]}.{str(events["time"])[-9:]}\n'
-             f'{datetime.fromtimestamp(event["time"]/1e9, tz=pytz.utc)}')
+             f'{datetime.fromtimestamp(event["time"] / 1e9, tz=pytz.utc)}')
     plt.suptitle(title, y=0.95)
     # NB: reflects panels order
     return (ax_s1, ax_s2, ax_s1_hp_t, ax_s1_hp_b,
@@ -358,3 +394,76 @@ def plot_single_event(context: strax.Context,
                                  time_range=(events[0]['time'],
                                              events[0]['endtime']),
                                  **kwargs)
+
+
+def _scatter_rec(_event,
+                 recs=None,
+                 scatter_kwargs=None):
+    """Convenient wrapper to show posrec of three algorithms for xenonnt"""
+    if recs is None:
+        recs = ('mlp', 'cnn', 'gcn')
+    elif len(recs) > 5:
+        raise ValueError("I only got five markers/colors")
+    if scatter_kwargs is None:
+        scatter_kwargs = {}
+    scatter_kwargs.setdefault('s', 100)
+    scatter_kwargs.setdefault('alpha', 0.8)
+    shapes = ('v', '^', '>', '<', '*', 'D', "P")
+    colors = ('brown', 'orange', 'lightcoral', 'gold', 'lime', 'crimson')
+    for _i, _r in enumerate(recs):
+        x, y = _event[f's2_x_{_r}'], _event[f's2_y_{_r}']
+        if np.isnan(x) or np.isnan(y):
+            continue
+        plt.scatter(x, y,
+                    marker=shapes[_i],
+                    c=colors[_i],
+                    label=_r.upper(),
+                    **scatter_kwargs
+                    )
+    plt.legend(loc='best', fontsize="x-small", markerscale=0.5)
+
+
+event_docs = """
+Make a waveform-display of a given event. Requires events, peaks and
+    peaklets (optionally: records). NB: time selection should return
+    only one event!
+
+:param context: strax.Context provided by the minianalysis wrapper
+:param run_id: run-id of the event
+:param events: events, provided by the minianalysis wrapper
+:param to_pe: gains, provided by the minianalysis wrapper
+:param records_matrix: False (no record matrix), True, or "raw"
+    (show raw-record matrix)
+:param s2_fuzz: extra time around main S2 [ns]
+:param s1_fuzz: extra time around main S1 [ns]
+:param max_peaks: max peaks for plotting in the wf plot
+:param xenon1t: True: is 1T, False: is nT
+:param display_peak_info: tuple, items that will be extracted from
+    event and displayed in the event info panel see above for format
+:param display_event_info: tuple, items that will be extracted from
+    event and displayed in the peak info panel see above for format
+:param s1_hp_kwargs: dict, optional kwargs for S1 hitpatterns
+:param s2_hp_kwargs: dict, optional kwargs for S2 hitpatterns
+:param event_time_limit = overrides x-axis limits of event
+    plot
+:param plot_all_positions if True, plot best-fit positions 
+    from all posrec algorithms
+"""
+event_returns = """
+:return: axes used for plotting:
+    ax_s1, ax_s2, ax_s1_hp_t, ax_s1_hp_b,
+    ax_event_info, ax_peak_info, ax_s2_hp_t, ax_s2_hp_b,
+    ax_ev,
+    ax_rec
+    Where those panels (axes) are:
+        - ax_s1, main S1 peak
+        - ax_s2, main S2 peak
+        - ax_s1_hp_t, S1 top hit pattern
+        - ax_s1_hp_b, S1 bottom hit pattern
+        - ax_s2_hp_t, S2 top hit pattern
+        - ax_s2_hp_b, S2 bottom hit pattern
+        - ax_event_info, text info on the event
+        - ax_peak_info, text info on the main S1 and S2
+        - ax_ev, waveform of the entire event
+        - ax_rec, (raw)record matrix (if any otherwise None)
+"""

--- a/tests/test_several.py
+++ b/tests/test_several.py
@@ -100,21 +100,18 @@ def test_several():
                              deep=True)
             plt_clf()
 
-            print('plot event displays')
-            straxen.analyses.event_display.plot_single_event(st,
-                                                             test_run_id_1T,
-                                                             events,
-                                                             xenon1t=True,
-                                                             event_number=0,
-                                                             records_matrix=True)
-            plt_clf()
             straxen.analyses.event_display.plot_single_event(st,
                                                              test_run_id_1T,
                                                              events,
                                                              xenon1t=True,
                                                              event_number=0,
                                                              records_matrix='raw')
+            st.event_display_simple(test_run_id_1T,
+                                    time_range=(events[0]['time'],
+                                                events[0]['endtime']),
+                                    xenon1t=True)
             plt_clf()
+
             st.event_display_interactive(test_run_id_1T, time_range=(events[0]['time'],
                                                                   events[0]['endtime']),
                                          xenon1t=True)


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
#418 is a nice PR that expands the usability of the static event display to single figures. With this PR, we slightly restructure the additions such that the setup of the axes etc. is done in another function then where the plotting takes place, this way, we can more easily support the simple event display as nicely drafted by @kdund .

**Can you briefly describe how it works?**
```python
st.event_display_simple
st.event_display
```
both refer to the easily customizable `_event_display`