### PR TITLE
increase input_timeout buffer daq reader

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -283,6 +283,9 @@ def new_context(cores=args.cores,
                            strax.DataDirectory(output_folder)]
         context.storage[0].readonly = True
         context.storage[0].local_only = True
+
+    # Temporary increase the input timeout for the DAQReader since chunks might be longer
+    context._plugin_class_registry['raw_records'].input_timeout = 300
     return context
 
 

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -283,9 +283,6 @@ def new_context(cores=args.cores,
                            strax.DataDirectory(output_folder)]
         context.storage[0].readonly = True
         context.storage[0].local_only = True
-
-    # Temporary increase the input timeout for the DAQReader since chunks might be longer
-    context._plugin_class_registry['raw_records'].input_timeout = 300
     return context
 
 

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -101,7 +101,8 @@ class DAQReader(strax.Plugin):
     )
     compressor = 'lz4'
     __version__ = '0.0.0'
-
+    input_timeout = 300
+    
     def infer_dtype(self):
         return {
             d: strax.raw_record_dtype(


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
We are experimenting with longer chunks, let's see how this works out.

Let's for the time being set this to a much longer value (current is 80s). If chunks are ~20 long and a few are in redax' memory 80s might not be enough.
