### PR TITLE
S2 merge further debug

### DIFF
--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -649,9 +649,9 @@ class MergedS2s(strax.OverlapWindowPlugin):
 
             # Mark the current gap merged and update info of its previous and next gap
             # There's no previous gap for gap[0], and no next gap for gap[n_gaps-1]
-            if gap_i != 0:
+            if previous_valid_gap[gap_i] != -1:
                 next_valid_gap[previous_valid_gap[gap_i]] = next_valid_gap[gap_i]
-            if gap_i != n_gaps - 1:
+            if next_valid_gap[gap_i] != n_gaps:
                 previous_valid_gap[next_valid_gap[gap_i]] = previous_valid_gap[gap_i]
 
             gaps_to_merge[gap_i + 1] = True

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -627,7 +627,7 @@ class MergedS2s(strax.OverlapWindowPlugin):
             left_i = previous_valid_gap[gap_i] + 1
             # the right is inclusive
             right_i = next_valid_gap[gap_i]
-
+            assert left_i <= right_i, 'Something went wrong, left is bigger then right?!'
             sum_area = areas[left_i:right_i + 1].sum()
 
             if peaklet_gaps[gap_i] > max_gap:

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -557,7 +557,7 @@ class MergedS2s(strax.OverlapWindowPlugin):
     depends_on = ('peaklets', 'peaklet_classification')
     data_kind = 'merged_s2s'
     provides = 'merged_s2s'
-    __version__ = '0.1.2'
+    __version__ = '0.2.0'
 
     def infer_dtype(self):
         return strax.unpack_dtype(self.deps['peaklets'].dtype_for('peaklets'))


### PR DESCRIPTION
# Debug #548

In #548 there was a bug for indices at the boundaries. In the process, we realized that in addition to fixing that, we could also simplify the logic.

To reproduce the error:
```python
import straxen
st = straxen.contexts.xenon1t_dali()
st.storage += [strax.DataDirectory('/dali/lgrandi/xenon1t/strax_converted/temp_data/strax_data', readonly=True)]
st.make('181027_2244', 'merged_s2s', progress_bar=True)
```

# How does it work
Only keep track of the start and end indices of the merges, that is all the information that one should need.