### PR TITLE
Rewrite EventBasics, set event level S1 tight coincidence

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -477,7 +477,6 @@ def main_loop():
             process_run(rd)
             continue
         # Nothing to do, let's do some cleanup
-        delete_temp_files()
         if not args.production:
             log.info(f'We have gone through the rundDB in a readonly mode there are no '
                      f'runs left. We looked at {new_runs_seen} new runs and '
@@ -660,6 +659,8 @@ def set_state(state, update_fields=None):
         production_mode=args.production
     )
     if update_fields:
+        update_fields = strax.storage.mongo.remove_np(update_fields)
+        log.debug(f'Update fields {update_fields}')
         bootstrax_state.update(update_fields)
 
     need_new_doc = (
@@ -898,21 +899,6 @@ def sufficient_diskspace():
     message = f"No disk space to write to. Kill bootstrax on {hostname}"
     log_warning(message, priority='fatal')
     raise RuntimeError(message)
-
-
-def delete_temp_files():
-    """
-    removes _temp files from output_folder if successfully processed
-    """
-    temp_files = [f for f in os.listdir(output_folder) if f.endswith('_temp')]
-    for f in temp_files:
-        run_id = int(f.split('-')[0])
-        if run_coll.find_one(
-                {'bootstrax.state': 'done',
-                 'number': run_id},
-                {'_id': 1}):
-            log.info(f'removing {output_folder}/{f}')
-            shutil.rmtree(f'{output_folder}/{f}')
 
 
 def delete_live_data(rd, live_data_path):

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -311,8 +311,7 @@ class EventBasics(strax.Plugin):
         self.set_event_properties(event, largest_s1s, largest_s2s, peaks)
 
         # Loop over S1s and S2s and over main / alt.
-        for i, largest_s_i in enumerate([largest_s1s, largest_s2s]):
-            s_i = i + 1
+        for s_i, largest_s_i in enumerate([largest_s1s, largest_s2s], 1):
             # Largest index 0 -> main sx, 1 -> alt sx
             for largest_index, main_or_alt in enumerate(['s', 'alt_s']):
                 peak_properties_to_save = [name for name, _, _ in self.peak_properties]

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -274,7 +274,7 @@ class EventBasics(strax.Plugin):
     # If copy_largest_peaks_in_events is ever numbafied, also numbafy this function
     def fill_events(self, result_buffer, events, split_peaks):
         """Loop over the events and peaks within that event"""
-        for event_i in range(len(events)):
+        for event_i, _ in enumerate(events):
             peaks_in_event_i = split_peaks[event_i]
             n_peaks = len(peaks_in_event_i)
 

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -125,7 +125,7 @@ class Events(strax.OverlapWindowPlugin):
         name='event_s1_min_coincidence',
         default=2,
         help="Event level S1 min coincidence. Should be >= s1_min_coincidence "
-             "in the peaklet classification")
+             "in the peaklet classification"),
 )
 class EventBasics(strax.Plugin):
     """
@@ -179,6 +179,7 @@ class EventBasics(strax.Plugin):
     def set_dtype_requirements(self):
         """Needs to be run before inferring dtype as it is needed there"""
         self._set_posrec_save()
+
         # Properties to store for each peak (main and alternate S1 and S2)
         self.peak_properties = (
             # name                dtype       comment

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -145,7 +145,8 @@ class EventBasics(strax.Plugin):
 
     def infer_dtype(self):
         # Basic event properties
-        self.set_dtype_requirements()
+        self._set_posrec_save()
+        self._set_dtype_requirements()
         dtype = []
         dtype += strax.time_fields
         dtype += [('n_peaks', np.int32,
@@ -173,24 +174,22 @@ class EventBasics(strax.Plugin):
         dtype += self._get_posrec_dtypes()
         return dtype
 
-    def set_dtype_requirements(self):
+    def _set_dtype_requirements(self):
         """Needs to be run before inferring dtype as it is needed there"""
-        self._set_posrec_save()
-
         # Properties to store for each peak (main and alternate S1 and S2)
         self.peak_properties = (
             # name                dtype       comment
-            ('time', np.int64, 'start time since unix epoch [ns]'),
-            ('center_time', np.int64, 'weighted center time since unix epoch [ns]'),
-            ('endtime', np.int64, 'end time since unix epoch [ns]'),
-            ('area', np.float32, 'area, uncorrected [PE]'),
-            ('n_channels', np.int32, 'count of contributing PMTs'),
-            ('n_competing', np.float32, 'number of competing PMTs'),
-            ('max_pmt', np.int16, 'PMT number which contributes the most PE'),
-            ('max_pmt_area', np.float32, 'area in the largest-contributing PMT (PE)'),
-            ('range_50p_area', np.float32, 'width, 50% area [ns]'),
-            ('range_90p_area', np.float32, 'width, 90% area [ns]'),
-            ('rise_time', np.float32, 'time between 10% and 50% area quantiles [ns]'),
+            ('time',              np.int64,   'start time since unix epoch [ns]'),
+            ('center_time',       np.int64,   'weighted center time since unix epoch [ns]'),
+            ('endtime',           np.int64,   'end time since unix epoch [ns]'),
+            ('area',              np.float32, 'area, uncorrected [PE]'),
+            ('n_channels',        np.int32,   'count of contributing PMTs'),
+            ('n_competing',       np.float32, 'number of competing PMTs'),
+            ('max_pmt',           np.int16,   'PMT number which contributes the most PE'),
+            ('max_pmt_area',      np.float32, 'area in the largest-contributing PMT (PE)'),
+            ('range_50p_area',    np.float32, 'width, 50% area [ns]'),
+            ('range_90p_area',    np.float32, 'width, 90% area [ns]'),
+            ('rise_time',         np.float32, 'time between 10% and 50% area quantiles [ns]'),
             ('area_fraction_top', np.float32, 'fraction of area seen by the top PMT array')
         )
 
@@ -252,16 +251,16 @@ class EventBasics(strax.Plugin):
         return posrec_dtpye
 
     @staticmethod
-    def set_nan_defaults(result):
+    def set_nan_defaults(buffer):
         """
         When constructing the dtype, take extra care to set values to
         np.Nan / -1 (for ints) as 0 might have a meaning
         """
-        for field in result.dtype.names:
-            if np.issubdtype(result.dtype[field], np.integer):
-                result[field][:] = -1
+        for field in buffer.dtype.names:
+            if np.issubdtype(buffer.dtype[field], np.integer):
+                buffer[field][:] = -1
             else:
-                result[field][:] = np.nan
+                buffer[field][:] = np.nan
 
     def compute(self, events, peaks):
         result = np.zeros(len(events), dtype=self.dtype)

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -382,9 +382,10 @@ class EventBasics(strax.Plugin):
         (largest_s_i) into their associated field in the event (e.g. s1_area),
         main_or_alt_index differentiates between main (index 0) and alt (index 1)
         """
