### PR TITLE
do not interpolate corrections if is an array (fix)

### DIFF
--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -138,7 +138,7 @@ class CorrectionsManagementServices():
                         values.append(df.loc[df.index == when, version].values[0])
             else:
                 df = self.interface.read(correction)
-                if correction in corrections_w_file or version in 'ONLINE':
+                if correction in corrections_w_file or correction in arrays_corrections or version in 'ONLINE':
                     df = self.interface.interpolate(df, when, how='fill')
                 else:
                     df = self.interface.interpolate(df, when)


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
Fix an issue with correction with arrays
If `straxen.get_correction_from_cmt(runid, ('hit_thresholds_tpc', 'v1', True))` is used or any other offline version it returns the following error
`TypeError: Cannot interpolate with all object-dtype columns in the DataFrame. Try setting at least one column to a numeric dtype.`
Because Pandas does not know how to interpolate an array. Then use the option "fill"

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
