### PR TITLE
Classify peak built from merged S2s

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -15,6 +15,7 @@ common_opts = dict(
         straxen.Peaklets,
         straxen.PeakletClassification,
         straxen.MergedS2s,
+        straxen.MergedS2sClassification,
         straxen.Peaks,
         straxen.PeakBasics,
         straxen.PeakProximity],

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -537,7 +537,7 @@ class PeakletClassificationHighEnergy(PeakletClassification):
 
 
 @export
-class MergedS2sClassification(straxen.PeakletClassification):
+class MergedS2sClassification(PeakletClassification):
     """Classify merged_s2s as unknown, S1, or S2."""
     provides = 'merged_s2s_classification'
     depends_on = ('merged_s2s',)

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -537,6 +537,18 @@ class PeakletClassificationHighEnergy(PeakletClassification):
 
 
 @export
+class MergedS2sClassification(straxen.PeakletClassification):
+    """Classify merged_s2s as unknown, S1, or S2."""
+    provides = 'merged_s2s_classification'
+    depends_on = ('merged_s2s',)
+    __version__ = '0.0.1'
+    child_plugin = True
+
+    def compute(self, merged_s2s):
+        return super().compute(merged_s2s)
+
+
+@export
 @strax.takes_config(
     strax.Option('s2_merge_max_duration', default=50_000,
                  help="Do not merge peaklets at all if the result would be a peak "
@@ -715,7 +727,7 @@ class Peaks(strax.Plugin):
     (replacing all peaklets that were later re-merged as S2s). As this
     step is computationally trivial, never save this plugin.
     """
-    depends_on = ('peaklets', 'peaklet_classification', 'merged_s2s')
+    depends_on = ('peaklets', 'peaklet_classification', 'merged_s2s', 'merged_s2s_classification')
     data_kind = 'peaks'
     provides = 'peaks'
     parallel = True


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
This pr aims to mitigate the effect of misclassification when the merge S2 plugin merges a normal S1 with a small S2 and labels the new peak S2 regardless of the peak rise time. Find details in [this note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:yue:classification_parameters#performance_on_regular_radon_run) 

## Can you briefly describe how it works?
We now add a new plugin that redoes the classification for merged S2s.
