### PR TITLE
Drop gcn_model

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -43,6 +43,8 @@ xnt_common_config = dict(
         nveto_blank=(2999, 2999)),
     # Clustering/classification parameters
     s1_max_rise_time=100,
+    gcn_model=None,
+    # Event level parameters
     s2_xy_correction_map=("CMT_model", ('s2_xy_map', "ONLINE"), True),
     fdc_map=("CMT_model", ('fdc_map', "ONLINE"), True),
     s1_xyz_correction_map=("CMT_model", ("s1_xyz_map", "ONLINE"), True),


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
If GCN is not used anymore, we might as well stop processing it.


## Can you briefly describe how it works?
When we set the config to None, it will not do any processing (thanks to Andrii foreseeing this).

## Alternative approach
Drop the plugin all together from the context by not registering it. I'm not sure if we want to go that drastic already but @reallsx might comment.
