### PR TITLE
Change records default processor

### DIFF
--- a/straxen/plugins/pulse_processing.py
+++ b/straxen/plugins/pulse_processing.py
@@ -119,7 +119,7 @@ class PulseProcessing(strax.Plugin):
         records=False,
         veto_regions=True,
         pulse_counts=True)
-    compressor = 'lz4'
+    compressor = 'zstd'
 
     depends_on = 'raw_records'
 
@@ -239,7 +239,7 @@ class PulseProcessingHighEnergy(PulseProcessing):
         records_he=False,
         pulse_counts_he=True)
     depends_on = 'raw_records_he'
-    compressor = 'lz4'
+    compressor = 'zstd'
     child_plugin = True
     save_when = strax.SaveWhen.TARGET
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
The (raw-)records processor is set at the daq. However, when re-making records, let's make sure to make it in a compressed format where ever possible.

We do need to keep in mind though that this might (potentially) lead to problems if the buffers are too big to fit into `zstd`. 

This is especially relevant for (re)processing records.