### PR TITLE
fix 1T sim context to have working dep. trees

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -200,6 +200,10 @@ def xenonnt_simulation(output_folder='./strax_data'):
                     ),
         **straxen.contexts.xnt_common_opts)
     st.register(wfsim.RawRecordsFromFaxNT)
+    # Deregister NV/MV
+    for plugin in list(st._plugin_class_registry.keys()):
+        if plugin.endswith('_nv') or plugin.endswith('_mv'):
+            del st._plugin_class_registry[plugin]
     return st
 
 
@@ -389,5 +393,5 @@ def xenon1t_simulation(output_folder='./strax_data'):
             detector='XENON1T',
             **straxen.contexts.x1t_common_config),
         **straxen.contexts.common_opts)
-    st.register(wfsim.RawRecordsFromFax1T)
+    st.register([wfsim.RawRecordsFromFax1T, straxen.PeakPositions1T])
     return st

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -200,10 +200,6 @@ def xenonnt_simulation(output_folder='./strax_data'):
                     ),
         **straxen.contexts.xnt_common_opts)
     st.register(wfsim.RawRecordsFromFaxNT)
-    # Deregister NV/MV
-    for plugin in list(st._plugin_class_registry.keys()):
-        if plugin.endswith('_nv') or plugin.endswith('_mv'):
-            del st._plugin_class_registry[plugin]
     return st
 
 

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -387,7 +387,7 @@ def xenon1t_simulation(output_folder='./strax_data'):
         config=dict(
             fax_config='fax_config_1t.json',
             detector='XENON1T',
-            **straxen.contexts.x1t_common_config),
-        **straxen.contexts.common_opts)
-    st.register([wfsim.RawRecordsFromFax1T, straxen.PeakPositions1T])
+            **x1t_common_config),
+        **x1t_context_config)
+    st.register(wfsim.RawRecordsFromFax1T)
     return st


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In https://github.com/XENONnT/WFSim/pull/146 we added a test that should test if the sim contexts are properly constructed. This turns out to be that some plugins are either missing or are depending on datatypes unknown to the context.

**Can you briefly describe how it works?**
In this PR, we either remove or add missing plugins such that all datatypes are properly known to the context.

**Can you give a minimal working example (or illustrate with a figure)?**
Run https://github.com/XENONnT/WFSim/pull/146