### PR TITLE
Patch scada interface

### DIFF
--- a/straxen/plugins/x1t_cuts.py
+++ b/straxen/plugins/x1t_cuts.py
@@ -198,7 +198,7 @@ class S1MaxPMT(strax.LoopPlugin):
     """Removes events where the largest hit in S1 is too large
     port from lax.sciencerun0.py"""
     depends_on = ('events', 'event_basics', 'peak_basics')
-    dtype = [('cut_s1_max_pmt', np.bool, 'S1 max PMT cut')] + strax.time_fields
+    dtype = [('cut_s1_max_pmt', np.bool_, 'S1 max PMT cut')] + strax.time_fields
     provides = 'cut_s1_max_pmt'
     __version__ = 1.2
 

--- a/straxen/plugins/x1t_cuts.py
+++ b/straxen/plugins/x1t_cuts.py
@@ -200,7 +200,7 @@ class S1MaxPMT(strax.LoopPlugin):
     depends_on = ('events', 'event_basics', 'peak_basics')
     dtype = [('cut_s1_max_pmt', np.bool_, 'S1 max PMT cut')] + strax.time_fields
     provides = 'cut_s1_max_pmt'
-    __version__ = 1.2
+    __version__ = 1.3
 
     def compute_loop(self, event, peaks):
         ret = dict(cut_s1_max_pmt=True)

--- a/straxen/scada.py
+++ b/straxen/scada.py
@@ -244,6 +244,10 @@ class SCADAInterface:
                    'corresponding times as nans instead.')
             warnings.warn(mes)
 
+        # Chop start/end time if precision is higher then seconds level.
+        start = (start//10**9)*10**9
+        end = (end//10**9)*10**9
+
         return int(start), int(end), now
 
     def _query_single_parameter(self,

--- a/tests/test_scada.py
+++ b/tests/test_scada.py
@@ -20,6 +20,8 @@ def test_query_sc_values():
     # Simple query test:
     # Query 5 s of data:
     start = 1609682275000000000
+    # Add micro-second to check if query does not fail if inquery precsion > SC precision
+    start += 10**6
     end = start + 5 * 10**9
     parameters = {'SomeParameter': 'XE1T.CTPC.Board06.Chan011.VMon'}
 


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
Fix a bug in scada interface noticed by @HaochenYanICRR. In the current version querying data with a higher precision than seconds will raise an error. In this PR we simply chop any ms/µs/ns entries in the time stamps. I also updated the test accordingly.

In addition I added  piggybacked a small change which removes the following warning when running tests:

```
straxen/plugins/x1t_cuts.py:201
  /home/dwenz/mymodules/straxen/straxen/plugins/x1t_cuts.py:201: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    dtype = [('cut_s1_max_pmt', np.bool, 'S1 max PMT cut')] + strax.time_field
```
