### PR TITLE
Rundb should not crash on fuzzy

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -660,9 +660,14 @@ def set_state(state, update_fields=None):
     )
     if update_fields:
         bootstrax_state.update(update_fields)
-    if (previous_entry is None or
-            (now() - previous_entry['time'].replace(tzinfo=pytz.utc).seconds > timeouts[
-                'min_status_interval']):
+
+    need_new_doc = (
+        (previous_entry is None) or
+        ((now() - previous_entry['time'].replace(tzinfo=pytz.utc)).seconds
+         > timeouts['min_status_interval']
+         )
+    )
+    if need_new_doc:
         bs_coll.insert_one(bootstrax_state)
     else:
         bs_coll.update_one({'_id': previous_entry['_id']}, {'$set': bootstrax_state})

--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -5,7 +5,7 @@ import socket
 from tqdm import tqdm
 from copy import deepcopy
 import strax
-from .rucio import key_to_rucio_did, RucioLocalBackend
+from .rucio import key_to_rucio_did
 import warnings
 
 try:
@@ -123,7 +123,7 @@ class RunDB(strax.StorageFrontend):
 
         if self.rucio_path is not None:
             # TODO replace with rucio backend in the rucio module
-            self.backends.append(RucioLocalBackend(self.rucio_path))
+            self.backends.append(strax.rucio(self.rucio_path))
             # When querying for rucio, add that it should be dali-userdisk
             self.available_query.append({'host': 'rucio-catalogue',
                                          'location': 'UC_DALI_USERDISK',
@@ -182,8 +182,7 @@ class RunDB(strax.StorageFrontend):
                 backend_name, backend_key = (
                     datum['protocol'],
                     f'{key.run_id}-{key.data_type}-{key.lineage_hash}')
-                assert backend_name == 'rucio'
-                return 'RucioLocalBackend', datum['did']
+                return backend_name, backend_key
 
         dq = self._data_query(key)
         doc = self.collection.find_one({**run_query, **dq}, projection=dq)


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
 - Small patch in bootstrax due to #558 
 - Warn, rather than crash for fuzzy-options. If rundb cannot understand fuzzy for, it should not prevent other frontends from doing so
 - ~Use the straxen RucioLocalBackend instead of strax' rucio backend.~ should go in a seperate PR