-        if len(largest_s_i) <= main_or_alt_index:
-            # Maybe there is no such peak. E.g. when asking for an alt-S1
-            # (main_or_alt_index == 1) and the largest_s_1 only has the main S1
+        index_not_in_list_of_largest_peaks = main_or_alt_index >= len(largest_s_i)
+        if index_not_in_list_of_largest_peaks:
+            # There is no such peak. E.g. main_or_alt_index == 1 but largest_s_i = ["Main S1"]
+            # Asking for index 1 doesn't work on a len 1 list of peaks.
             return
 
         for i, ev_field in enumerate(result_fields):

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -260,9 +260,16 @@ class EventBasics(strax.Plugin):
 
         return posrec_dtpye
 
+    def set_nan_defaults(self, result):
+        # TODO don't remember which where the important ones
+        nan_types = 's2_x', 's2_y'
+        for field in result.dtype.names:
+            if any([field in n for n in nan_types]):
+                result[field][:] = np.nan
+
     def compute(self, events, peaks):
         result = np.ones(len(events), dtype=self.dtype)
-        result *= -1
+        self.set_nan_defaults(result)
 
         fully_contained_in = strax.fully_contained_in(peaks, events)
         for event_i, event in events:

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -261,7 +261,8 @@ class EventBasics(strax.Plugin):
         return posrec_dtpye
 
     def compute(self, events, peaks):
