### PR TITLE
Reduce plugin testing time

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,10 +1,9 @@
 name: Python style
-on: 
+on:
   pull_request:
     types:
       - created
 jobs:
-
   qa:
     name: Quality check
     runs-on: ubuntu-18.04

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -18,7 +18,7 @@ jobs:
         uses: wemake-services/wemake-python-styleguide@0.15.2
         continue-on-error: true
         with:
-          reporter: 'github-pr-check'
+          reporter: 'github-pr-review'
         env:
           NUMBA_DISABLE_JIT: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,5 +1,8 @@
 name: Python style
-on: [pull_request]
+on: 
+  pull_request:
+    types:
+      - created
 jobs:
 
   qa:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -141,18 +141,20 @@ def _run_plugins(st,
         # The stuff should be there
         assert st.is_stored(run_id, target), f'Could not make {target}'
 
-        if make_all:
-            end_targets = set(st._get_end_targets(st._plugin_class_registry))
-            for p in end_targets-set(forbidden_plugins):
-                st.make(run_id, p)
-            # Now make sure we can get some data for all plugins
-            all_datatypes = set(st._plugin_class_registry.keys())
-            for p in all_datatypes-set(forbidden_plugins):
-                should_be_stored = (st._plugin_class_registry[p].save_when ==
-                                    strax.SaveWhen.ALWAYS)
-                if should_be_stored:
-                    is_stored = st.is_stored(run_id, p)
-                    assert is_stored, f"{p} did not save correctly!"
+        if not make_all:
+            return
+
+        end_targets = set(st._get_end_targets(st._plugin_class_registry))
+        for p in end_targets-set(forbidden_plugins):
+            st.make(run_id, p)
+        # Now make sure we can get some data for all plugins
+        all_datatypes = set(st._plugin_class_registry.keys())
+        for p in all_datatypes-set(forbidden_plugins):
+            should_be_stored = (st._plugin_class_registry[p].save_when ==
+                                strax.SaveWhen.ALWAYS)
+            if should_be_stored:
+                is_stored = st.is_stored(run_id, p)
+                assert is_stored, f"{p} did not save correctly!"
     print("Wonderful all plugins work (= at least they don't fail), bye bye")
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -141,24 +141,18 @@ def _run_plugins(st,
         # The stuff should be there
         assert st.is_stored(run_id, target), f'Could not make {target}'
 
-        # I'm only going to do this for nT because:
-        #  A) Doing this many more times does not give us much more
-        #     info (everything above already worked fine)
-        #  B) Most development will be on nT, 1T may get less changes
-        #     in the near future
         if make_all:
+            end_targets = set(st._get_end_targets(st._plugin_class_registry))
+            for p in end_targets-set(forbidden_plugins):
+                st.make(run_id, p)
             # Now make sure we can get some data for all plugins
-            for p in list(st._plugin_class_registry.keys()):
-                if p not in forbidden_plugins:
-                    st.get_array(run_id=run_id,
-                                 targets=p,
-                                 **proces_kwargs)
-
-                    # Check for types that we want to save that they are stored.
-                    if (int(st._plugin_class_registry['peaks'].save_when) >
-                            int(strax.SaveWhen.TARGET)):
-                        is_stored = st.is_stored(run_id, p)
-                        assert is_stored, f"{p} did not save correctly!"
+            all_datatypes = set(st._plugin_class_registry.keys())
+            for p in all_datatypes-set(forbidden_plugins):
+                should_be_stored = (st._plugin_class_registry[p].save_when ==
+                                    strax.SaveWhen.ALWAYS)
+                if should_be_stored:
+                    is_stored = st.is_stored(run_id, p)
+                    assert is_stored, f"{p} did not save correctly!"
     print("Wonderful all plugins work (= at least they don't fail), bye bye")
 
 


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Decrease the plugin testing time by only computing the last plugins in the tree.
The `tests/test_plugins.py` is one of the slowest tests we do (it also does a lot). 

## Time decrease
About 25% on this long test
_before_
```
143.54s call     tests/test_plugins.py::test_nT
123.40s call     tests/test_plugins.py::test_nT_mutlticore
54.68s call      tests/test_plugins.py::test_1T
```
_after_
```
115.44s call     tests/test_plugins.py::test_nT
98.67s call      tests/test_plugins.py::test_nT_mutlticore
48.38s call      tests/test_plugins.py::test_1T
```