### PR TITLE
Wrap correction functions for mc optional config

### DIFF
--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -8,23 +8,28 @@ export, __all__ = strax.exporter()
 __all__ += ['FIXED_TO_PE']
 
 
-def correction_options(f):
+def correction_options(get_correction_fuction):
     """A wrapper function for functions here in the get_corrections module
     Search for special options like ["MC", ] and apply arg shuffling accordingly
+    :param get_correction_fuction: function here in the get_corrections module
+
+    :returns: function wrapped with the option search
     """
-    @wraps(f)
-    def _correction_options(run_id, conf, *arg):
+    @wraps(get_correction_fuction)
+    def correction_options_wrapped(run_id, conf, *arg):
         if isinstance(conf, tuple):
             # MC chain simulation can put run_id inside configuration
             if 'MC' in conf:
                 tag, run_id, *conf = conf
-                assert tag == 'MC', 'Get corrections require input in the from of tuple("MC", run_id, *conf) when "MC" option is invoked'
-                return f(run_id, tuple(conf), *arg)
+                if tag != 'MC':
+                    raise Exception('Get corrections require input in the from of tuple '
+                                    '("MC", run_id, *conf) when "MC" option is invoked')
+                return get_correction_fuction(run_id, tuple(conf), *arg)
 
-        # Else use the get correstions as they are
-        return f(run_id, conf, *arg)
+        # Else use the get corrections as they are
+        return get_correction_fuction(run_id, conf, *arg)
 
-    return _correction_options
+    return correction_options_wrapped
 
 
 @export

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -9,8 +9,12 @@ __all__ += ['FIXED_TO_PE']
 
 
 def correction_options(get_correction_function):
-    """A wrapper function for functions here in the get_corrections module
+    """
+    A wrapper function for functions here in the get_corrections module
     Search for special options like ["MC", ] and apply arg shuffling accordingly
+    Example: get_to_pe(
+        run_id, ('MC', cmt_run_id, 'CMT_model', ('to_pe_model', 'ONLINE')), n_tpc_pmts])
+
     :param get_correction_function: A function here in the get_corrections module
     :returns: The function wrapped with the option search
     """
@@ -19,11 +23,11 @@ def correction_options(get_correction_function):
         if isinstance(conf, tuple):
             # MC chain simulation can put run_id inside configuration
             if 'MC' in conf:
-                tag, run_id, *conf = conf
+                tag, cmt_run_id, *conf = conf
                 if tag != 'MC':
                     raise ValueError('Get corrections require input in the from of tuple '
-                                    '("MC", run_id, *conf) when "MC" option is invoked')
-                return get_correction_function(run_id, tuple(conf), *arg)
+                                     '("MC", run_id, *conf) when "MC" option is invoked')
+                return get_correction_function(cmt_run_id, tuple(conf), *arg)
 
         # Else use the get corrections as they are
         return get_correction_function(run_id, conf, *arg)

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -8,14 +8,13 @@ export, __all__ = strax.exporter()
 __all__ += ['FIXED_TO_PE']
 
 
-def correction_options(get_correction_fuction):
+def correction_options(get_correction_function):
     """A wrapper function for functions here in the get_corrections module
     Search for special options like ["MC", ] and apply arg shuffling accordingly
-    :param get_correction_fuction: function here in the get_corrections module
-
-    :returns: function wrapped with the option search
+    :param get_correction_function: A function here in the get_corrections module
+    :returns: The function wrapped with the option search
     """
-    @wraps(get_correction_fuction)
+    @wraps(get_correction_function)
     def correction_options_wrapped(run_id, conf, *arg):
         if isinstance(conf, tuple):
             # MC chain simulation can put run_id inside configuration
@@ -24,10 +23,10 @@ def correction_options(get_correction_fuction):
                 if tag != 'MC':
                     raise Exception('Get corrections require input in the from of tuple '
                                     '("MC", run_id, *conf) when "MC" option is invoked')
-                return get_correction_fuction(run_id, tuple(conf), *arg)
+                return get_correction_function(run_id, tuple(conf), *arg)
 
         # Else use the get corrections as they are
-        return get_correction_fuction(run_id, conf, *arg)
+        return get_correction_function(run_id, conf, *arg)
 
     return correction_options_wrapped
 

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -21,7 +21,7 @@ def correction_options(get_correction_function):
             if 'MC' in conf:
                 tag, run_id, *conf = conf
                 if tag != 'MC':
-                    raise Exception('Get corrections require input in the from of tuple '
+                    raise ValueError('Get corrections require input in the from of tuple '
                                     '("MC", run_id, *conf) when "MC" option is invoked')
                 return get_correction_function(run_id, tuple(conf), *arg)
 

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -168,7 +168,6 @@ def get_config_from_cmt(run_id, conf):
     return this_file
 
 
-@correction_options
 def get_elife(run_id, elife_conf):
     # 1T support for electron lifetimes from a file
     # Let's remove these functions and only rely on the CMT in the future

--- a/tests/test_cmt.py
+++ b/tests/test_cmt.py
@@ -1,3 +1,5 @@
+"""Testing functions for the CMT services"""
+
 import straxen
 import numpy as np
 
@@ -29,15 +31,15 @@ def test_mc_wrapper_elife(run_id='009000',
     # different run-number.
     mc_elife_diff = straxen.get_correction_from_cmt(
         mc_id,
-        ('MC', cmt_id, ("elife", "ONLINE", True)
-         ))
+        ('MC', cmt_id, "elife", "ONLINE", True)
+    )
 
     # Repeat the query from above to verify, let's see if we are getting
     # the same results as for `elife` above
     mc_elife_same = straxen.get_correction_from_cmt(
         mc_id,
-        ('MC', run_id, ("elife", "ONLINE", True)
-         ))
+        ('MC', run_id, "elife", "ONLINE", True)
+    )
 
     assert elife != mc_elife_diff
     assert elife == mc_elife_same
@@ -56,7 +58,7 @@ def test_mc_wrapper_gains(run_id='009000',
         same as run_id! otherwise the values might actually be the same
         and the test does not work).
     :param execute: Execute this test (this is set to False since the
-        test takes 9 minutes which is too long. We can activate this if 
+        test takes 9 minutes which is too long. We can activate this if
         the testing time due to faster CMT queries is reduced).
     :return: None
     """

