### PR TITLE
Fix minianalyses from apply_selection

### DIFF
--- a/straxen/mini_analysis.py
+++ b/straxen/mini_analysis.py
@@ -94,7 +94,7 @@ def mini_analysis(requires=tuple(),
                 for dkind, dtypes in deps_by_kind.items():
                     if dkind in kwargs:
                         # Already have data, just apply cuts
-                        kwargs[dkind] = apply_selection(
+                        kwargs[dkind] = strax.apply_selection(
                             kwargs[dkind],
                             selection_str=kwargs['selection_str'],
                             time_range=kwargs['time_range'],

--- a/straxen/mini_analysis.py
+++ b/straxen/mini_analysis.py
@@ -94,7 +94,7 @@ def mini_analysis(requires=tuple(),
                 for dkind, dtypes in deps_by_kind.items():
                     if dkind in kwargs:
                         # Already have data, just apply cuts
-                        kwargs[dkind] = context.apply_selection(
+                        kwargs[dkind] = apply_selection(
                             kwargs[dkind],
                             selection_str=kwargs['selection_str'],
                             time_range=kwargs['time_range'],


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Disuse old function from strax (context.apply_selection)

this fixes this issue 
 - https://github.com/XENONnT/straxen/pull/665/checks?check_run_id=3619658672
 - https://github.com/XENONnT/straxen/actions/runs/1241080919

## Can you briefly describe how it works?
some kwargs for apply selections are passed on as args, which cause the args to be in the wrong order after https://github.com/AxFoundation/strax/pull/530
