### PR TITLE
Add source to runs table

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -29,7 +29,7 @@ common_opts = dict(
     check_available=('raw_records', 'peak_basics'),
     store_run_fields=(
         'name', 'number',
-        'start', 'end', 'livetime', 'mode'))
+        'start', 'end', 'livetime', 'mode', 'source'))
 
 xnt_common_config = dict(
     n_tpc_pmts=straxen.n_tpc_pmts,


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Per @kdund 's suggestion add the 'source' field to the rundb query

## Can you briefly describe how it works?
Tell strax to extract the source if any from the rundoc

## Can you give a minimal working example (or illustrate with a figure)?
```python
st = straxen.contexts.xenonnt_online(_minimum_run_number=20000)
st.context_config['store_run_fields'] = ('name', 'number', 'start', 'end', 'livetime', 'mode', 'source')
st.select_runs()
```
