### PR TITLE
Download contexts from the database

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -3,6 +3,25 @@ import strax
 import straxen
 from copy import deepcopy
 
+# initialize runDB API if utilix is configured.
+if straxen.utilix_is_configured():
+    from utilix.mongo_files import APIDownloader
+    downloader = APIDownloader(store_files_at='./')
+
+
+def load_context(context_name, file='xenonnt.py', **kwargs):
+    """Downloads a context file from the files database, imports it, and initializes it.
+    :param context_name: name of context to be imported
+    :param file: the name of the file that will be downloaded."""
+    # download file
+    assert file.endswith('.py'), f"The contexts file must have a .py suffix. You passed {file}"
+    path = downloader.download_single(file, human_readable_file_name=True)
+    module = file.split('.')[0]
+    exec(f'import {module}')
+    st = getattr(eval(module), context_name)(**kwargs)
+    return st
+
+
 common_opts = dict(
     register_all=[
         straxen.event_processing,

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -73,7 +73,7 @@ def print_versions(modules=('strax', 'straxen'), return_string=False):
 
 
 @export
-def utilix_is_configured(header='RunDB', section='pymongo_database') -> bool:
+def utilix_is_configured(header='RunDB', section='xent_database') -> bool:
     """
     Check if we have the right connection to
     :return: bool, can we connect to the Mongo database?


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
This PR adds a new function `straxen.contexts.load_context`. This function uses utilix to download additional context files from the database, so that we can define production contexts outside of the straxen installation. This might be useful if e.g. we need to update corrections but we don't want to update to a new straxen version. It also will help resolve some issues we've had in the MC group about context definitions. 

## Can you briefly describe how it works?
It takes 2 arguments: `context_name` and `file`. The `context_name` is the name of the context function that will be loaded, and `file` is the name of the file in the files database. The default filename is `xenonnt.py`, a version which I have already uploaded. 

First, the `file` is downloaded using utilix, which requires a utilix config file with the proper credentials. This file is downloaded to your current directory so that it is automatically in your python path. We then use `eval`, `exec` and `getattr` to import the `context_name` from the file, and initialize it. You can pass normal context kwargs to `load_context` which then get propagated to the initialization of the context. The initialized context is returned. 
 

## Can you give a minimal working example (or illustrate with a figure)?
I have uploaded a file which is essentially a copy of contexts.py, but with xenonnt_online renamed to just `xenonnt`. You can load it as follows
```
st = straxen.contexts.load_context('xenonnt')
print(st.provided_dtypes()['peaklets']['hash'])

# returns 2as4vw56ce
```


