### PR TITLE
Speed up event pattern fit

### DIFF
--- a/straxen/numbafied_scipy.py
+++ b/straxen/numbafied_scipy.py
@@ -1,0 +1,36 @@
+import numba
+import ctypes
+import strax
+from scipy.special.cython_special import loggamma, betainc, gammaln
+
+export, __all__ = strax.exporter()
+# Numba versions of scipy functions:
+# Based on http://numba.pydata.org/numba-doc/latest/extending/high-level.html but
+# omitting the address step.
+# Unfortunately this approach does not allow to cache the resulting numba functions.
+#  Any ideas in this regard would be welcome.
+# All subsequent function will treat their inputs as 64bit floats:
+double = ctypes.c_double
+
+functype = ctypes.CFUNCTYPE(double, double)
+gammaln_float64 = functype(gammaln)
+@export
+@numba.njit
+def numba_gammaln(x):
+    return gammaln_float64(x)
+
+
+functype = ctypes.CFUNCTYPE(double, double, double, double)
+betainc_float64 = functype(betainc)
+@export
+@numba.njit
+def numba_betainc(x1, x2, x3):
+    return betainc_float64(x1, x2, x3)
+
+
+functype = ctypes.CFUNCTYPE(double, double)
+loggamma_float64 = functype(loggamma)
+@export
+@numba.njit
+def numba_loggamma(x):
+    return loggamma_float64(x)

--- a/straxen/plugins/event_patternfit.py
+++ b/straxen/plugins/event_patternfit.py
@@ -393,16 +393,16 @@ def binom_test(k, n, p):
 
     if k < n * p:
         if (_d0 >= d) and (_d0 > _dmu):
-            n_iter, j_min, j_max = 0, 0, 0
+            n_iter, j_min, j_max = -1, 0, 0
         elif _dn > d:
-            n_iter, j_min, j_max = 0, 0, 0
+            n_iter, j_min, j_max = -2, 0, 0
         else:
             j_min, j_max = k, n
         def _check_(d, y0, y1):
             return (d>y1) and (d<=y0)
     elif k>n*p:
         if _d0 >= d:
-            n_iter, j_min, j_max = 0, 0, 0
+            n_iter, j_min, j_max = -1, 0, 0
         else:
             j_min, j_max = 0, k
         def _check_(d, y0, y1):
@@ -428,8 +428,12 @@ def binom_test(k, n, p):
 
         j = max(min((j_min + j_max) / 2, n), 0)
         
-        if k * j == 0:
+        # here we use n_iter also for decide to do one-side (left/right) test 
+        # or two-side test
+        if (k * j == 0)and(n_iter==-1):
             pval = binom_sf(max(k, j), n, p)
+        if (k * j == 0)and(n_iter==-2):
+            pval = binom_cdf(max(k, j), n, p)
         else:
             pval = binom_cdf(min(k, j), n, p) + binom_sf(max(k, j), n, p)
         pval = min(1.0, pval)

--- a/straxen/plugins/event_patternfit.py
+++ b/straxen/plugins/event_patternfit.py
@@ -421,9 +421,9 @@ def binom_test(k, n, p):
                 n_pts = 50
             j_range = np.linspace(j_min, j_max, n_pts)
             y = binom_pmf(j_range, n, p)
-            for i in range(n_pts - 1):
-                if _check_(d, y[i], y[i + 1]):
-                    j_min, j_max = j_range[i], j_range[i + 1]
+            for ii in range(n_pts - 1):
+                if _check_(d, y[ii], y[ii + 1]):
+                    j_min, j_max = j_range[ii], j_range[ii + 1]
                     break
 
         j = max(min((j_min + j_max) / 2, n), 0)
@@ -432,7 +432,7 @@ def binom_test(k, n, p):
         # or two-side test
         if (k * j == 0)and(n_iter==-1):
             pval = binom_sf(max(k, j), n, p)
-        if (k * j == 0)and(n_iter==-2):
+        elif (k * j == 0)and(n_iter==-2):
             pval = binom_cdf(max(k, j), n, p)
         else:
             pval = binom_cdf(min(k, j), n, p) + binom_sf(max(k, j), n, p)

