### PR TITLE
Remove zero gain hits

### DIFF
--- a/straxen/plugins/veto_hitlets.py
+++ b/straxen/plugins/veto_hitlets.py
@@ -89,7 +89,7 @@ class nVETOHitlets(strax.Plugin):
 
     def compute(self, records_nv, start, end):
         hits = strax.find_hits(records_nv, min_amplitude=self.config['hit_min_amplitude_nv'])
-        hits = remove_switched_off_channels(hits, self.channel_range, self.to_pe)
+        hits = remove_switched_off_channels(hits, self.to_pe)
 
         temp_hitlets = strax.create_hitlets_from_hits(hits,
                                                       self.config['save_outside_hits_nv'],

--- a/straxen/plugins/veto_hitlets.py
+++ b/straxen/plugins/veto_hitlets.py
@@ -131,7 +131,7 @@ def remove_switched_off_channels(hits, to_pe):
     channel_off = np.argwhere(to_pe == 0).flatten()
     mask_off = np.isin(hits['channel'], channel_off)
     hits = hits[~mask_off]
-
+    return hits
 
 @export
 @strax.takes_config(

--- a/straxen/plugins/veto_hitlets.py
+++ b/straxen/plugins/veto_hitlets.py
@@ -89,6 +89,9 @@ class nVETOHitlets(strax.Plugin):
 
     def compute(self, records_nv, start, end):
         hits = strax.find_hits(records_nv, min_amplitude=self.config['hit_min_amplitude_nv'])
+        active_channel = np.argwhere(self.to_pe > 0).flatten()
+        hits = hits[np.isin(hits['channel'], active_channel)]
+
         temp_hitlets = strax.create_hitlets_from_hits(hits,
                                                       self.config['save_outside_hits_nv'],
                                                       self.channel_range,

--- a/straxen/plugins/veto_hitlets.py
+++ b/straxen/plugins/veto_hitlets.py
@@ -122,21 +122,15 @@ class nVETOHitlets(strax.Plugin):
         return hitlets
 
 
-def remove_switched_off_channels(hits, channel_range, to_pe):
+def remove_switched_off_channels(hits, to_pe):
     """Removes hits which were found in a channel without any gain.
-
     :param hits: Hits found in records.
-    :param channel_range: Tuple of min/max channel. E.g. (2000, 2119)
-        for the neutron-veto.
     :param to_pe: conversion factor from ADC per sample.
     :return: Hits
     """
-    channel_on = np.argwhere(to_pe > 0).flatten()
-    all_channel = np.arange(channel_range[0], channel_range[1] + 1)
-    channel_off = set(all_channel) - set(channel_on)
-    mask_on = ~np.isin(hits['channel'], list(channel_off))
-    hits = hits[mask_on]
-    return hits
+    channel_off = np.argwhere(to_pe == 0).flatten()
+    mask_off = np.isin(hits['channel'], channel_off)
+    hits = hits[~mask_off]
 
 
 @export

--- a/tests/test_veto_hitlets.py
+++ b/tests/test_veto_hitlets.py
@@ -15,7 +15,6 @@ class TestRemoveSwtichedOffChannels(unittest.TestCase):
     def test_empty_inputs(self):
         hits = np.zeros(0, strax.hit_dtype)
         hits = straxen.veto_hitlets.remove_switched_off_channels(hits,
-                                                                 self.channel_range,
                                                                  self.to_pe)
         assert not len(hits), 'Empty input should return an empty result.'
 
@@ -24,12 +23,10 @@ class TestRemoveSwtichedOffChannels(unittest.TestCase):
         hits[0]['channel'] = 15
         hits[1]['channel'] = 18
         hits_returned = straxen.veto_hitlets.remove_switched_off_channels(hits,
-                                                                          self.channel_range,
                                                                           self.to_pe)
         assert hits_returned['channel'] == 15, 'Returned a wrong channel.'
 
         self.to_pe[:] = 1
         hits_returned = straxen.veto_hitlets.remove_switched_off_channels(hits,
-                                                                          self.channel_range,
                                                                           self.to_pe)
         assert len(hits_returned) == 2, 'Did not return all channels.'

--- a/tests/test_veto_hitlets.py
+++ b/tests/test_veto_hitlets.py
@@ -23,9 +23,13 @@ class TestRemoveSwtichedOffChannels(unittest.TestCase):
         hits = np.zeros(2, strax.hit_dtype)
         hits[0]['channel'] = 15
         hits[1]['channel'] = 18
-        hits = straxen.veto_hitlets.remove_switched_off_channels(hits,
-                                                                 self.channel_range,
-                                                                 self.to_pe)
-        assert hits['channel'] == 15, 'Returned a wrong channel.'
+        hits_returned = straxen.veto_hitlets.remove_switched_off_channels(hits,
+                                                                          self.channel_range,
+                                                                          self.to_pe)
+        assert hits_returned['channel'] == 15, 'Returned a wrong channel.'
 
-
+        self.to_pe[:] = 1
+        hits_returned = straxen.veto_hitlets.remove_switched_off_channels(hits,
+                                                                          self.channel_range,
+                                                                          self.to_pe)
+        assert len(hits_returned) == 2, 'Did not return all channels.'

--- a/tests/test_veto_hitlets.py
+++ b/tests/test_veto_hitlets.py
@@ -1,0 +1,31 @@
+import strax
+import straxen
+import numpy as np
+
+import unittest
+
+
+class TestRemoveSwtichedOffChannels(unittest.TestCase):
+
+    def setUp(self):
+        self.channel_range = (10, 19)
+        self.to_pe = np.zeros(20)
+        self.to_pe[10:17] = 1
+
+    def test_empty_inputs(self):
+        hits = np.zeros(0, strax.hit_dtype)
+        hits = straxen.veto_hitlets.remove_switched_off_channels(hits,
+                                                                 self.channel_range,
+                                                                 self.to_pe)
+        assert not len(hits), 'Empty input should return an empty result.'
+
+    def test_return(self):
+        hits = np.zeros(2, strax.hit_dtype)
+        hits[0]['channel'] = 15
+        hits[1]['channel'] = 18
+        hits = straxen.veto_hitlets.remove_switched_off_channels(hits,
+                                                                 self.channel_range,
+                                                                 self.to_pe)
+        assert hits['channel'] == 15, 'Returned a wrong channel.'
+
+


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
In this PR we add a tiny function which removes all hits (hitlets) for channels which gain was set to zero, if any.  