### PR TITLE
Update gain models and elife for simulation context

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -48,9 +48,9 @@ xnt_common_config = dict(
     s1_xyz_correction_map=("CMT_model", ("s1_xyz_map", "ONLINE"), True),
 )
 
-xnt_simulation_config = deepcopy(xnt_common_config)
-xnt_simulation_config.update(gain_model =("to_pe_constant", 0.0005),    
-                             gain_model_nv=("to_pe_constant", 0.0005),
+xnt_simulation_config=deepcopy(xnt_common_config)
+xnt_simulation_config.update(gain_model =("to_pe_constant", 0.01),
+                             gain_model_nv=("to_pe_constant", 0.01),
                              gain_model_mv=("to_pe_constant", "adc_mv"),
                              elife_conf=('elife_constant',1e6))
 

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -1,7 +1,7 @@
 from immutabledict import immutabledict
 import strax
 import straxen
-
+from copy import deepcopy
 
 common_opts = dict(
     register_all=[
@@ -47,6 +47,12 @@ xnt_common_config = dict(
     fdc_map=("CMT_model", ('fdc_map', "ONLINE"), True),
     s1_xyz_correction_map=("CMT_model", ("s1_xyz_map", "ONLINE"), True),
 )
+
+xnt_simulation_config = deepcopy(xnt_common_config)
+xnt_simulation_config.update(gain_model =("to_pe_constant", 0.0005),    
+                             gain_model_nv=("to_pe_constant", 0.0005),
+                             gain_model_mv=("to_pe_constant", "adc_mv"),
+                             elife_conf=('elife_constant',1e6))
 
 # Plugins in these files have nT plugins, E.g. in pulse&peak(let)
 # processing there are plugins for High Energy plugins. Therefore do not
@@ -183,13 +189,13 @@ def xenonnt_led(**kwargs):
 # This gain model is the average to_pe. For something more fancy use the CMT
 def xenonnt_simulation(output_folder='./strax_data'):
     import wfsim
-    xnt_common_config['gain_model'] = ('to_pe_constant', 0.01)
     st = strax.Context(
         storage=strax.DataDirectory(output_folder),
+        xnt_common_config['gains']=bla
         config=dict(detector='XENONnT',
                     fax_config='fax_config_nt_design.json',
                     check_raw_record_overlaps=True,
-                    **straxen.contexts.xnt_common_config,
+                    **straxen.contexts.xnt_simulation_config,
                     ),
         **straxen.contexts.xnt_common_opts)
     st.register(wfsim.RawRecordsFromFaxNT)

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -47,13 +47,14 @@ xnt_common_config = dict(
     fdc_map=("CMT_model", ('fdc_map', "ONLINE"), True),
     s1_xyz_correction_map=("CMT_model", ("s1_xyz_map", "ONLINE"), True),
 )
-#these are placeholders to avoid calling cmt with non integer run_ids. Better solution pending. 
-#s1,s2 and fd corrections are still problamatic
+# these are placeholders to avoid calling cmt with non integer run_ids. Better solution pending.
+# s1,s2 and fd corrections are still problematic
 xnt_simulation_config = deepcopy(xnt_common_config)
-xnt_simulation_config.update(gain_model = ("to_pe_constant", 0.01),
-                             gain_model_nv = ("to_pe_constant", 0.01),
-                             gain_model_mv = ("to_pe_constant", "adc_mv"),
-                             elife_conf = ('elife_constant', 1e6))
+xnt_simulation_config.update(gain_model=("to_pe_constant", 0.01),
+                             gain_model_nv=("to_pe_constant", 0.01),
+                             gain_model_mv=("to_pe_constant", "adc_mv"),
+                             elife_conf=('elife_constant', 1e6),
+                             )
 
 # Plugins in these files have nT plugins, E.g. in pulse&peak(let)
 # processing there are plugins for High Energy plugins. Therefore do not

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -47,7 +47,8 @@ xnt_common_config = dict(
     fdc_map=("CMT_model", ('fdc_map', "ONLINE"), True),
     s1_xyz_correction_map=("CMT_model", ("s1_xyz_map", "ONLINE"), True),
 )
-
+#these are placeholders to avoid calling cmt with non integer run_ids. Better solution pending. 
+#s1,s2 and fd corrections are still problamatic
 xnt_simulation_config = deepcopy(xnt_common_config)
 xnt_simulation_config.update(gain_model = ("to_pe_constant", 0.01),
                              gain_model_nv= ("to_pe_constant", 0.01),

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -191,7 +191,6 @@ def xenonnt_simulation(output_folder='./strax_data'):
     import wfsim
     st = strax.Context(
         storage=strax.DataDirectory(output_folder),
-        xnt_common_config['gains']=bla
         config=dict(detector='XENONnT',
                     fax_config='fax_config_nt_design.json',
                     check_raw_record_overlaps=True,

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -47,14 +47,13 @@ xnt_common_config = dict(
     fdc_map=("CMT_model", ('fdc_map', "ONLINE"), True),
     s1_xyz_correction_map=("CMT_model", ("s1_xyz_map", "ONLINE"), True),
 )
-# these are placeholders to avoid calling cmt with non integer run_ids. Better solution pending.
-# s1,s2 and fd corrections are still problematic
+#these are placeholders to avoid calling cmt with non integer run_ids. Better solution pending. 
+#s1,s2 and fd corrections are still problamatic
 xnt_simulation_config = deepcopy(xnt_common_config)
-xnt_simulation_config.update(gain_model=("to_pe_constant", 0.01),
-                             gain_model_nv=("to_pe_constant", 0.01),
-                             gain_model_mv=("to_pe_constant", "adc_mv"),
-                             elife_conf=('elife_constant', 1e6),
-                             )
+xnt_simulation_config.update(gain_model = ("to_pe_constant", 0.01),
+                             gain_model_nv = ("to_pe_constant", 0.01),
+                             gain_model_mv = ("to_pe_constant", "adc_mv"),
+                             elife_conf = ('elife_constant', 1e6))
 
 # Plugins in these files have nT plugins, E.g. in pulse&peak(let)
 # processing there are plugins for High Energy plugins. Therefore do not

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -48,11 +48,11 @@ xnt_common_config = dict(
     s1_xyz_correction_map=("CMT_model", ("s1_xyz_map", "ONLINE"), True),
 )
 
-xnt_simulation_config=deepcopy(xnt_common_config)
-xnt_simulation_config.update(gain_model =("to_pe_constant", 0.01),
-                             gain_model_nv=("to_pe_constant", 0.01),
-                             gain_model_mv=("to_pe_constant", "adc_mv"),
-                             elife_conf=('elife_constant',1e6))
+xnt_simulation_config = deepcopy(xnt_common_config)
+xnt_simulation_config.update(gain_model = ("to_pe_constant", 0.01),
+                             gain_model_nv= ("to_pe_constant", 0.01),
+                             gain_model_mv= ("to_pe_constant", "adc_mv"),
+                             elife_conf= ('elife_constant', 1e6))
 
 # Plugins in these files have nT plugins, E.g. in pulse&peak(let)
 # processing there are plugins for High Energy plugins. Therefore do not


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
This pull request:
- Changes the values for the gain models and elife to constants to not depend on the cmt, since this  doesn't work jet for mc
