### PR TITLE
Added support of dill for resource files

### DIFF
--- a/straxen/common.py
+++ b/straxen/common.py
@@ -106,16 +106,16 @@ def open_resource(file_name: str, fmt='text'):
             result = result_slurped
     elif fmt == 'pkl':
         with open(file_name, 'rb') as f:
-            result = pickle.load(f)
+            result = pickle.load(f)  # nosec
     elif fmt == 'pkl.gz':
         with gzip.open(file_name, 'rb') as f:
-            result = pickle.load(f)
+            result = pickle.load(f)  # nosec
     elif fmt == 'dill':
         with open(file_name, 'rb') as f:
-            result = dill.load(f)
+            result = dill.load(f)  # nosec
     elif fmt == 'dill.gz':
         with gzip.open(file_name, 'rb') as f:
-            result = dill.load(f)
+            result = dill.load(f)  # nosec
     elif fmt == 'json.gz':
         with gzip.open(file_name, 'rb') as f:
             result = json.load(f)

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -8,6 +8,7 @@ import json
 import os
 import os.path as osp
 import pickle
+import dill
 import socket
 import sys
 import tarfile
@@ -108,6 +109,12 @@ def open_resource(file_name: str, fmt='text'):
     elif fmt == 'pkl.gz':
         with gzip.open(file_name, 'rb') as f:
             result = pickle.load(f)
+    elif fmt == 'dill':
+        with open(file_name, 'rb') as f:
+            result = dill.load(f)
+    elif fmt == 'dill.gz':
+        with gzip.open(file_name, 'rb') as f:
+            result = dill.load(f)
     elif fmt == 'json.gz':
         with gzip.open(file_name, 'rb') as f:
             result = json.load(f)


### PR DESCRIPTION
Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible

**What is the problem / what does the code in this PR do**
Adds support for dill files in resources in `get_resource`/`open_resource` functions

**Can you briefly describe how it works?**
Usage is identical to pickle files
**Can you give a minimal working example (or illustrate with a figure)?**

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
