### PR TITLE
Make release v1 0 0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = '1.0.0-rc0'
+current_version = 1.0.0
 files = setup.py straxen/__init__.py
 commit = True
 tag = True

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,38 @@
+1.0.0 / 2021-09-01
+-------------------
+major / minor:
+    
+- merge s2 without s1 (#645)
+- First nVeto monitor plugin (#634)
+- Peak event veto tagging (#618)
+- Fix peaklet area bias (#601)
+- Add lone hit information to merged S2s. (#623)
+    
+
+patches and fixes:
+    
+- Fix n_hits of peaks (#646) 
+- Update requirements for strax (#644)
+- Modifications of nT simulation context (#602)
+- Straxer for other packages (#595)
+- [Bug fix] alt_s{i}_delay computation (#598)
+- Bump version refactor code for cleanliness. (#597)
+- Increase buffer size (#604)
+- Stop testing py3.6 (#621)
+- Remove online event monitor (#620)
+- Add matplotlib to test requirements (#626)
+- Fix rundb select runs with superruns (#627)
+- Change EventInfo to save when explicit (#628)
+- Update test data (#631)
+- Allow database to not be initialized (#636)
+- new plot_pmts (#637)
+- Speed up event pattern fit (#625)
+- kwargs for saver (#639)
+- Add a plugin for external trigger run on nVeto calibration (#630)
+- Fix veto event positions (#641)
+- Use rucio from straxen & nest RucioRemote imports (#592)
+
+
 0.19.3 / 2021-07-16
 -------------------
 - Rewrite EventBasics, set event level S1 tight coincidence (#569)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('HISTORY.md') as file:
     history = file.read()
 
 setuptools.setup(name='straxen',
-                 version='1.0.0-rc0',
+                 version='1.0.0',
                  description='Streaming analysis for XENON',
                  author='Straxen contributors, the XENON collaboration',
                  url='https://github.com/XENONnT/straxen',

--- a/straxen/__init__.py
+++ b/straxen/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0-rc0'
+__version__ = '1.0.0'
 
 from utilix import uconfig
 from .common import *


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Make release of version v1.0.0. 

FYI: For some reason I had to manually add the quotation marks around the version in `setupy.py` and `__init__.py` when using `bumpversion release`. Not sure why this was the case. In strax it worked fine.  