### PR TITLE
Fix example command

### DIFF
--- a/docs/source/scripts.rst
+++ b/docs/source/scripts.rst
@@ -17,7 +17,7 @@ following command up to ``event_info_double``.
 
 .. code-block:: bash
 
-    straxer 12100 event_info_double
+    straxer 012100 --target event_info_double
 
 For more information on the options, please refer to the help:
 


### PR DESCRIPTION
The example command didn't work on dali.
I fixed it.
Excuse me for very tiny PR, but I believe it saves analyzer's time.
