### PR TITLE
fix _find for rucio to include transferred. Set kwarg defaults

### DIFF
--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -138,8 +138,11 @@ class RunDB(strax.StorageFrontend):
                     #  entry is deprecated.
                     '$and': [{'$or': [
                         {'meta.lineage': key.lineage},
-                        {'did': {'$regex': f'/*{key.data_type}-{key.lineage_hash}'},
-                         }
+                        {'did':
+                             {'$regex':
+                                  f'/*{key.data_type}-{key.lineage_hash}'
+                              },
+                         },
                     ]},
                         {'$or': self.available_query}]}}}
 
@@ -165,7 +168,6 @@ class RunDB(strax.StorageFrontend):
                         'did': rucio_key,
                         **rucio_available_query,
                     },
-
                 }}
             doc = self.collection.find_one({**run_query,
                                             **dq,


### PR DESCRIPTION
# What is the problem / what does the code in this PR do
Like for find_several, also use the `transferred` rule on rucio for a single `find`.

Additionally, set kwargs default that are usually False anyway (and True is not supported).

**Can you briefly describe how it works?**
`RunDB.find` was finding runs still in transit.

**Why do we need this `if self.rucio_path is not None:` codeblock?**
Good question, as part of https://github.com/XENONnT/straxen/issues/456 I'd like to do a proper refactor, should not be very complicated since we have already figured this out in `find_several`