### PR TITLE
Previous S2 Shadow Plugin draft

### DIFF
--- a/straxen/plugins/event_shadow.py
+++ b/straxen/plugins/event_shadow.py
@@ -1,0 +1,39 @@
+import numpy as np
+import strax
+import straxen
+
+class Shadow(strax.Plugin):
+    """Compute several new parameters to describe the noise level.
+        We can use these to reduce AC BG. """
+
+    # Name of the data type this plugin provides
+    provides = ('event_shadow',) #a tuple, same level as 'event_ifo'etc.
+
+    depends_on = ('event_basics',)
+
+    # Numpy datatype of the output
+    dtype = [('shadow', np.float32,'previous s2 shadow at event level [PE/ns]')] + strax.time_fields
+
+    # Version of the plugin. Increment this if you change the algorithm.
+    __version__ = '0.0.1'
+
+    def compute(self, events):
+
+        shadow = np.zeros(len(events))
+        pre_s2_x = np.zeros(len(events))
+        pre_s2_y = np.zeros(len(events))
+        distance_to_pre_s2 = np.zeros(len(events))
+        len_events = len(events)
+
+        for i in range(1,20):
+            new_shadow = events['s2_area'][0:len_events-i]/(events['s2_center_time'][i:]-events['s2_center_time'][0:len_events-i])
+            test = new_shadow > shadow[i:]
+            pre_s2_x[i:]=events['s2_x'][0:len_events-i]*test + pre_s2_x[i:]*(~test)
+            pre_s2_y[i:]=events['s2_y'][0:len_events-i]*test + pre_s2_y[i:]*(~test)
+            shadow[i:] = new_shadow*test + shadow[i:]*(~test)
+
+        #distance_to_pre_s2 = pre_s2_x**2 + pre_s2_y**2
+        
+        return dict(time=events['time'],
+            endtime=strax.endtime(events),
+                    shadow = shadow)

--- a/straxen/plugins/event_shadow_test.py
+++ b/straxen/plugins/event_shadow_test.py
@@ -1,0 +1,39 @@
+import numpy as np
+import strax
+import straxen
+
+class Shadow(strax.Plugin):
+    """Compute several new parameters to describe the noise level.
+        We can use these to reduce AC BG. """
+
+    # Name of the data type this plugin provides
+    provides = ('event_shadow',) #a tuple, same level as 'event_ifo'etc.
+
+    depends_on = ('event_basics',)
+
+    # Numpy datatype of the output
+    dtype = [('shadow', np.float32,'previous s2 shadow at event level [PE/ns]')] + strax.time_fields
+
+    # Version of the plugin. Increment this if you change the algorithm.
+    __version__ = '0.0.1'
+
+    def compute(self, events):
+
+        shadow = np.zeros(len(events))
+        pre_s2_x = np.zeros(len(events))
+        pre_s2_y = np.zeros(len(events))
+        distance_to_pre_s2 = np.zeros(len(events))
+        len_events = len(events)
+
+        for i in range(1,20):
+            new_shadow = events['s2_area'][0:len_events-i]/(events['s2_center_time'][i:]-events['s2_center_time'][0:len_events-i])
+            test = new_shadow > shadow[i:]
+            pre_s2_x[i:]=events['s2_x'][0:len_events-i]*test + pre_s2_x[i:]*(~test)
+            pre_s2_y[i:]=events['s2_y'][0:len_events-i]*test + pre_s2_y[i:]*(~test)
+            shadow[i:] = new_shadow*test + shadow[i:]*(~test)
+
+        #distance_to_pre_s2 = pre_s2_x**2 + pre_s2_y**2
+        
+        return dict(time=events['time'],
+            endtime=strax.endtime(events),
+                    shadow = shadow)


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
This plug in could compute the previous s2 shadow variable, which could be used to reduce the isolated S1 and S2 events.

## Can you briefly describe how it works?
we define the shadow parameter as [previous s2 area/ time difference].
To calculate this, we loop over the previous 20 events (about 3 seconds given the event rate now)
 and take the maximum as the shadow value.

## Can you give a minimal working example (or illustrate with a figure)?
here is an example of how to use the variable
https://github.com/chnlkx/XENONnT/blob/main/Iso_S1_new.ipynb

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
