### PR TITLE
track if rucio is active

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -171,8 +171,9 @@ def xenonnt_online(output_folder='./strax_data',
     # if we said so, add the rucio frontend to storage
     if use_rucio:
         st.storage.append(straxen.rucio.RucioFrontend(
-            include_remote=True,
-            staging_dir=output_folder))
+            include_remote=straxen.RUCIO_AVAILABLE,
+            staging_dir=output_folder,
+        ))
 
     # Only the online monitor backend for the DAQ
     if _database_init and (_add_online_monitor_frontend or we_are_the_daq):

--- a/straxen/rucio.py
+++ b/straxen/rucio.py
@@ -24,10 +24,13 @@ try:
     replica_client = ReplicaClient()
     did_client = DIDClient()
     download_client = DownloadClient()
+    RUCIO_AVAILABLE = True
 except (ModuleNotFoundError, RuntimeError):
     warnings.warn("No installation of rucio-clients found. Can't use rucio remove backend")
+    RUCIO_AVAILABLE = False
 
 export, __all__ = strax.exporter()
+__all__ += ['RUCIO_AVAILABLE']
 
 
 class TooMuchDataError(Exception):

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -23,12 +23,12 @@ def import_wfsim():
 
 
 def test_xenonnt_online():
-    st = xenonnt_online(_database_init=False)
+    st = xenonnt_online(_database_init=False, use_rucio=False)
     st.search_field('time')
 
 
 def test_xenonnt_led():
-    st = xenonnt_led(_database_init=False)
+    st = xenonnt_led(_database_init=False, use_rucio=False)
     st.search_field('time')
 
 

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -3,6 +3,7 @@ a field (i.e. can build the dependencies in the context correctly)
 See issue #233 and PR #236"""
 from straxen.contexts import xenon1t_dali, xenon1t_led, xenon1t_simulation, fake_daq, demo
 from straxen.contexts import xenonnt_led, xenonnt_online, xenonnt_simulation, xenonnt
+import straxen
 import tempfile
 import os
 

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -22,12 +22,12 @@ def import_wfsim():
 
 
 def test_xenonnt_online():
-    st = xenonnt_online(_database_init=False, use_rucio=False)
+    st = xenonnt_online(_database_init=False)
     st.search_field('time')
 
 
 def test_xenonnt_led():
-    st = xenonnt_led(_database_init=False, use_rucio=False)
+    st = xenonnt_led(_database_init=False)
     st.search_field('time')
 
 

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -2,7 +2,7 @@
 a field (i.e. can build the dependencies in the context correctly)
 See issue #233 and PR #236"""
 from straxen.contexts import xenon1t_dali, xenon1t_led, xenon1t_simulation, fake_daq, demo
-from straxen.contexts import xenonnt_led, xenonnt_online, xenonnt_simulation
+from straxen.contexts import xenonnt_led, xenonnt_online, xenonnt_simulation, xenonnt
 import tempfile
 import os
 

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -1,7 +1,8 @@
 """For all of the context, do a quick check to see that we are able to search
 a field (i.e. can build the dependencies in the context correctly)
 See issue #233 and PR #236"""
-from straxen.contexts import *
+from straxen.contexts import xenon1t_dali, xenon1t_led, xenon1t_simulation, fake_daq, demo
+from straxen.contexts import xenonnt_led, xenonnt_online, xenonnt_simulation
 import tempfile
 import os
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -260,7 +260,8 @@ def test_1T(ncores=1):
 def test_nT(ncores=1):
     if ncores == 1:
         print('-- nT lazy mode --')
-    st = straxen.contexts.xenonnt_online(_database_init=straxen.utilix_is_configured())
+    st = straxen.contexts.xenonnt_online(_database_init=straxen.utilix_is_configured(),
+                                         use_rucio=False)
     offline_gain_model = ("to_pe_placeholder", True)
     _update_context(st, ncores, fallback_gains=offline_gain_model, nt=True)
     # Lets take an abandoned run where we actually have gains for in the CMT

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -260,8 +260,7 @@ def test_1T(ncores=1):
 def test_nT(ncores=1):
     if ncores == 1:
         print('-- nT lazy mode --')
-    st = straxen.contexts.xenonnt_online(_database_init=straxen.utilix_is_configured(),
-                                         use_rucio=False)
+    st = straxen.contexts.xenonnt_online(_database_init=straxen.utilix_is_configured())
     offline_gain_model = ("to_pe_placeholder", True)
     _update_context(st, ncores, fallback_gains=offline_gain_model, nt=True)
     # Lets take an abandoned run where we actually have gains for in the CMT

--- a/tests/test_several.py
+++ b/tests/test_several.py
@@ -231,7 +231,7 @@ def test_nt_minianalyses():
             print("Temporary directory is ", temp_dir)
             os.chdir(temp_dir)
             from .test_plugins import DummyRawRecords, testing_config_nT, test_run_id_nT
-            st = straxen.contexts.xenonnt_online()
+            st = straxen.contexts.xenonnt_online(use_rucio=False)
             rundb = st.storage[0]
             rundb.readonly = True
             st.storage = [rundb, strax.DataDirectory(temp_dir)]


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Tweak #472, only init the remove backend if rucio is installed

## Can you briefly describe how it works?
Keep track of a flag, if that is false, don't use the remove

