### PR TITLE
Smart RSE selection in RucioRemoteBackend

### DIFF
--- a/straxen/rucio.py
+++ b/straxen/rucio.py
@@ -165,7 +165,7 @@ class RucioFrontend(strax.StorageFrontend):
         """
         try:
             md = self._get_backend("RucioLocalBackend").get_metadata(did)
-        except (strax.DataNotAvailable, strax.DataCorrupted):
+        except (strax.DataNotAvailable, strax.DataCorrupted, KeyError):
             return False
 
         return self._all_chunk_stored(md, did)

--- a/straxen/rucio.py
+++ b/straxen/rucio.py
@@ -152,7 +152,7 @@ class RucioFrontend(strax.StorageFrontend):
         elif self.local_rse == 'SDSC_USERDISK':
             prefix = '/expanse/lustre/projects/chi135/shockley/rucio'
         else:
-            raise ValueError(f'We are not on dali not expanse and thus cannot load rucio')
+            raise ValueError(f'We are not on dali nor expanse and thus cannot load rucio')
         return prefix
 
     def did_is_local(self, did):

--- a/straxen/rucio.py
+++ b/straxen/rucio.py
@@ -25,7 +25,9 @@ class RucioFrontend(strax.StorageFrontend):
     """
     Uses the rucio client for the data find.
     """
-    local_rses = {'UC_DALI_USERDISK': r'.rcc.'}
+    local_rses = {'UC_DALI_USERDISK': r'.rcc.',
+                  'SDSC_USERDISK': r'.sdsc.'
+                  }
     local_did_cache = None
     local_rucio_path = None
 
@@ -147,8 +149,10 @@ class RucioFrontend(strax.StorageFrontend):
         elif self.local_rse == 'UC_DALI_USERDISK':
             # If rucio is not loaded but we are on dali, look here:
             prefix = '/dali/lgrandi/rucio/'
+        elif self.local_rse == 'SDSC_USERDISK':
+            prefix = '/expanse/lustre/projects/chi135/shockley/rucio'
         else:
-            raise ValueError(f'We are not on dali and cannot load rucio')
+            raise ValueError(f'We are not on dali not expanse and thus cannot load rucio')
         return prefix
 
     def did_is_local(self, did):


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Previously we always assumed that any data we would want to download was on a specific RSE (UC_OSG_USERDISK), while that obviously will not always be the case. This update aims to select the best RSE based on where the host where straxen is running. 

## Can you briefly describe how it works?
This update uses the hostname (via `socket.getfqdn()`) along with specific environment variables associated with OSG jobs to determine where the code is running, and then determines if the data in question is on a preferred RSE for that location. 

## Can you give a minimal working example (or illustrate with a figure)?
I tested [this code snippet](https://gist.github.com/ershockley/19d38769bb4fd9b3aa425f2cfcf71dfd) on both Midway and Expanse (in development container). It looks for a run on SDSC_USERDISK (which I happen to know are all on UC_OSG_USERDISK at this time also) and then load 2 seconds of raw_records. Depending on which site I run on, the data is downloaded from different endpoints: 

On Midway:
```Singularity> hostname -f; python test_remote.py
dali-login1.rcc.local
Downloading xnt_018159:raw_records-rfzvpzj4mf-metadata.json from UC_OSG_USERDISK
Loading raw_records: |                                                                            | 0.00 % [00:00<?]Downloading xnt_018159:raw_records-rfzvpzj4mf-000000 from UC_OSG_USERDISK
Loading raw_records: |▏                                                | 0.35 % [00:06<29:05], #1 (6.05 s). 7.5 MB/s
```

On Expanse:

```
Singularity> hostname -f; python test_remote.py
login02.expanse.sdsc.edu
Downloading xnt_018159:raw_records-rfzvpzj4mf-metadata.json from SDSC_USERDISK
Loading raw_records: |                                                                            | 0.00 % [00:00<?]Downloading xnt_018159:raw_records-rfzvpzj4mf-000000 from SDSC_USERDISK
Loading raw_records: |▏                                                | 0.35 % [00:04<22:00], #1 (4.58 s). 9.9 MB/s
```

You can see that when running on Midway, it grabs the data from UC_OSG_USERDISK, whereas on Expanse it grabs it from SDSC_USERDISK. 