--- a/straxen/plugins/event_patternfit.py
+++ b/straxen/plugins/event_patternfit.py
@@ -374,14 +374,34 @@ def binom_test(k, n, p):
     integrate the tails outward from k and j. In the case where either
     k or j are zero, only the non-zero tail is integrated.
     """
+    # define the S1 interval for finding the maximum
+    mu, sigma = n*p, np.sqrt(n*p*(1-p))
+    if mu-2*sigma < 0:
+        _s1_min = 0
+    else:
+        _s1_min = mu-2*sigma
+    if mu+2*sigma > n:
+        _s1_max = n
+    else:
+        _s1_max = mu+2*sigma
+    _s1 = np.arange(_s1_min, _s1_max, 0.01)
+    # compute the binomial probability for each S1 and define the Binom range for later
+    _ds1 = binom_pmf(_s1, n, p)
+    _s1argmax = np.argmax(_ds1)
+    if _s1argmax - 2 > 0:
+        minimum = _s1[_s1argmax - 2]
+    else:
+        minimum = _s1[0]
+    maximum = _s1[_s1argmax + 2]
+    # comments TODO
     _d0 = binom_pmf(0, n, p)
-    _dmu = binom_pmf(n*p, n, p)
+    _dmax = binom_pmf(_s1[_s1argmax], n, p)
     _dn = binom_pmf(n, n, p)
     d = binom_pmf(k, n, p)
     rerr = 1 + 1e-7
     d = d * rerr
     _d0 = _d0 * rerr
-    _dmu = _dmu * rerr 
+    _dmax = _dmax * rerr 
     _dn = _dn * rerr
     # define number of interaction for finding the the value j
     # the exceptional case of n<=0, is avoid since n_iter is at least 2
@@ -390,30 +410,34 @@ def binom_test(k, n, p):
         n_iter = max(n_iter, 2)
     else:
         n_iter = 2
-
-    if k < n * p:
-        if (_d0 >= d) and (_d0 > _dmu):
+    # comments TODO
+    if k < minimum:
+        if (_d0 >= d) and (_d0 > _dmax):
             n_iter, j_min, j_max = -1, 0, 0
         elif _dn > d:
             n_iter, j_min, j_max = -2, 0, 0
         else:
-            j_min, j_max = k, n
+            j_min, j_max = _s1[_s1argmax], n
         def _check_(d, y0, y1):
             return (d>y1) and (d<=y0)
-    elif k>n*p:
+    # comments TODO
+    elif k>maximum:
         if _d0 >= d:
             n_iter, j_min, j_max = -1, 0, 0
         else:
-            j_min, j_max = 0, k
+            j_min, j_max = 0, _s1[_s1argmax]
         def _check_(d, y0, y1):
             return (d>=y0) and (d<y1)
-    elif k==n*p:
+    # comments TODO
+    else:
         n_iter, j_min, j_max = 0, k, k
         def _check_(d, y0, y1):
             return (d>=y0) and (d<y1)
     
+    # comments TODO
     if (d==0):
         pval = 0.0
+    # comments TODO
     else:
         for i in range(n_iter):
             n_pts = int(j_max - j_min)


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
There was a request to improve the performance of our event_pattern_fit-plugin. With the proposed changes the speed increases by a factor of three. See also attached images.

## Can you briefly describe how it works?
I profiled the performance of the compute method of the plugin and found binomial_test to be the bottleneck. To increase the performance I numbafied the corresponding functions and created some numbafiable scipy-functions based on their cython implementations.  The new bottleneck is now given by `neg2llh_modpoisson`. However, any attempt to increase its performance failed.  

![kr83m_run_event_pattern_fit](https://user-images.githubusercontent.com/43881800/128351740-46090b04-f556-4673-9d33-4c52ba283e88.png)
![binom_test_imporved](https://user-images.githubusercontent.com/43881800/128351747-0b852179-1431-42da-8647-e7ff78ec8dfc.png)
