### PR TITLE
debug merged S2s #548

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,7 @@ patches and fixes:
 - Add scada interface to docs (#560)
 - Tweaks for new release 0.19.0 (#562)
 
+
 0.18.6-0.18.8 / 2021-06-03
 -------------------
 - Patches installation for pypi (#529, e880420, fce6d87)


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
In #548 we got a bug due to this this `>` which should have been `>=`:
```python
            if (peaklet_ends[right_i - 1] - peaklet_starts[left_i]) > max_duration:
```

## Can you briefly describe how it works?
If there is something at the boundary, strax will create a too small buffer to fit this WF, leading to a ValueError [here](https://github.com/AxFoundation/strax/blob/058b39ac87c9cf9f0db98866d3554aa3d419b6db/strax/processing/peak_merging.py#L59)
