### PR TITLE
First nVeto monitor plugin

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -192,7 +192,8 @@ def xenonnt_online(output_folder='./strax_data',
             readonly=not we_are_the_daq,
             take_only=('veto_intervals',
                        'online_peak_monitor',
-                       'event_basics',))]
+                       'event_basics',
+                       'online_monitor_nv'))]
 
     # Remap the data if it is before channel swap (because of wrongly cabled
     # signal cable connectors) These are runs older than run 8797. Runs

--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -216,8 +216,9 @@ class nVetoPeakMonitor(strax.Plugin):
 
 
         hitlets_channel_count, _ = np.histogram(hitlets_nv['channel'],
-                                                 bins=n_pmt,
-                                                 range=[2000, 2000+n_pmt])
+                                                bins=n_pmt,
+                                                range=[min_pmt, max_pmt + 1],
+                                                )
         # Count number of lone-hits per PMT
         res['hitlets_per_channel'] = hitlets_channel_count
         res['events_nv_per_chunk'] = len(events_nv)

--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -179,12 +179,11 @@ class OnlinePeakMonitor(strax.Plugin):
   
 @export
 @strax.takes_config(
-    strax.Option(
-        'n_nveto_pmts', 
-        type=int,
-        default=120,
-        help='Number of nVeto PMTs'),
+    strax.Option('channel_map', track=False, type=immutabledict,
+                 help="immutabledict mapping subdetector to (min, max) "
+                      "channel number."))
 )
+
 class nVetoPeakMonitor(strax.Plugin):
     depends_on = ('hitlets_nv', 'events_nv')
     provides = 'online_monitor_nv'

--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -175,7 +175,8 @@ class OnlinePeakMonitor(strax.Plugin):
             range=self.config['area_vs_width_bounds'],
             bins=self.config['area_vs_width_nbins'])
         return hist.T
-    
+
+  
 @export
 @strax.takes_config(
     strax.Option(

--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -211,7 +211,9 @@ class nVetoPeakMonitor(strax.Plugin):
         res = np.zeros(1, dtype=self.dtype)
         res['time'] = start
         res['endtime'] = end
-        n_pmt = self.config['n_nveto_pmts']
+        min_pmt, max_pmt = self.config['channel_map']['nveto']
+        n_pmt = (max_pmt - min_pmt) + 1
+
 
         hitlets_channel_count, _ = np.histogram(hitlets_nv['channel'],
                                                  bins=n_pmt,

--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -185,10 +185,11 @@ class OnlinePeakMonitor(strax.Plugin):
         help='Number of nVeto PMTs'),
 )
 class nVetoPeakMonitor(strax.Plugin):
-    depends_on = 'hitlets_nv', 'events_nv'
-    provides = 'nVeto_peak_monitor'
-    data_kind = 'nVeto_peak_monitor'
-    __version__ = '0.0.1'
+    depends_on = ('hitlets_nv', 'events_nv')
+    provides = 'online_monitor_nv'
+    data_kind = 'online_monitor_nv'
+    __version__ = '0.0.2'
+
     rechunk_on_save = False
 
     def infer_dtype(self):


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
I added a plugin nVetoPeakMonitor at the end of the code.

## Can you briefly describe how it works?
I count number of hitlets_nv per channel and number of events. 

## Can you give a minimal working example (or illustrate with a figure)?
I made an example here https://github.com/XENONnT/analysiscode/tree/master/olmo_nVeto 