### PR TITLE
Fixing veto intervals time

### DIFF
--- a/straxen/plugins/acqmon_processing.py
+++ b/straxen/plugins/acqmon_processing.py
@@ -116,7 +116,7 @@ class VetoIntervals(strax.OverlapWindowPlugin):
                         result["veto_type"][vetos_seen] = name + 'veto'
                         vetos_seen += 1
         result = result[:vetos_seen]
-        result['time'] = np.clip(strax.endtime(result), start, end)
+        result['time'] = np.clip(result['time'], start, end)
         result['endtime'] = np.clip(strax.endtime(result), 0, end)
         sort = np.argsort(result['time'])
         result = result[sort]
@@ -197,7 +197,8 @@ class VetoProximity(strax.OverlapWindowPlugin):
                         inx = np.searchsorted(veto_start_time_selection, event_center, side='right')
 
                     # Time to previous veto on/off
-                    # Just using maxsize as a huge value that will not fit in any potential VetoCut range
+                    # Just using a huge value that will not fit in any potential
+                    # DAQVetoCut range
                     if inx == 0:
                         previous_veto = T_NO_VETO_FOUND
                     else:

--- a/straxen/plugins/acqmon_processing.py
+++ b/straxen/plugins/acqmon_processing.py
@@ -67,7 +67,7 @@ class VetoIntervals(strax.OverlapWindowPlugin):
     hev_*   <= DDC10 hardware high energy veto
     """
 
-    __version__ = '0.1.5'
+    __version__ = '0.1.6'
     depends_on = ('aqmon_hits')
     provides = ('veto_intervals')
     data_kind = ('veto_intervals')


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Fixing a small bug in the Veto Intervals final dtype, previously it was outputting "endtime" twice. This was pointed to me by several people already. 

Also, I guess it's kinda worth keeping the np.clip, just in case something bugs out and we have at least the start/end times to rely upon.

PS. Plus updated one of the comments.