### PR TITLE
Straxer for other packages

### DIFF
--- a/bin/straxer
+++ b/bin/straxer
@@ -191,7 +191,7 @@ def main(args):
     # to do them after argparsing (so --help is fast)
     import strax
     import straxen
-    straxen.print_versions({'strax', 'straxen', args.package})
+    straxen.print_versions(tuple({'strax', 'straxen', args.package}))
 
     st = setup_context(args)
 

--- a/bin/straxer
+++ b/bin/straxer
@@ -113,6 +113,7 @@ def parse_args():
         help='Also add folder to st.storage')
     return parser.parse_args()
 
+
 def setup_context(args):
     # reimport to be safe
     import strax
@@ -120,6 +121,7 @@ def setup_context(args):
 
     context_module = importlib.import_module(f'{args.package}.contexts')
     st = getattr(context_module, args.context)()
+
     if args.context_kwargs:
         logging.info(f'set context kwargs {args.context_kwargs}')
         st = getattr(context_module, args.context)(**args.context_kwargs)

--- a/bin/straxer
+++ b/bin/straxer
@@ -263,7 +263,7 @@ def main(args):
                  f"peak RAM usage was around {peak_ram:.1f} MB.")
 
 
-def register_to_context(st, module:str):
+def register_to_context(st, module: str):
     if not os.path.exists(module):
         raise FileNotFoundError(f'No such file {module}')
     assert module.endswith('.py'), "only py files please!"
@@ -294,4 +294,3 @@ if __name__ == '__main__':
         print(f"Memory profiler says peak RAM usage was: {max(mem):.1f} MB")
     else:
         sys.exit(main(args))
-

--- a/bin/straxer
+++ b/bin/straxer
@@ -9,10 +9,10 @@ import os
 import os.path as osp
 import platform
 import psutil
-import sys
 import json
 import importlib
-
+import sys
+from pprint import pprint
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -40,6 +40,11 @@ def parse_args():
         '--context_kwargs',
         type=json.loads,
         help='Use a json-file to load the context with')
+    parser.add_argument(
+        '--register_from_file',
+        type=str,
+        help='do st.register_all from a specified file'
+    )
     parser.add_argument(
         '--config_kwargs',
         type=json.loads,
@@ -108,39 +113,35 @@ def parse_args():
         help='Also add folder to st.storage')
     return parser.parse_args()
 
-
-def main(args):
-    logging.basicConfig(
-        level=logging.DEBUG if args.debug else logging.INFO,
-        format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s')
-
-    print(f"Starting processing of run {args.run_id} until {args.target}")
-    print(f"\tpython {platform.python_version()} at {sys.executable}")
-
-    # These imports take a bit longer, so it's nicer
-    # to do them after argparsing (so --help is fast)
+def setup_context(args):
+    # reimport to be safe
     import strax
-    print(f"\tstrax {strax.__version__} at {osp.dirname(strax.__file__)}")
     import straxen
-    print(f"\tstraxen {straxen.__version__} at {osp.dirname(straxen.__file__)}")
-    
+
     context_module = importlib.import_module(f'{args.package}.contexts')
     st = getattr(context_module, args.context)()
-    if args.diagnose_sorting:
-        st.set_config(dict(diagnose_sorting=True))
     if args.context_kwargs:
         logging.info(f'set context kwargs {args.context_kwargs}')
-        st = getattr(module, args.context)(**args.context_kwargs)
+        st = getattr(context_module, args.context)(**args.context_kwargs)
 
     if args.config_kwargs:
         logging.info(f'set context options to {args.config_kwargs}')
-        st.set_config(args.config_kwargs)
+        st.set_config(to_dict_tuple(args.config_kwargs))
+
+    if args.register_from_file:
+        register_to_context(st, args.register_from_file)
+
+    if args.diagnose_sorting:
+        st.set_config(dict(diagnose_sorting=True))
+
     st.context_config['allow_multiprocess'] = args.multiprocess
     st.context_config['allow_shm'] = args.shm
     st.context_config['allow_lazy'] = not (args.notlazy is True)
+
     if args.timeout is not None:
         st.context_config['timeout'] = args.timeout
     st.context_config['max_messages'] = args.max_messages
+
     if args.build_lowlevel:
         st.context_config['forbid_creation_of'] = tuple()
     else:
@@ -175,6 +176,23 @@ def main(args):
     if st.is_stored(args.run_id, args.target):
         logging.info("This data is already available.")
         return 1
+    return st
+
+
+def main(args):
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s')
+
+    logging.info(f"Starting processing of run {args.run_id} until {args.target}")
+
+    # These imports take a bit longer, so it's nicer
+    # to do them after argparsing (so --help is fast)
+    import strax
+    import straxen
+    straxen.print_versions({'strax', 'straxen', args.package})
+
+    st = setup_context(args)
 
     logging.debug(st.available_for_run(args.run_id))
 
@@ -239,15 +257,25 @@ def main(args):
         print(msg, flush=True)
 
     logging.info(f"\nStraxer is done! "
-          f"We took {time.time() - clock_start:.1f} seconds, "
-          f"peak RAM usage was around {peak_ram:.1f} MB.")
+                 f"We took {time.time() - clock_start:.1f} seconds, "
+                 f"peak RAM usage was around {peak_ram:.1f} MB.")
 
 
-def json_to_dict(path:str):
-    if not os.path.exists(path):
-        raise FileNotFoundError(f'{path} does not exist')
-    with open(path, mode='r') as f:
-        res = json.loads(f.read())
+def register_to_context(st, module:str):
+    if not os.path.exists(module):
+        raise FileNotFoundError(f'No such file {module}')
+    assert module.endswith('.py'), "only py files please!"
+    folder, file = os.path.split(module)
+    sys.path.append(folder)
+    to_register = importlib.import_module(os.path.splitext(file)[0])
+    st.register_all(to_register)
+    logging.info(f'Successfully registered {file}. Printing plugins')
+    pprint(st._plugin_class_registry)
+
+
+def to_dict_tuple(res: dict):
+    """Convert list configs to tuple configs"""
+    res = res.copy()
     for k, v in res.copy().items():
         if type(v) == list:
             # Remove lists to tuples

