### PR TITLE
[Bug fix] alt_s{i}_delay computation

### DIFF
--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -133,7 +133,7 @@ class EventBasics(strax.Plugin):
     The main S2 and alternative S2 are given by the largest two S2-Peaks
     within the event. By default this is also true for S1.
     """
-    __version__ = '1.0.0'
+    __version__ = '1.0.1'
 
     depends_on = ('events',
                   'peak_basics',
@@ -334,8 +334,10 @@ class EventBasics(strax.Plugin):
             result['drift_time'] = largest_s2s[0]['center_time'] - largest_s1s[0]['center_time']
             if len(largest_s1s) > 1:
                 result['alt_s1_interaction_drift_time'] = largest_s2s[0]['center_time'] - largest_s1s[1]['center_time']
+                result['alt_s1_delay'] = largest_s1s[1]['center_time'] - largest_s1s[0]['center_time']
             if len(largest_s2s) > 1:
                 result['alt_s2_interaction_drift_time'] = largest_s2s[1]['center_time'] - largest_s1s[0]['center_time']
+                result['alt_s2_delay'] = largest_s2s[1]['center_time'] - largest_s2s[0]['center_time']
 
         # areas before main S2
         if len(largest_s2s):

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -133,7 +133,7 @@ class EventBasics(strax.Plugin):
     The main S2 and alternative S2 are given by the largest two S2-Peaks
     within the event. By default this is also true for S1.
     """
-    __version__ = '1.0.1'
+    __version__ = '1.1.0'
 
     depends_on = ('events',
                   'peak_basics',


### PR DESCRIPTION
 ## What does the code in this PR do / what does it improve?
 - In the current version of straxen, the alt_s{i}_delay variables is always -1.
 - Restore the computation of the delay time between the main and alt S1s and S2s peaks. It was deleted by accident in the last release of straxen: https://github.com/XENONnT/straxen/pull/569/files#diff-75af39866372953e59e003b61a91bed2bee9effbb8159dd6fc911bcd8e2142d6L295-R326
 - This variable is a key element for Kr83m event selection.

## Can you briefly describe how it works?
Compute the difference between the center time of the main and alt peaks for both S1s and S2s.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
