### PR TITLE
Scada allowed, fix #392

### DIFF
--- a/.github/scripts/create_readonly_utilix_config.sh
+++ b/.github/scripts/create_readonly_utilix_config.sh
@@ -22,9 +22,11 @@ pymongo_database = $PYMONGO_DATABASE
 [scada]
 scdata_url = $SCADA_URL
 sclastvalue_url = $SCADA_VALUE_URL
-querytype = $SCADA_QUERY_TYPE
-username = $SCADA_USER
-api_key = $SCADA_KEY
+
+sclogin_url = $SCADA_LOGIN_URL
+straxen_username = $SCADA_USER
+straxen_password = $SCADA_PWD
+pmt_parameter_names = no_file_found
 EOF
 echo "YEAH boy, complete github actions voodoo now made you have access to our database!"
 else

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -35,6 +35,7 @@ jobs:
     - name: patch utilix file
       run: bash .github/scripts/create_readonly_utilix_config.sh
       env:
+        # Database
         RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
         RUNDB_API_USER_READONLY: ${{ secrets.RUNDB_API_USER_READONLY }}
         RUNDB_API_PASSWORD_READONLY: ${{ secrets.RUNDB_API_PASSWORD_READONLY}}
@@ -42,11 +43,12 @@ jobs:
         PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
         PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
         PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
+        # SCADA
         SCADA_URL: ${{ secrets.SCADA_URL }}
         SCADA_VALUE_URL: ${{ secrets.SCADA_VALUE_URL }}
         SCADA_USER: ${{ secrets.SCADA_USER }}
-        SCADA_LOGIN_URL: $ {{ secrets.SCADA_LOGIN_URL }}
-        SCADA_PWD:  $ {{ secrets.SCADA_PWD }}
+        SCADA_LOGIN_URL: ${{ secrets.SCADA_LOGIN_URL }}
+        SCADA_PWD: ${{ secrets.SCADA_PWD }}
     - name: Coveralls
       env:
         NUMBA_DISABLE_JIT: 1

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -44,9 +44,10 @@ jobs:
         PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
         SCADA_URL: ${{ secrets.SCADA_URL }}
         SCADA_VALUE_URL: ${{ secrets.SCADA_VALUE_URL }}
-        SCADA_QUERY_TYPE: ${{ secrets.SCADA_QUERY_TYPE }}
         SCADA_USER: ${{ secrets.SCADA_USER }}
         SCADA_KEY: ${{ secrets.SCADA_KEY }}
+        SCADA_LOGIN_URL: $ {{ secrets.SCADA_LOGIN_URL }}
+        SCADA_PWD:  $ {{ secrets.SCADA_PWD }}
     - name: Coveralls
       env:
         NUMBA_DISABLE_JIT: 1

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -45,7 +45,6 @@ jobs:
         SCADA_URL: ${{ secrets.SCADA_URL }}
         SCADA_VALUE_URL: ${{ secrets.SCADA_VALUE_URL }}
         SCADA_USER: ${{ secrets.SCADA_USER }}
-        SCADA_KEY: ${{ secrets.SCADA_KEY }}
         SCADA_LOGIN_URL: $ {{ secrets.SCADA_LOGIN_URL }}
         SCADA_PWD:  $ {{ secrets.SCADA_PWD }}
     - name: Coveralls

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -50,9 +50,10 @@ jobs:
           PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
           SCADA_URL: ${{ secrets.SCADA_URL }}
           SCADA_VALUE_URL: ${{ secrets.SCADA_VALUE_URL }}
-          SCADA_QUERY_TYPE: ${{ secrets.SCADA_QUERY_TYPE }}
           SCADA_USER: ${{ secrets.SCADA_USER }}
           SCADA_KEY: ${{ secrets.SCADA_KEY }}
+          SCADA_LOGIN_URL: $ {{ secrets.SCADA_LOGIN_URL }}
+          SCADA_PWD:  $ {{ secrets.SCADA_PWD }}
       - name: Test package
         run: |
           python setup.py test -v

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   update:
+    name: Pytest
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -38,9 +39,10 @@ jobs:
         uses: py-actions/py-dependency-install@v2
       - name: patch utilix file
         # Since we skip this step for python 3.7, we are testing without the database
-        if: matrix.python-version == 3.6 ||  matrix.python-version == 3.8
+        if: matrix.python-version == 3.6 ||  matrix.python-version == 3.8 || matrix.python-version == 3.9
         run: bash .github/scripts/create_readonly_utilix_config.sh
         env:
+          # Rundb
           RUNDB_API_URL: ${{ secrets.RUNDB_API_URL }}
           RUNDB_API_USER_READONLY: ${{ secrets.RUNDB_API_USER_READONLY }}
           RUNDB_API_PASSWORD_READONLY: ${{ secrets.RUNDB_API_PASSWORD_READONLY}}
@@ -48,12 +50,12 @@ jobs:
           PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
           PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
           PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
-
+          # SCADA
           SCADA_URL: ${{ secrets.SCADA_URL }}
           SCADA_VALUE_URL: ${{ secrets.SCADA_VALUE_URL }}
           SCADA_USER: ${{ secrets.SCADA_USER }}
-          SCADA_LOGIN_URL: $ {{ secrets.SCADA_LOGIN_URL }}
-          SCADA_PWD:  $ {{ secrets.SCADA_PWD }}
+          SCADA_LOGIN_URL: ${{ secrets.SCADA_LOGIN_URL }}
+          SCADA_PWD: ${{ secrets.SCADA_PWD }}
       - name: Test package
         run: |
           python setup.py test -v

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -48,10 +48,10 @@ jobs:
           PYMONGO_USER: ${{ secrets.PYMONGO_USER }}
           PYMONGO_PASSWORD: ${{ secrets.PYMONGO_PASSWORD }}
           PYMONGO_DATABASE: ${{ secrets.PYMONGO_DATABASE }}
+
           SCADA_URL: ${{ secrets.SCADA_URL }}
           SCADA_VALUE_URL: ${{ secrets.SCADA_VALUE_URL }}
           SCADA_USER: ${{ secrets.SCADA_USER }}
-          SCADA_KEY: ${{ secrets.SCADA_KEY }}
           SCADA_LOGIN_URL: $ {{ secrets.SCADA_LOGIN_URL }}
           SCADA_PWD:  $ {{ secrets.SCADA_PWD }}
       - name: Test package


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Some of the testing settings need to be updated to allow #392 

**Can you briefly describe how it works?**
When testing, we use a tempory secret .xenon_config file to allow access to to-test entities like the database and scada. 

If we e.g. change a URL, we need to update the secret in the config-file accordingly.

We use this on two places:
- coveralls.yml -> for making a coveralls report and uploading the code coverage
- pytest.yml -> for testing with different python versions etc.

**Where is this accessible?**
Only on the XENONnT fork. That provides us with an additional layer of protection, in addition to the already secure usage of [github sectets](https://docs.github.com/en/actions/reference/encrypted-secrets) (I've tried debugging these things, in fact they are so secret that I grew a few grey hairs by the fact that the secrets where so secret I could impossibly understand what was going on.).

For that reason, always tests should also pass as if we did not have access to the database.