### PR TITLE
S1 posrec events

### DIFF
--- a/straxen/plugins/s1_position_reconstruction.py
+++ b/straxen/plugins/s1_position_reconstruction.py
@@ -9,6 +9,7 @@ import straxen
 from warnings import warn
 export, __all__ = strax.exporter()
 
+# Current defaul algorithm: data-driven CNN. 
 DEFAULT_S1POSREC_ALGO_OPTION = tuple([strax.Option("default_s1reconstruction_algorithm",
                  help="default S1 reconstruction algorithm that provides (x,y,z)",
                  default="cnn_s1",
@@ -97,6 +98,7 @@ class S1EventPositionBase(strax.Plugin):
         # Getting actual position reconstruction
         _in = events['s1_area_per_channel']
         with np.errstate(divide='ignore', invalid='ignore'):
+        # Normalise patters by dividing by largest PMT output between the two arrays. 
             _in = _in / _in.max(axis=1,keepdims=True)
         _out = self.model.predict(_in)
 

--- a/straxen/plugins/s1_position_reconstruction.py
+++ b/straxen/plugins/s1_position_reconstruction.py
@@ -1,0 +1,183 @@
+"""S1-based 3D position reconstruction for Xenon-nT"""
+
+import os
+import tempfile
+import tarfile
+import numpy as np
+import strax
+import straxen
+from warnings import warn
+export, __all__ = strax.exporter()
+
+DEFAULT_S1POSREC_ALGO_OPTION = tuple([strax.Option("default_s1reconstruction_algorithm",
+                 help="default S1 reconstruction algorithm that provides (x,y,z)",
+                 default="cnn_s1",
+                 )])
+
+@export
+@strax.takes_config(
+        strax.Option("s1_cnn_model_path", 
+                     help="Path to the S1 CNN model", 
+                     default=("/project2/lgrandi/guidam/CNN_S1_XYZ_SAVED_MODELS/version_datadriven_00_080921")
+                    ),
+    strax.Option('n_top_pmts', default=straxen.n_top_pmts,
+                 help="Number of top PMTs")
+)
+
+
+class S1EventPositionBase(strax.Plugin):
+    """
+    Base class for the alternative S1 three-dimensional position reconstruction.
+    This class should only be used when subclassed for the different algorithms. 
+    """
+
+    depends_on = ('events','event_area_per_channel',)
+    algorithm = None
+    compressor = 'zstd'
+    parallel = True
+    __version__ = '0.0.0'
+
+    def infer_dtype(self):
+        if self.algorithm is None:
+            raise NotImplementedError(f'Base class should not be used without '
+                                      f'algorithm as done in {__class__.__name__}')
+        dtype = [('x_' + self.algorithm, np.float32,
+                  f'Reconstructed {self.algorithm} S1 X position (cm), uncorrected'),
+                 ('y_' + self.algorithm, np.float32,
+                  f'Reconstructed {self.algorithm} S1 Y position (cm), uncorrected'),
+                 ('z_' + self.algorithm, np.float32,
+                  f'Reconstructed {self.algorithm} S1 Z position (cm), uncorrected')
+                  ]
+
+        dtype += strax.time_fields
+        return dtype
+
+    def setup(self):
+        self.model_file = self._get_model_file_name()
+        if self.model_file is None:
+            warn(f'No file provided for {self.algorithm}. Setting all values '
+                 f'for {self.provides} to None.')
+            # No further setup required
+            return
+
+        # Load the tensorflow model
+        import tensorflow as tf
+        if os.path.exists(self.model_file):
+            print(f"Path is local. Loading {self.algorithm} TF model locally "
+                  f"from disk.")
+        else:
+            downloader = straxen.MongoDownloader()
+            try:
+                self.model_file = downloader.download_single(self.model_file)
+            except straxen.mongo_storage.CouldNotLoadError as e:
+                raise RuntimeError(f'Model files {self.model_file} is not found') from e
+        with tempfile.TemporaryDirectory() as tmpdirname:
+        # Allow to load the model both from folder or from file.
+            try:
+                tar = tarfile.open(self.model_file, mode="r:gz")
+                tar.extractall(path=tmpdirname)
+                self.model = tf.keras.models.load_model(tmpdirname)
+            except:
+                self.model = tf.keras.models.load_model(self.model_file)
+
+
+    def compute(self,events):
+        result = np.ones(len(events), dtype=self.dtype)
+        result['time'], result['endtime'] = events['time'], strax.endtime(events)
+
+        result['x_' + self.algorithm] *= float('nan')
+        result['y_' + self.algorithm] *= float('nan')
+        result['z_' + self.algorithm] *= float('nan')
+
+        if self.model_file is None:
+            # This plugin is disabled since no model is provided
+            return result
+
+
+        # Getting actual position reconstruction
+        _in = events['s1_area_per_channel']
+        with np.errstate(divide='ignore', invalid='ignore'):
+            _in = _in / _in.max(axis=1,keepdims=True)
+        _out = self.model.predict(_in)
+
+        # writing output to the result
+        
+        result['x_' + self.algorithm] = _out[:, 0]
+        result['y_' + self.algorithm] = _out[:, 1]
+        result['z_' + self.algorithm] = _out[:, 2]
+        return result
+
+    def _get_model_file_name(self):
+
+        config_file = f'{self.algorithm}_model'
+        model_from_config = self.config.get(config_file, 'No file')
+        if model_from_config == 'No file':
+            raise ValueError(f'{__class__.__name__} should have {config_file} '
+                             f'provided as an option.')
+        if isinstance(model_from_config, str) and os.path.exists(model_from_config):
+            # Allow direct path specification
+            return model_from_config
+        if model_from_config is None:
+            # Allow None to be specified (disables processing for given posrec)
+            return model_from_config
+
+        # Use CMT
+        model_file = straxen.get_config_from_cmt(self.run_id, model_from_config)
+        return model_file
+
+@export
+@strax.takes_config(
+    strax.Option('cnn_s1_model',
+                 help='Neural network model.' 
+                      'If CMT, specify as (CMT_model, (cnn_s1_model, ONLINE), True)))'
+                      'Set to None to skip the computation of this plugin.',
+                default="/project2/lgrandi/guidam/CNN_S1_XYZ_SAVED_MODELS/version00_020521"
+#                  default=("CMT_model", ('cnn_s1_model', "None"), True)
+                )
+)
+
+class S1EventPositionCNN(S1EventPositionBase):
+    """Convolutional Neural Network (CNN) neural net for S1 (x,y,z) position reconstruction"""
+    provides = "s1_event_positions_cnn"
+    algorithm = "cnn_s1"
+    __version__ = '0.0.1'
+
+
+@export
+@strax.takes_config(
+    *DEFAULT_S1POSREC_ALGO_OPTION
+)
+class S1EventPosition(strax.MergeOnlyPlugin):
+    """
+    Merge the reconstructed S1 algorithms of the different algorithms 
+    into a single one that can be used in Event Basics.
+    
+    Select one of the plugins to provide the 'x','y' and 'z' to be used 
+    further down the chain. Since we already have the information
+    needed here, there is no need to wait until events to make the
+    decision.
+        
+    Since the computation is trivial as it only combined the three 
+    input plugins, don't save this plugins output.
+    """
+    provides = "s1_event_positions"
+    depends_on = ("s1_event_positions_cnn")
+    save_when = strax.SaveWhen.NEVER
+    __version__ = '0.0.0'
+
+    def infer_dtype(self):
+        dtype = strax.merged_dtype([self.deps[d].dtype_for(d) for d in self.depends_on])
+        dtype += [('x', np.float32, 'Reconstructed S1 X position (cm), uncorrected'),
+                  ('y', np.float32, 'Reconstructed S1 Y position (cm), uncorrected'),
+                  ('z', np.float32, 'Reconstructed S1 Z position (cm), uncorrected')]
+        return dtype
+
+    def compute(self, events):
+        result = {dtype: events[dtype] for dtype in events.dtype.names}
+        algorithm = self.config['default_s1reconstruction_algorithm']
+        if not 'x_' + algorithm in events.dtype.names:
+            raise ValueError
+        for xyz in ('x', 'y', 'z'):
+            result[xyz] = events[f'{xyz}_{algorithm}']
+        return result
+

--- a/straxen/plugins/s1_position_reconstruction.py
+++ b/straxen/plugins/s1_position_reconstruction.py
@@ -27,7 +27,7 @@ DEFAULT_S1POSREC_ALGO_OPTION = tuple([strax.Option("default_s1reconstruction_alg
 
 class S1EventPositionBase(strax.Plugin):
     """
-    Base class for the alternative S1 three-dimensional position reconstruction.
+    Base class for S1 three-dimensional position reconstruction.
     This class should only be used when subclassed for the different algorithms. 
     """
 
@@ -149,8 +149,7 @@ class S1EventPositionCNN(S1EventPositionBase):
 )
 class S1EventPosition(strax.MergeOnlyPlugin):
     """
-    Merge the reconstructed S1 algorithms of the different algorithms 
-    into a single one that can be used in Event Basics.
+    Merge the reconstructed S1 algorithms of the different algorithms.
     
     Select one of the plugins to provide the 'x','y' and 'z' to be used 
     further down the chain. Since we already have the information


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
This PR adds **S1-based position reconstruction** methods at event level. 

It was decided that implementing it at peak level was not necessary. The script is copied from the [standard position reconstruction](https://github.com/XENONnT/straxen/blob/master/straxen/plugins/position_reconstruction.py), so that different models can be menaged in the future. 

At the current stage only the **CNN data-driven** (see [here](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:analysis:reconstruction_team:s1_xyz_rec_with_data_driven)) is included. 

The **runtime** per event should be bounded by more than one order of magnitude by "event_area_per_channel" and it results now in ≈ 6 ms per event. 
 
Possible applications: improve event quality selections, to map possible charge insensitive regions
of the detector and to analyse events without a reliable S2 signal.

## Can you briefly describe how it works?

Loaded the trained model, for each event the (x,y,z) position in cm is returned taking as input the PMT hit patterns of the S1 signal, after that they have been normalized by dividing by the channel with maximum area. 

## Can you give a minimal working example (or illustrate with a figure)?
Example of predition:
![example_prediction](https://user-images.githubusercontent.com/44644744/135132642-c07182dd-367d-47df-852e-0e7a043980d6.PNG)




_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._