-        result = np.ones(len(events), self.dtype) * -1
+        result = np.ones(len(events), dtype=self.dtype)
+        result *= -1
 
         fully_contained_in = strax.fully_contained_in(peaks, events)
         for event_i, event in events:

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -120,7 +120,12 @@ class Events(strax.OverlapWindowPlugin):
     strax.Option(
         name='force_main_before_alt', default=False,
         help="Make the alternate S1 (and likewise S2) the main S1 if "
-             "occurs before the main S1.")
+             "occurs before the main S1."),
+    strax.Option(
+        name='event_s1_min_coincidence',
+        default=2,
+        help="Event level S1 min coincidence. Should be >= s1_min_coincidence "
+             "in the peaklet classification")
 )
 class EventBasics(strax.LoopPlugin):
     """
@@ -252,6 +257,10 @@ class EventBasics(strax.LoopPlugin):
                 # the main or alternate S1
                 if s_i == 1 and result[f's2_index'] != -1:
                     s_mask &= peaks['time'] < main_s[2]['time']
+            if s_i == 1:
+                # If we have an event-level S1 tight coincidence, let's apply that here too
+                s_mask &= peaks['tight_coincidence'] > self.config['event_s1_min_coincidence']
+
             ss = peaks[s_mask]
             s_indices = np.arange(len(peaks))[s_mask]
 

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -1,5 +1,6 @@
 import strax
 import numpy as np
+import numba
 import straxen
 from warnings import warn
 from .position_reconstruction import DEFAULT_POSREC_ALGO_OPTION
@@ -135,7 +136,7 @@ class EventBasics(strax.Plugin):
     The main S2 and alternative S2 are given by the largest two S2-Peaks
     within the event. By default this is also true for S1.
     """
-    __version__ = 'bla' #1.0.0'
+    __version__ = '1.0.0'
 
     depends_on = ('events',
                   'peak_basics',
@@ -276,6 +277,10 @@ class EventBasics(strax.Plugin):
         self.set_nan_defaults(result)
 
         fully_contained_in = strax.fully_contained_in(peaks, events)
+        self.fill_events(result, events, peaks, fully_contained_in)
+        return result
+
+    def fill_events(self, result, events, peaks, fully_contained_in):
         for event_i, event in enumerate(events):
             peak_mask = fully_contained_in == event_i
             n_peaks = np.sum(peak_mask)
@@ -290,7 +295,6 @@ class EventBasics(strax.Plugin):
             result_i = self.get_results_for_event(peaks[peak_mask])
             for field, value in result_i.items():
                 result[event_i][field] = value
-        return result
 
     # TODO numbafy
     def get_results_for_event(self, peaks):


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
 - For speed, we might want to be able to increase the S1-tight coincidence requirement at a later stage in the processing. To do so, add a new option to EventBasics that ignores S1s that are below the tight coincidence requirement. This was a nice idea by @JosephJHowlett 
 - No more loop plugin as it's not needed to do a slow loop (my aim was to get it fully numba, I almost succeeded but in the end I did not manage due to the many fields that need passed on as arguments `copy_largest_peaks_in_events` 😭 ).
 - Set some Nan defaults to parameters for fields. If a parameter is stored as an int, default to -1. This was a request by @jpienaar13 .
 - Split the code a lot make the overall workflow clearer (hopefully), I might have overdone it a bit in the dtype setup, if so, please let me know.
 

## Can you briefly describe how it works?
To change the S1 coincidence level at event level, you can do:
```python
st_new.set_config(dict(event_s1_min_coincidence=3))
st_new.get_df(run_id, target)
```

## Can you give an example:
![afbeelding](https://user-images.githubusercontent.com/22295914/124778285-26b20000-df41-11eb-9651-9a17021efca5.png)
