### PR TITLE
Update online_monitor.py

### DIFF
--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -164,7 +164,7 @@ class OnlinePeakMonitor(strax.Plugin):
         # Estimate Single Electron (SE) gain
         se_hist, se_bins = np.histogram(peaks['area'], bins=n_bins,
                                         range=self.config['online_se_bounds'])
-        bin_centers = (se_bins[1:] + se_bins[:1]) / 2
+        bin_centers = (se_bins[1:] + se_bins[:-1]) / 2
         res['online_se_gain'] = bin_centers[np.argmax(se_hist)]
         return res
 


### PR DESCRIPTION
Fixing the PE bin center for SE Gain

Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible

**What is the problem / what does the code in this PR do**
The SE gain is ~40 PE and the online monitor says ~22PE. This code fixes that bin centers are (bin_upper_bounds + bin_lower_bounds) / 2, not (bin_upper_bounds + lowest_bin)/2

**Can you briefly describe how it works?**
I added a missing "-" to fix the bins[:1] (which is just the lowest bin) to bins[:-1] so that it is all bin lower bounds

**Can you give a minimal working example (or illustrate with a figure)?**
bin_bounds = [7.0, 7.63, 8.26, 8.89, 9.52, 10.15, 10.78, 11.41, 12.04, 12.67, 13.3, 13.93, 14.56, 15.19, 15.82, 16.45, 17.08, 17.71, 18.34, 18.97, 19.6, 20.23, 20.86, 21.49, 22.12, 22.75, 23.38, 24.01, 24.64, 25.27, 25.9, 26.53, 27.16, 27.79, 28.42, 29.05, 29.68, 30.31, 30.94, 31.57, 32.2, 32.83, 33.46, 34.09, 34.72, 35.35, 35.98, 36.61, 37.24, 37.87, 38.5, 39.13, 39.76, 40.39, 41.02, 41.65, 42.28, 42.91, 43.54, 44.17, 44.8, 45.43, 46.06, 46.69, 47.32, 47.95, 48.58, 49.21, 49.84, 50.47, 51.1, 51.73, 52.36, 52.99, 53.62, 54.25, 54.88, 55.51, 56.14, 56.77, 57.4, 58.03, 58.66, 59.29, 59.92, 60.55, 61.18, 61.81, 62.44, 63.07, 63.7, 64.33, 64.96, 65.59, 66.22, 66.85, 67.48, 68.11, 68.74, 69.37, 70.0]

old_incorrect_bin_centers = [7.315, 7.63, 7.945, 8.26, 8.575, 8.889999, 9.205, 9.52, 9.835, 10.15, 10.465, 10.780001, 11.094999, 11.41, 11.725, 12.04, 12.355, 12.67, 12.985, 13.3, 13.615, 13.93, 14.245, 14.56, 14.875, 15.19, 15.505, 15.82, 16.135, 16.45, 16.765, 17.08, 17.395, 17.71, 18.025, 18.34, 18.654999, 18.970001, 19.285, 19.6, 19.915, 20.23, 20.545, 20.86, 21.175, 21.49, 21.805, 22.12, 22.435, 22.75, 23.065, 23.38, 23.695, 24.01, 24.325, 24.64, 24.955, 25.27, 25.585, 25.9, 26.215, 26.53, 26.845, 27.16, 27.475, 27.79, 28.105, 28.42, 28.735, 29.05, 29.365, 29.68, 29.995, 30.31, 30.625, 30.94, 31.255, 31.57, 31.885, 32.2, 32.515, 32.83, 33.145, 33.46, 33.775, 34.09, 34.405, 34.72, 35.035, 35.35, 35.665, 35.98, 36.295, 36.61, 36.925, 37.24, 37.555, 37.87, 38.185, 38.5]

correct_bin_centers = [7.315, 7.945, 8.575001, 9.205, 9.835, 10.465, 11.094999, 11.725, 12.355, 12.985001, 13.615, 14.245001, 14.875, 15.504999, 16.135, 16.765, 17.395, 18.025, 18.654999, 19.285, 19.915, 20.545, 21.175, 21.805, 22.435001, 23.064999, 23.695, 24.325, 24.955, 25.585, 26.215, 26.845001, 27.475, 28.105, 28.735, 29.365, 29.994999, 30.625, 31.255001, 31.885, 32.515, 33.145, 33.775, 34.405, 35.035, 35.665, 36.295, 36.925003, 37.555, 38.184998, 38.815002, 39.445, 40.074997, 40.705, 41.335, 41.965, 42.595, 43.225, 43.855, 44.485, 45.114998, 45.745003, 46.375, 47.004997, 47.635002, 48.265, 48.895, 49.525, 50.155, 50.785, 51.415, 52.045, 52.675003, 53.305, 53.934998, 54.565002, 55.195, 55.824997, 56.455, 57.085, 57.715, 58.345, 58.975, 59.605, 60.235, 60.864998, 61.495003, 62.125, 62.754997, 63.385002, 64.015, 64.645004, 65.274994, 65.905, 66.535, 67.165, 67.795, 68.425, 69.055, 69.685]

Please include the following if applicable:
  - Update the docstring(s)
  - Update the documentation
  - Tests to check the (new) code is working as desired.
  - Does it solve one of the open issues on github?

Please make sure that all automated tests have passed before asking for a review (you can save the PR as a draft otherwise).
