### PR TITLE
Change tight_coincidence

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -287,6 +287,7 @@ x1t_common_config = dict(
     peak_right_extension=30,
     s1_max_rise_time=60,
     s1_max_rise_time_post100=150,
+    s1_min_coincidence=3,
     # Events*
     left_event_extension=int(0.3e6),
     right_event_extension=int(1e6),

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -92,7 +92,7 @@ class Peaklets(strax.Plugin):
     parallel = 'process'
     compressor = 'zstd'
 
-    __version__ = '0.3.9'
+    __version__ = '0.3.10'
 
     def infer_dtype(self):
         return dict(peaklets=strax.peak_dtype(
@@ -779,7 +779,7 @@ def get_tight_coin(hit_max_times, peak_max_times, left, right):
 
             # if the hit is in the window, its a tight coin
             d = hit_max_times[left_hit_i] - p_t
-            if (-left < d) & (d < right):
+            if (-left <= d) & (d <= right):
                 n_coin[p_i] += 1
 
             # stop the loop when we know we're outside the range

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -480,7 +480,7 @@ class PeakletsHighEnergy(Peaklets):
                  help="Maximum S1 rise time for < 100 PE [ns]"),
     strax.Option('s1_max_rise_time_post100', default=200,
                  help="Maximum S1 rise time for > 100 PE [ns]"),
-    strax.Option('s1_min_coincidence', default=3,
+    strax.Option('s1_min_coincidence', default=2,
                  help="Minimum tight coincidence necessary to make an S1"),
     strax.Option('s2_min_pmts', default=4,
                  help="Minimum number of PMTs contributing to an S2"))

--- a/tests/test_several.py
+++ b/tests/test_several.py
@@ -40,9 +40,9 @@ def test_secret():
 # They were added on 27/11/2020 and may be outdated by now
 EXPECTED_OUTCOMES_TEST_SEVERAL = {
     'n_peaks': 128,
-    'n_s1': 4,
+    'n_s1': 6,
     'run_live_time': 0.17933107,
-    'n_events': 2
+    'n_events': 2,
 }
 
 


### PR DESCRIPTION
In pax's waveform simulator, the [tight_coincidence_window](https://github.com/XENON1T/pax/blob/871b241f81456de26c8eab4fd74c282cdd5a9394/pax/plugins/peak_processing/BasicProperties.py#L125) was implemented with <= and >=, but in [straxen](https://github.com/XENONnT/straxen/blob/d298b675b06cddb954b4fad893fbb74364fa1d3e/straxen/plugins/peaklet_processing.py) it used < and > -- this amounts to an effectively 20ns smaller total left-right window. In other words, though we set the left and right window to the same values (50ns) as in pax, we end up with a "tighter" coincidence requirement.

This PR modifies straxen so that the windows have the same definition as in the past.

_edit by Joran_
At the request of the ACs, we are also lowering the tight coincidence to 2.