### PR TITLE
set event_info_double as endpoint for kr

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -73,7 +73,7 @@ what bootstrax is thinking of at the moment.
   - **disk_used**: used part of the disk whereto this bootstrax instance
    is writing to (in percent).
 """
-__version__ = '1.1.4'
+__version__ = '1.1.5'
 
 import argparse
 from datetime import datetime, timedelta, timezone
@@ -590,6 +590,11 @@ def infer_target(rd: dict) -> dict:
         log.debug('diagnostic-mode')
         targets = 'raw_records'
         post_process = 'raw_records'
+    elif 'kr83m' in mode and len(targets):
+        # Override the first (highest level) plugin for Kr runs (could
+        # also use source field, outcome is the same)
+        if targets[0] == 'event_info':
+            targets[0] = 'event_info_double'
 
     if 'tpc' not in detectors:
         keep = []


### PR DESCRIPTION
## What is the problem / what does the code in this PR do
If we are ever to take Kr runs, if would be nice if we in that case could automatically set the target to event_info_double such that it's immediately available for analysers.

## Can you briefly describe how it works?
In bootstrax, we do a couple of checks for what kind of target we are going to process. Here we simply replace event_info -> event_info_double in the case of a Kr mode.