### PR TITLE
new plot_pmts

### DIFF
--- a/straxen/common.py
+++ b/straxen/common.py
@@ -298,7 +298,7 @@ def get_secret(x):
 @export
 def download_test_data():
     """Downloads strax test data to strax_test_data in the current directory"""
-    blob = get_resource('https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/11929e7595e178dd335d59727024847efde530fb/strax_test_data_straxv0.9.tar',
+    blob = get_resource('https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/609b492e1389369734c7d2cbabb38059f14fc05e/strax_files/strax_test_data_straxv0.9.tar',  #  noqa
                         fmt='binary')
     f = io.BytesIO(blob)
     tf = tarfile.open(fileobj=f)

--- a/straxen/matplotlib_utils.py
+++ b/straxen/matplotlib_utils.py
@@ -73,7 +73,6 @@ def plot_pmts(
     plt.subplots_adjust(wspace=0)
     plt.colorbar(ax=axes, extend=extend, label=label)
 
-
 @export
 def plot_on_single_pmt_array(
         c,
@@ -145,7 +144,7 @@ def plot_on_single_pmt_array(
         for p in pos:
             if p['i'] in dead_pmts:
                 plt.text(p['x'], p['y'], str(p['i']),
-                         horizontalalignment='center',                 
+                         horizontalalignment='center',
                          verticalalignment='center',
                          fontsize=dead_pmt_label_size,
                          color=dead_pmt_label_color)
@@ -154,7 +153,7 @@ def plot_on_single_pmt_array(
                                          facecolor=dead_pmt_color,
                                          zorder=-5,
                                          linewidth=1))
-
+              
     if pmt_label_size:
         for p in pos:
             plt.text(p['x'], p['y'], str(p['i']),

--- a/straxen/matplotlib_utils.py
+++ b/straxen/matplotlib_utils.py
@@ -83,7 +83,7 @@ def plot_on_single_pmt_array(
         pmt_label_color='white',
         show_tpc=True,
         log_scale=False, vmin=None, vmax=None,
-        dead_pmts=None, dead_pmt_color='gray', 
+        dead_pmts=None, dead_pmt_color='gray',
         dead_pmt_label_size=8, dead_pmt_label_color='black',
         **kwargs):
     """Plot one of the PMT arrays and color it by c.

--- a/straxen/matplotlib_utils.py
+++ b/straxen/matplotlib_utils.py
@@ -16,6 +16,7 @@ def plot_pmts(
         xenon1t=False,
         show_tpc=True,
         extend='neither', vmin=None, vmax=None,
+        show_axis_labels=False,
         **kwargs):
     """Plot the PMT arrays side-by-side, coloring the PMTS with c.
 
@@ -36,7 +37,10 @@ def plot_pmts(
         # Single-valued array passed
         vmax += 1
     if figsize is None:
-        figsize = (11, 4) if xenon1t else (13, 5.5)
+        if xenon1t: figsize = (11, 4)
+        elif xenon1t and show_axis_labels: figsize = (11.25, 4.25)
+        elif show_axis_labels: figsize = (13.25, 5.75)
+        else: figsize = (13, 5.5)
 
     f, axes = plt.subplots(1, 2, figsize=figsize)
     for array_i, array_name in enumerate(['top', 'bottom']):
@@ -51,10 +55,14 @@ def plot_pmts(
             show_tpc=show_tpc,
             vmin=vmin, vmax=vmax,
             **kwargs)
+        if (array_i == 0) and show_axis_labels:
+            ax.set_xlabel('x [cm]')
+            ax.xaxis.set_label_coords(1.035, -0.075)
+            ax.set_ylabel('y [cm]')
 
     axes[1].yaxis.tick_right()
     axes[1].yaxis.set_label_position('right')
-
+    
     plt.tight_layout()
     plt.subplots_adjust(wspace=0)
     plt.colorbar(ax=axes, extend=extend, label=label)
@@ -71,7 +79,8 @@ def plot_on_single_pmt_array(
         pmt_label_color='white',
         show_tpc=True,
         log_scale=False, vmin=None, vmax=None,
-        dead_pmts=None, dead_pmt_color='gray',
+        dead_pmts=None, dead_pmt_color='gray', 
+        dead_pmt_label_size=8, dead_pmt_label_color='black',
         **kwargs):
     """Plot one of the PMT arrays and color it by c.
 
@@ -128,12 +137,18 @@ def plot_on_single_pmt_array(
     else:
         ax.set_axis_off()
     if dead_pmts is not None:
-        _dead_mask = [pi in dead_pmts for pi in pos['i']]
-        result = plt.scatter(
-            pos[_dead_mask]['x'],
-            pos[_dead_mask]['y'],
-            c=dead_pmt_color,
-            **kwargs)
+        for p in pos:
+            if p['i'] in dead_pmts:
+                plt.text(p['x'], p['y'], str(p['i']),
+                         horizontalalignment='center',                 
+                         verticalalignment='center',
+                         fontsize=dead_pmt_label_size,
+                         color=dead_pmt_label_color)
+                ax.add_artist(plt.Circle((p['x'], p['y']), 3.75,
+                                         edgecolor='w',
+                                         facecolor=dead_pmt_color,
+                                         zorder=-5,
+                                         linewidth=1))
 
     if pmt_label_size:
         for p in pos:

--- a/straxen/matplotlib_utils.py
+++ b/straxen/matplotlib_utils.py
@@ -26,6 +26,7 @@ def plot_pmts(
     :param extend: same as plt.colorbar(extend=...)
     :param vmin: Minimum of color scale
     :param vmax: maximum of color scale
+    :show_axis_labels: if True it will show x and y labels
 
     Other arguments are passed to plot_on_single_pmt_array.
     """
@@ -37,10 +38,15 @@ def plot_pmts(
         # Single-valued array passed
         vmax += 1
     if figsize is None:
-        if xenon1t: figsize = (11, 4)
-        elif xenon1t and show_axis_labels: figsize = (11.25, 4.25)
-        elif show_axis_labels: figsize = (13.25, 5.75)
-        else: figsize = (13, 5.5)
+        if xenon1t: 
+            if show_axis_labels: 
+                figsize = (11.25, 4.25)
+            else: 
+                figsize = (11, 4)
+        elif show_axis_labels: 
+            figsize = (13.25, 5.75)
+        else: 
+            figsize = (13, 5.5)
 
     f, axes = plt.subplots(1, 2, figsize=figsize)
     for array_i, array_name in enumerate(['top', 'bottom']):
@@ -66,7 +72,6 @@ def plot_pmts(
     plt.tight_layout()
     plt.subplots_adjust(wspace=0)
     plt.colorbar(ax=axes, extend=extend, label=label)
-
 
 
 @export

--- a/straxen/matplotlib_utils.py
+++ b/straxen/matplotlib_utils.py
@@ -16,7 +16,6 @@ def plot_pmts(
         xenon1t=False,
         show_tpc=True,
         extend='neither', vmin=None, vmax=None,
-        show_axis_labels=False,
         **kwargs):
     """Plot the PMT arrays side-by-side, coloring the PMTS with c.
 
@@ -38,15 +37,7 @@ def plot_pmts(
         # Single-valued array passed
         vmax += 1
     if figsize is None:
-        if xenon1t: 
-            if show_axis_labels: 
-                figsize = (11.25, 4.25)
-            else: 
-                figsize = (11, 4)
-        elif show_axis_labels: 
-            figsize = (13.25, 5.75)
-        else: 
-            figsize = (13, 5.5)
+        figsize = (11.25, 4.25) if xenon1t else (13.25, 5.75)
 
     f, axes = plt.subplots(1, 2, figsize=figsize)
     for array_i, array_name in enumerate(['top', 'bottom']):
@@ -61,11 +52,11 @@ def plot_pmts(
             show_tpc=show_tpc,
             vmin=vmin, vmax=vmax,
             **kwargs)
-        if (array_i == 0) and show_axis_labels:
-            ax.set_xlabel('x [cm]')
-            ax.xaxis.set_label_coords(1.035, -0.075)
-            ax.set_ylabel('y [cm]')
-
+    
+    axes[0].set_xlabel('x [cm]')
+    axes[0].xaxis.set_label_coords(1.035, -0.075)
+    axes[0].set_ylabel('y [cm]')
+    
     axes[1].yaxis.tick_right()
     axes[1].yaxis.set_label_position('right')
     


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
I am trying to include the dead_pmt in ` straxen.plot_pmts` for the [PMT blessing plots](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:analysis:plots:ongoing_blessing#pmt_performances), but the option already present changes the colormap (see attached picture). Furthermore, I didn't find any way to include the x and y labels. 

```
cmap = plt.cm.viridis  
cmaplist = [cmap(i) for i in range(cmap.N)]
cmap = mpl.colors.LinearSegmentedColormap.from_list('Custom cmap', cmaplist, cmap.N)

array = np.random.uniform(low=50, high=60, size=494)
array[0]   = np.nan
array[10]  = np.nan
array[50]  = np.nan
array[100] = np.nan
array[150] = np.nan
array[170] = np.nan
array[200] = np.nan
array[280] = np.nan
array[310] = np.nan
array[350] = np.nan
array[400] = np.nan
array[450] = np.nan

bounds = np.linspace(np.nanmin(array), np.nanmax(array), 10, dtype=int)
norm = mpl.colors.BoundaryNorm(bounds, cmap.N)

straxen.plot_pmts(array,
                  cmap=cmap, norm=norm, dead_pmts=[0, 10, 50, 100, 150, 170, 200, 280, 310, 350, 400, 450])
```
![SPE_old_plot_pmts](https://user-images.githubusercontent.com/38431109/129708628-b9e39159-882b-45cc-9cc6-1b6a8387aabf.png)

## Can you briefly describe how it works?
I have added the [option](https://github.com/XENONnT/straxen/blob/24e23873b2ba0bec0fc0d09ff28a92986ab4fec5/straxen/matplotlib_utils.py#L19) for showing the x and y labels, and I have [changed](https://github.com/XENONnT/straxen/blob/24e23873b2ba0bec0fc0d09ff28a92986ab4fec5/straxen/matplotlib_utils.py#L139) how the dead pmts are shown. 
```
# With new plot_pmts map
straxen.plot_pmts(array, show_axis_labels=True,
                  cmap=cmap, norm=norm, dead_pmts=[0, 10, 50, 100, 150, 170, 200, 280, 310, 350, 400, 450])
```
![SPE_new_plot_pmts](https://user-images.githubusercontent.com/38431109/129709409-225e02da-da4c-4e3d-8980-1184ab06be26.png)

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [x] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_