### PR TITLE
Increase buffer size

### DIFF
--- a/straxen/plugins/veto_hitlets.py
+++ b/straxen/plugins/veto_hitlets.py
@@ -120,7 +120,10 @@ class nVETOHitlets(strax.Plugin):
         del hits
 
         # Get hitlet data and split hitlets:
-        temp_hitlets = strax.get_hitlets_data(temp_hitlets, records_nv, to_pe=self.to_pe)
+        temp_hitlets = strax.get_hitlets_data(temp_hitlets, 
+                                              records_nv, 
+                                              to_pe=self.to_pe, 
+                                              min_hitlet_sample=600)
 
         temp_hitlets = strax.split_peaks(temp_hitlets,
                                          records_nv,

--- a/straxen/plugins/veto_hitlets.py
+++ b/straxen/plugins/veto_hitlets.py
@@ -120,9 +120,9 @@ class nVETOHitlets(strax.Plugin):
         del hits
 
         # Get hitlet data and split hitlets:
-        temp_hitlets = strax.get_hitlets_data(temp_hitlets, 
-                                              records_nv, 
-                                              to_pe=self.to_pe, 
+        temp_hitlets = strax.get_hitlets_data(temp_hitlets,
+                                              records_nv,
+                                              to_pe=self.to_pe,
                                               min_hitlet_sample=600)
 
         temp_hitlets = strax.split_peaks(temp_hitlets,


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Hopefully solves: https://github.com/XENONnT/straxen/issues/596

I processed test wise a few runs with straxer and `NUMBA_DEBUG_CACHE 1` to see how often we trigger recompiling due to a changed buffer size for nv/mv hitlets and it is almost every third chunk. I tripled now the buffer size which reduced the number of recompiling to almost zero. 

I also checked the peak memory usage and the buffer size does not have a big impact. The peak usage increased by about 200 MB to 1700MB for hitlets_nv and 1000MB for hitlets_mv. 

As a nice side effect the plugin is now faster as we are not recompiling everything all the time.