### PR TITLE
Max-size for rechunkable raw-records

### DIFF
--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -89,6 +89,7 @@ class DAQReader(strax.Plugin):
     data_kind = immutabledict(zip(provides, provides))
     depends_on = tuple()
     parallel = 'process'
+    chunk_target_size_mb = 50
     rechunk_on_save = immutabledict(
         raw_records=False,
         raw_records_he=False,


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Set the max size of the raw-records-aqmon* to be max 50 MB to avoid overflows in the mongo buffer for veto_intervals.


Max-size for rechunkable raw-records
## Can you briefly describe how it works?

16 MB is the max size of a mongo document. We cannot exceed that without redesigning the mongo-storage frontend. If we split the veto_intervals over more chunks, this size/chunk (i.e. size per document) is reduced. By splitting raw-records-aqmon over more chunks, veto_intervals will also be split more, reducing the size per chunk.
