### PR TITLE
1T left extension patch

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -266,7 +266,7 @@ x1t_common_config = dict(
     # Smaller right extension since we applied the filter
     peak_right_extension=30,
     # Events*
-    left_event_extension=int(0.7e6),
+    left_event_extension=int(0.3e6),
     right_event_extension=int(1e6),
     elife_conf=straxen.aux_repo + '3548132b55f81a43654dba5141366041e1daaf01/strax_files/elife.npy',
     electron_drift_velocity=("electron_drift_velocity_constant", 1.3325e-4, False),


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
The left extension was 1 ms, by adding the max drift time, we should again be at 1 ms. The 1T max drift time was about 700 us. Fix this
