### PR TITLE
z coordinate update

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -272,6 +272,7 @@ x1t_common_config = dict(
     electron_drift_velocity=("electron_drift_velocity_constant", 1.3325e-4, False),
     event_info_function='disabled',
     max_drift_length=96.9,
+    electron_drift_time_gate=("electron_drift_time_gate_constant", 1700),
 )
 
 

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -16,7 +16,7 @@ corrections_w_file = ['mlp_model', 'gcn_model', 'cnn_model',
                       'fdc_map_cnn']
 
 single_value_corrections = ['elife', 'baseline_samples_nv',
-                            'electron_drift_velocity']
+                            'electron_drift_velocity', 'electron_drift_time_gate']
 
 
 @export

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -328,6 +328,11 @@ class EventBasics(strax.LoopPlugin):
         default=("electron_drift_velocity", "ONLINE", True)
     ),
     strax.Option(
+        name='electron_drift_time_gate',
+        help='Electron drift time from the gate in ns',
+        default=("electron_drift_time_gate", "ONLINE", True)
+    ),
+    strax.Option(
         name='fdc_map',
         help='3D field distortion correction map path',
         default_by_run=[
@@ -367,6 +372,8 @@ class EventPositions(strax.Plugin):
          'Interaction r-position using observed S2 positions directly (cm)'),
         ('r_field_distortion_correction', np.float32,
          'Correction added to r_naive for field distortion (cm)'),
+        ('z_field_distortion_correction', np.float32,
+         'Correction added to z_naive for field distortion (cm)'),
         ('theta', np.float32,
          'Interaction angular position (radians)')
             ] + strax.time_fields
@@ -375,6 +382,7 @@ class EventPositions(strax.Plugin):
 
         is_CMT = isinstance(self.config['fdc_map'], tuple)
         self.electron_drift_velocity = get_correction_from_cmt(self.run_id, self.config['electron_drift_velocity'])
+        self.electron_drift_time_gate = get_correction_from_cmt(self.run_id, self.config['electron_drift_time_gate'])
         if is_CMT:
             config_name, cmt_version, is_nt = self.config['fdc_map']
             map_algo = f'{config_name}_{self.config["default_reconstruction_algorithm"]}'
@@ -395,7 +403,7 @@ class EventPositions(strax.Plugin):
         result = {'time': events['time'],
                   'endtime': strax.endtime(events)}
         
-        z_obs = - self.electron_drift_velocity * events['drift_time']
+        z_obs = - self.electron_drift_velocity * (events['drift_time'] - self.electron_drift_time_gate)
         orig_pos = np.vstack([events[f's2_x'], events[f's2_y'], z_obs]).T
         r_obs = np.linalg.norm(orig_pos[:, :2], axis=1)
         delta_r = self.map(orig_pos)
@@ -411,7 +419,10 @@ class EventPositions(strax.Plugin):
         with np.errstate(invalid='ignore'):
             z_cor = -(z_obs ** 2 - delta_r ** 2) ** 0.5
             invalid = np.abs(z_obs) < np.abs(delta_r)
+            # do not apply z correction above gate
+            invalid |= z_obs >= 0
         z_cor[invalid] = z_obs[invalid]
+        delta_z = z_cor - z_obs
 
         result.update({'x': orig_pos[:, 0] * scale,
                        'y': orig_pos[:, 1] * scale,
@@ -420,7 +431,9 @@ class EventPositions(strax.Plugin):
                        'r_field_distortion_correction': delta_r,
                        'theta': np.arctan2(orig_pos[:, 1], orig_pos[:, 0]),
                        'z_naive': z_obs,
-                       'z': z_cor})
+                       'z': z_obs,
+                       'z_field_distortion_correction': delta_z
+                       })
 
         return result
 

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -355,7 +355,7 @@ class EventPositions(strax.Plugin):
 
     depends_on = ('event_basics', )
     
-    __version__ = '0.1.3'
+    __version__ = '0.1.4'
 
     dtype = [
         ('x', np.float32,

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -363,7 +363,7 @@ class EventPositions(strax.Plugin):
         ('y', np.float32,
          'Interaction y-position, field-distortion corrected (cm)'),
         ('z', np.float32,
-         'Interaction z-position, field-distortion corrected (cm)'),
+         'Interaction z-position using mean drift velocity only (cm)'),
         ('r', np.float32,
          'Interaction radial position, field-distortion corrected (cm)'),
         ('z_naive', np.float32,

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -363,7 +363,7 @@ class EventPositions(strax.Plugin):
         ('y', np.float32,
          'Interaction y-position, field-distortion corrected (cm)'),
         ('z', np.float32,
-         'Interaction z-position using mean drift velocity only (cm)'),
+         'Interaction z-position, using mean drift velocity only (cm)'),
         ('r', np.float32,
          'Interaction radial position, field-distortion corrected (cm)'),
         ('z_naive', np.float32,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -32,6 +32,7 @@ testing_config_nT = dict(
     nveto_pmt_position_map=nveto_pmt_dummy_df,
     s1_xyz_correction_map=pax_file('XENON1T_s1_xyz_lce_true_kr83m_SR0_pax-680_fdc-3d_v0.json'),
     electron_drift_velocity=("electron_drift_velocity_constant", 1e-4),
+    electron_drift_time_gate=("electron_drift_time_gate_constant", 2700),
 )
 
 testing_config_1T = dict(
@@ -39,6 +40,7 @@ testing_config_1T = dict(
     gain_model=('1T_to_pe_placeholder', False),
     elife_conf=('elife_constant', 1e6),
     electron_drift_velocity=("electron_drift_velocity_constant", 1e-4),
+    electron_drift_time_gate=("electron_drift_time_gate_constant", 1700),
 )
 
 test_run_id_nT = '008900'


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

* Take `electron_drift_time_gate` into account when calculating `z_naive`
* Fixing issue [#527](https://github.com/XENONnT/straxen/issues/527)

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?
A test is done in 
https://xenonnt.slack.com/archives/C020GRDUNN8/p1622855301162000. Not sure why it fails automatic checks. Is it related to the Travis shutdown?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [x] _Does it solve one of the open issues on github?_