--- a/tests/test_cmt.py
+++ b/tests/test_cmt.py
@@ -1,0 +1,90 @@
+import straxen
+import numpy as np
+
+
+def test_mc_wrapper_elife(run_id='009000',
+                          cmt_id='016000',
+                          mc_id='mc_0',
+                          ):
+    """
+    Test that for two different run ids, we get different elifes using
+    the MC wrapper.
+    :param run_id: First run-id (used for normal query)
+    :param cmt_id: Second run-id used as a CMT id (should not be the
+        same as run_id! otherwise the values might actually be the same
+        and the test does not work).
+    :return: None
+    """
+    if not straxen.utilix_is_configured():
+        return
+    assert np.abs(int(run_id) - int(cmt_id)) > 500, 'runs must be far apart'
+
+    # First for the run-id let's get the value
+    elife = straxen.get_correction_from_cmt(
+        run_id,
+        ("elife", "ONLINE", True))
+
+    # Now, we repeat the same query using the MC wrapper, this should
+    # give us a different result since we are now asking for a very
+    # different run-number.
+    mc_elife_diff = straxen.get_correction_from_cmt(
+        mc_id,
+        ('MC', cmt_id, ("elife", "ONLINE", True)
+         ))
+
+    # Repeat the query from above to verify, let's see if we are getting
+    # the same results as for `elife` above
+    mc_elife_same = straxen.get_correction_from_cmt(
+        mc_id,
+        ('MC', run_id, ("elife", "ONLINE", True)
+         ))
+
+    assert elife != mc_elife_diff
+    assert elife == mc_elife_same
+
+
+def test_mc_wrapper_gains(run_id='009000',
+                          cmt_id='016000',
+                          mc_id='mc_0',
+                          execute=True,
+                          ):
+    """
+    Test that for two different run ids, we get different gains using
+    the MC wrapper.
+    :param run_id: First run-id (used for normal query)
+    :param cmt_id: Second run-id used as a CMT id (should not be the
+        same as run_id! otherwise the values might actually be the same
+        and the test does not work).
+    :param execute: Execute this test (this is set to False since the
+        test takes 9 minutes which is too long. We can activate this if 
+        the testing time due to faster CMT queries is reduced).
+    :return: None
+    """
+    if not straxen.utilix_is_configured() or not execute:
+        return
+
+    assert np.abs(int(run_id) - int(cmt_id)) > 500, 'runs must be far apart'
+
+    # First for the run-id let's get the value
+    gains = straxen.get_to_pe(
+        run_id,
+        ('CMT_model', ('to_pe_model', 'ONLINE')),
+        straxen.n_tpc_pmts)
+
+    # Now, we repeat the same query using the MC wrapper, this should
+    # give us a different result since we are now asking for a very
+    # different run-number.
+    mc_gains_diff = straxen.get_to_pe(
+        mc_id,
+        ('MC', cmt_id, 'CMT_model', ('to_pe_model', 'ONLINE')),
+        straxen.n_tpc_pmts)
+
+    # Repeat the query from above to verify, let's see if we are getting
+    # the same results as for `gains` above
+    mc_gains_same = straxen.get_to_pe(
+        mc_id,
+        ('MC', run_id, 'CMT_model', ('to_pe_model', 'ONLINE')),
+        straxen.n_tpc_pmts)
+
+    assert not np.all(gains == mc_gains_diff)
+    assert np.all(gains == mc_gains_same)


### PR DESCRIPTION
Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible

**What is the problem / what does the code in this PR do**
Following the discussion in https://github.com/XENONnT/WFSim/pull/108 of using the alternative id when using CMT, we would like to make it possible through this PR.

**Can you briefly describe how it works?**
The  `correction_options` function wrapper would look for 'MC' tag in the second argument  (which generally is the `*model` context config) and use the alternative run_id included in the config to replace the original run_id in the get correction functions.

**Can you give a minimal working example (or illustrate with a figure)?**
```
to_pe = straxen.get_to_pe(run_id, ('MC', cmt_run_id, 'CMT_model', ('to_pe_model', 'ONLINE')), st.config['n_tpc_pmts'])
```

will return to_pe values for the run with cmt_run_id instead of the run with run_id.