### PR TITLE
use did for finding several runs

### DIFF
--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -129,7 +129,11 @@ class RunDB(strax.StorageFrontend):
             'data': {
                 '$elemMatch': {
                     'type': key.data_type,
-                    'meta.lineage': key.lineage,
+                    # TODO remove the meta.lineage since this doc
+                    #  entry is deprecated
+                    '$or': [{'meta.lineage': key.lineage,
+                             'did': self.key_to_rucio_did(key)
+                             }],
                     '$or': self.available_query}}}
 
     def _find(self, key: strax.DataKey,
@@ -149,7 +153,6 @@ class RunDB(strax.StorageFrontend):
             dq = {
                 'data': {
                     '$elemMatch': {
-                        # TODO can we query smart on the lineage_hash?
                         'type': key.data_type,
                         'did': rucio_key,
                         'status': 'transferred'}}}

--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -132,7 +132,7 @@ class RunDB(strax.StorageFrontend):
                     # TODO remove the meta.lineage since this doc
                     #  entry is deprecated
                     '$or': [{'meta.lineage': key.lineage,
-                             'did': self.key_to_rucio_did(key)
+                             'did': self.key_to_rucio_did(key),
                              }],
                     '$or': self.available_query}}}
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
#450 

**Can you briefly describe how it works?**
`RunDB.select_runs` uses a different query than `RunDB._find`. The `RunDB._find` is a bit "sloppy" and only uses the lineage-hash (the `did` field) to verify if we have data. The `RunDB.select_runs` uses the entire lineage ancestry. 

Now the issue in #450 showed up because of a slight misconception in outsource. Nevertheless, after discussing with @ershockley , this entire field might be a bit overkill to put in the rundocs ddocs. 

With this PR, we allow the rucio did to be used. 