### PR TITLE
Implement SDSC as a local RSE for Expanse

### DIFF
--- a/straxen/rucio.py
+++ b/straxen/rucio.py
@@ -152,7 +152,7 @@ class RucioFrontend(strax.StorageFrontend):
         elif self.local_rse == 'SDSC_USERDISK':
             prefix = '/expanse/lustre/projects/chi135/shockley/rucio'
         else:
-            raise ValueError(f'We are not on dali not expanse and thus cannot load rucio')
+            raise ValueError(f'We are not on dali nor expanse and thus cannot load rucio')
         return prefix
 
     def did_is_local(self, did):

--- a/straxen/rucio.py
+++ b/straxen/rucio.py
@@ -25,7 +25,9 @@ class RucioFrontend(strax.StorageFrontend):
     """
     Uses the rucio client for the data find.
     """
-    local_rses = {'UC_DALI_USERDISK': r'.rcc.'}
+    local_rses = {'UC_DALI_USERDISK': r'.rcc.',
+                  'SDSC_USERDISK': r'.sdsc.'
+                  }
     local_did_cache = None
     local_rucio_path = None
 
@@ -147,8 +149,10 @@ class RucioFrontend(strax.StorageFrontend):
         elif self.local_rse == 'UC_DALI_USERDISK':
             # If rucio is not loaded but we are on dali, look here:
             prefix = '/dali/lgrandi/rucio/'
+        elif self.local_rse == 'SDSC_USERDISK':
+            prefix = '/expanse/lustre/projects/chi135/shockley/rucio'
         else:
-            raise ValueError(f'We are not on dali and cannot load rucio')
+            raise ValueError(f'We are not on dali not expanse and thus cannot load rucio')
         return prefix
 
     def did_is_local(self, did):


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Since we now have Expanse implemented as a production site, it would be good to read directly from the Rucio storage there.

## Can you briefly describe how it works?
Exactly the same way the rucio frontend is able to read directly from rucio storage on Dali. 

## Can you give a minimal working example (or illustrate with a figure)?
I'm really the only member currently with an account on Expanse, so it's a bit difficult for others to test at the moment. But I was able to load data from a specific run that was copied to the rucio storage on SDSC. 

Since this PR should not break anything, it would be nice if we can merge and include in the next release. It would make testing on OSG much easier. 

