### PR TITLE
Add small feature for printing versions of git

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -228,6 +228,13 @@ except ModuleNotFoundError:
     log = logging.getLogger()
 
 log.info(f'---\n bootstrax version {__version__}\n---')
+log.info(
+    straxen.print_versions(
+        modules='strax straxen utilix daqnt numpy tensorflow numba'.split(),
+        include_git=True,
+        return_string=True,
+    ))
+
 
 # Set the output folder
 output_folder = '/data/xenonnt_processed/' if args.production else test_data_folder

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -8,6 +8,7 @@ coveralls==3.2.0
 commentjson==0.9.0
 coverage==5.5
 flake8==3.9.2
+gitpython==3.1.18
 holoviews==1.14.5
 ipywidgets==7.6.4
 hypothesis==6.17.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ numba>=0.50.0
 requests
 commentjson
 matplotlib
+gitpython

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -44,7 +44,7 @@ def dataframe_to_wiki(df, float_digits=5, title='Awesome table',
 @export
 def print_versions(modules=('strax', 'straxen', 'cutax'),
                    return_string=False,
-                   include_git_details=False):
+                   include_git=True):
     """
     Print versions of modules installed.
 
@@ -74,11 +74,12 @@ def print_versions(modules=('strax', 'straxen', 'cutax'),
         if hasattr(mod, '__path__'):
             module_path = mod.__path__[0]
             message += f'\t{module_path}'
-            if include_git_details:
+            if include_git:
                 try:
                     repo = Repo(module_path, search_parent_directories=True)
                 except InvalidGitRepositoryError:
-                    message += f'\tnot git'
+                    # not a git repo
+                    pass
                 else:
                     try:
                         branch = repo.active_branch
@@ -88,7 +89,7 @@ def print_versions(modules=('strax', 'straxen', 'cutax'),
                         commit_hash = repo.head.object.hexsha
                     except TypeError:
                         commit_hash = 'unknown'
-                    message += f'\tgit: {branch}:{commit_hash}'
+                    message += f'\tgit branch:{branch} | {commit_hash[:7]}'
     if return_string:
         return message
     print(message)

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -80,7 +80,15 @@ def print_versions(modules=('strax', 'straxen', 'cutax'),
                 except InvalidGitRepositoryError:
                     message += f'\tnot git'
                 else:
-                    message += f'\tgit: {repo.active_branch}:{repo.head.object.hexsha}'
+                    try:
+                        branch = repo.active_branch
+                    except TypeError:
+                        branch = 'unknown'
+                    try:
+                        commit_hash = repo.head.object.hexsha
+                    except TypeError:
+                        commit_hash = 'unknown'
+                    message += f'\tgit: {branch}:{commit_hash}'
     if return_string:
         return message
     print(message)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,4 @@
-from straxen.misc import TimeWidgets
+from straxen.misc import TimeWidgets, print_versions
 
 
 def test_widgets():
@@ -41,3 +41,13 @@ def test_change_in_fields():
 
     start00, _ = tw.get_start_end()
     assert start20 - start00 == minutes, 'Time field did not update its value!'
+
+
+def test_print_versions(modules=('numpy', 'straxen', 'non_existing_module')):
+    for return_string in [True, False]:
+        for include_git in [True, False]:
+            res = print_versions(modules,
+                                 return_string=return_string,
+                                 include_git_details=include_git)
+            if return_string:
+                assert res is not None

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -48,6 +48,6 @@ def test_print_versions(modules=('numpy', 'straxen', 'non_existing_module')):
         for include_git in [True, False]:
             res = print_versions(modules,
                                  return_string=return_string,
-                                 include_git_details=include_git)
+                                 include_git=include_git)
             if return_string:
                 assert res is not None


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Allow one to print the git branch and last commit message

## Can you briefly describe how it works?
Use https://gitpython.readthedocs.io/en/stable/intro.html to load a repo and print the branch and commit hash

## Can you give a minimal working example (or illustrate with a figure)?
Please see the attached test for a simple example
