### PR TITLE
do check for overlaps in NV

### DIFF
--- a/straxen/plugins/nveto_recorder.py
+++ b/straxen/plugins/nveto_recorder.py
@@ -29,9 +29,8 @@ export, __all__ = strax.exporter()
     strax.Option('channel_map', track=False, type=immutabledict,
                  help="frozendict mapping subdetector to (min, max) "
                       "channel number."),
-    # TODO, should be True but need to check.
     strax.Option('check_raw_record_overlaps_nv',
-                 default=False, track=False,
+                 default=True, track=False,
                  help='Crash if any of the pulses in raw_records overlap with others '
                       'in the same channel'),
 )


### PR DESCRIPTION
This PR reactivates the NV overlapping pulse checks.

@WenzDaniel, you said this was checked and confirmed right?