### PR TITLE
Use rucio from straxen & nest RucioRemote imports

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -103,7 +103,8 @@ def xenonnt(cmt_version='global_ONLINE', **kwargs):
 
 
 def xenonnt_online(output_folder='./strax_data',
-                   use_rucio=False,
+                   use_rucio=True,
+                   use_rucio_remote=False,
                    we_are_the_daq=False,
                    _minimum_run_number=7157,
                    _maximum_run_number=None,
@@ -122,6 +123,7 @@ def xenonnt_online(output_folder='./strax_data',
     :param output_folder: str, Path of the strax.DataDirectory where new
         data can be stored
     :param use_rucio: bool, whether or not to use the rucio frontend
+    :param use_rucio_remote: bool, if download data from rucio directly
     :param we_are_the_daq: bool, if we have admin access to upload data
     :param _minimum_run_number: int, lowest number to consider
     :param _maximum_run_number: Highest number to consider. When None
@@ -179,7 +181,7 @@ def xenonnt_online(output_folder='./strax_data',
     # if we said so, add the rucio frontend to storage
     if use_rucio:
         st.storage.append(straxen.rucio.RucioFrontend(
-            include_remote=straxen.RUCIO_AVAILABLE,
+            include_remote=use_rucio_remote,
             staging_dir=output_folder,
         ))
 

--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -5,7 +5,7 @@ import socket
 from tqdm import tqdm
 from copy import deepcopy
 import strax
-from .rucio import key_to_rucio_did
+from .rucio import key_to_rucio_did, RucioLocalBackend
 import warnings
 
 try:
@@ -123,7 +123,7 @@ class RunDB(strax.StorageFrontend):
 
         if self.rucio_path is not None:
             # TODO replace with rucio backend in the rucio module
-            self.backends.append(strax.rucio(self.rucio_path))
+            self.backends.append(RucioLocalBackend(self.rucio_path))
             # When querying for rucio, add that it should be dali-userdisk
             self.available_query.append({'host': 'rucio-catalogue',
                                          'location': 'UC_DALI_USERDISK',
@@ -179,9 +179,8 @@ class RunDB(strax.StorageFrontend):
                 datum = doc['data'][0]
                 error_message = f'Expected {rucio_key} got data on {datum["location"]}'
                 assert datum.get('did', '') == rucio_key, error_message
-                backend_name, backend_key = (
-                    datum['protocol'],
-                    f'{key.run_id}-{key.data_type}-{key.lineage_hash}')
+                backend_name = 'RucioLocalBackend'
+                backend_key = key_to_rucio_did(key)
                 return backend_name, backend_key
 
         dq = self._data_query(key)


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
- Reduce import verbosity
- Nest RucioRemote - imports (do them only when needed, but fail hard)
- Use straxens backend, instead of strax such that we can one day [remove that from strax](https://github.com/AxFoundation/strax/pull/451)