--- a/bin/straxer
+++ b/bin/straxer
@@ -23,16 +23,26 @@ def parse_args():
         type=str,
         help="ID of the run to process; usually the run name.")
     parser.add_argument(
+        '--package',
+        default='straxen',
+        help="Where to load the context from (straxen/cutax/pema)")
+    parser.add_argument(
         '--context',
         default='xenonnt_online',
-        help="Name of straxen context to use")
+        help="Name of context to use")
     parser.add_argument(
         '--target',
         default='event_info',
-        help='Target final data type to produce')
+        nargs='*',
+        help='Target final data type to produce. Can be a list for multicore mode.')
     parser.add_argument(
-        '--config_from_json', default='',
-        help='Use a json-file to load the config from')
+        '--context_kwargs',
+        type=json.loads,
+        help='Use a json-file to load the context with')
+    parser.add_argument(
+        '--config_kwargs',
+        type=json.loads,
+        help='Use a json-file to set the context to')
     parser.add_argument(
         '--from_scratch',
         action='store_true',
@@ -68,7 +78,7 @@ def parse_args():
     parser.add_argument(
         '--profile_to',
         default='',
-        help="Filename to output profile information to. If ommitted,"
+        help="Filename to output profile information to. If omitted,"
              "no profiling will occur.")
     parser.add_argument(
         '--profile_ram',
@@ -112,13 +122,20 @@ def main(args):
     print(f"\tstrax {strax.__version__} at {osp.dirname(strax.__file__)}")
     import straxen
     print(f"\tstraxen {straxen.__version__} at {osp.dirname(straxen.__file__)}")
-
-    st = getattr(straxen.contexts, args.context)()
+    if not args.package == 'straxen':
+        # pylint: disable=exec-used
+        exec(f'import {args.package}')
+    module = getattr(locals()[args.package], 'contexts')
+    st = getattr(module, args.context)()
     if args.diagnose_sorting:
         st.set_config(dict(diagnose_sorting=True))
-    if args.config_from_json != '':
-        conf = json_to_dict(args.config_from_json)
-        st.set_config(conf)
+    if args.context_kwargs:
+        logging.info(f'set context kwargs {args.context_kwargs}')
+        st = getattr(module, args.context)(**args.context_kwargs)
+
+    if args.config_kwargs:
+        logging.info(f'set context options to {args.config_kwargs}')
+        st.set_config(args.config_kwargs)
     st.context_config['allow_multiprocess'] = args.multiprocess
     st.context_config['allow_shm'] = args.shm
     st.context_config['allow_lazy'] = not (args.notlazy is True)
@@ -141,10 +158,14 @@ def main(args):
         for sf in st.storage:
             # Set all others to read only
             sf.readonly = True
-        # TODO
-        #  should we check that it doesn't exist already?
-        st.storage += [
-            strax.DataDirectory('./strax_data')]
+        for sf in st.storage:
+            if hasattr(sf, 'path'):
+                if sf.path == './strax_data':
+                    break
+        else:
+            st.storage += [
+                strax.DataDirectory('./strax_data')]
+
     if args.add_folder != '':
         for sf in st.storage:
             # Set all others to read only
@@ -155,6 +176,8 @@ def main(args):
     if st.is_stored(args.run_id, args.target):
         logging.info("This data is already available.")
         return 1
+
+    logging.debug(st.available_for_run(args.run_id))
 
     try:
         md = st.run_metadata(args.run_id)
@@ -178,7 +201,10 @@ def main(args):
         kwargs = dict(
             run_id=args.run_id,
             targets=args.target,
-            max_workers=int(args.workers))
+            max_workers=int(args.workers),
+            allow_multiple=len(strax.to_str_tuple(args.target)) > 1,
+            progress_bar=False,
+        )
 
         if args.profile_to:
             with strax.profile_threaded(args.profile_to):
@@ -239,3 +265,4 @@ if __name__ == '__main__':
         print(f"Memory profiler says peak RAM usage was: {max(mem):.1f} MB")
     else:
         sys.exit(main(args))
+

--- a/bin/straxer
+++ b/bin/straxer
@@ -6,13 +6,12 @@ import datetime
 import logging
 import time
 import os
-import os.path as osp
-import platform
 import psutil
 import json
 import importlib
 import sys
 from pprint import pprint
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -196,7 +195,8 @@ def main(args):
 
     st = setup_context(args)
 
-    logging.debug(st.available_for_run(args.run_id))
+    # Reactivate after https://github.com/XENONnT/straxen/issues/586
+    # logging.debug(st.available_for_run(args.run_id))
 
     try:
         md = st.run_metadata(args.run_id)

--- a/bin/straxer
+++ b/bin/straxer
@@ -11,6 +11,7 @@ import platform
 import psutil
 import sys
 import json
+import importlib
 
 
 def parse_args():
@@ -122,11 +123,9 @@ def main(args):
     print(f"\tstrax {strax.__version__} at {osp.dirname(strax.__file__)}")
     import straxen
     print(f"\tstraxen {straxen.__version__} at {osp.dirname(straxen.__file__)}")
-    if not args.package == 'straxen':
-        # pylint: disable=exec-used
-        exec(f'import {args.package}')
-    module = getattr(locals()[args.package], 'contexts')
-    st = getattr(module, args.context)()
+    
+    context_module = importlib.import_module(f'{args.package}.contexts')
+    st = getattr(context_module, args.context)()
     if args.diagnose_sorting:
         st.set_config(dict(diagnose_sorting=True))
     if args.context_kwargs:

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -8,6 +8,8 @@ import warnings
 import datetime
 import pytz
 from os import environ as os_environ
+from importlib import import_module
+
 
 export, __all__ = strax.exporter()
 from configparser import NoSectionError
@@ -57,10 +59,12 @@ def print_versions(modules=('strax', 'straxen', 'cutax'), return_string=False):
     message += f"\npython\tv{py_version}"
     for m in strax.to_str_tuple(modules):
         try:
-            # pylint: disable=exec-used
-            exec(f'import {m}')
-            # pylint: disable=eval-used
-            message += f'\n{m}\tv{eval(m).__version__}\t{eval(m).__path__[0]}'
+            mod = import_module(m)
+            message += f'\n{m}'
+            if hasattr(mod, '__version__'):
+                message += f'\tv{mod.__version__}'
+            if hasattr(mod, '__path__'):
+                message += '\t{mod.__path__[0]}'
         except (ModuleNotFoundError, ImportError):
             print(f'{m} is not installed')
     if return_string:

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -64,7 +64,7 @@ def print_versions(modules=('strax', 'straxen', 'cutax'), return_string=False):
             if hasattr(mod, '__version__'):
                 message += f'\tv{mod.__version__}'
             if hasattr(mod, '__path__'):
-                message += '\t{mod.__path__[0]}'
+                message += f'\t{mod.__path__[0]}'
         except (ModuleNotFoundError, ImportError):
             print(f'{m} is not installed')
     if return_string:


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Allow straxer to:
- be run for other packages (like cutax)
   ``` --package cutax```
- allow multi-target processing
   ```--target event_info cut_daq_veto```
- allow context and config kwargs (NB: should be JSON)
  ```--context_kwargs '{"use_rucio": 1}'```
  ```--config_kwargs '{"s1_min_tight_coincidence": 10}'```


## Can you give a minimal working example (or illustrate with a figure)
Use all these features in one example:
```
straxer 017918 --target event_info cut_daq_veto \
               --package cutax \
               --context xenonnt_v3 \
               --notlazy --timeout 600 \
               --context_kwargs '{"use_rucio": 1}'
```