### PR TITLE
Require data to be transferred to dali to load

### DIFF
--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -152,7 +152,7 @@ class RunDB(strax.StorageFrontend):
                         # TODO can we query smart on the lineage_hash?
                         'type': key.data_type,
                         'did': rucio_key,
-                        'protocol': 'rucio'}}}
+                        'status': 'transferred'}}}
             doc = self.collection.find_one({**run_query, **dq},
                                            projection=dq)
             if doc is not None:


### PR DESCRIPTION
This fixes a small issue in the RunDB frontend when loading data via rucio. We previously did not require the data to be `transferred`, which made it seem like data was available when it wasn't.  This also drops the `protocol=rucio` from the query since this doesn't seem to do anything.
