### PR TITLE
Fix rundb select runs with superruns

### DIFF
--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -241,7 +241,7 @@ class RunDB(strax.StorageFrontend):
         if self.runid_field == 'name':
             run_query = {'name': {'$in': [key.run_id for key in keys]}}
         else:
-            run_query = {f'{self.runid_field}': {'$in': [int(key.run_id) for key in keys]}}
+            run_query = {f'{self.runid_field}': {'$in': [int(key.run_id) for key in keys if not key.run_id.startswith('_')]}}
         dq = self._data_query(keys[0])
 
         # dict.copy is sometimes not sufficient for nested dictionary


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

As reported by @HenningSE  there was a small bug in rundb.py which would not allow to use select runs after creating a superrun. In this PR we fix the issue.

Code to reproduce the error: 
```
st = straxen.contexts.xenonnt_online()
st.define_run('_test', ('025472', '025473'))
st.set_context_config({'write_superruns': True})
st.make('_test', 'event_info')
st.select_runs(available=('event_info',))
```