### PR TITLE
Add n saturated channels

### DIFF
--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -135,7 +135,7 @@ class EventBasics(strax.Plugin):
     The main S2 and alternative S2 are given by the largest two S2-Peaks
     within the event. By default this is also true for S1.
     """
-    __version__ = '1.1.1'
+    __version__ = '1.2.0'
 
     depends_on = ('events',
                   'peak_basics',
@@ -195,7 +195,10 @@ class EventBasics(strax.Plugin):
             ('range_50p_area',    np.float32, 'width, 50% area [ns]'),
             ('range_90p_area',    np.float32, 'width, 90% area [ns]'),
             ('rise_time',         np.float32, 'time between 10% and 50% area quantiles [ns]'),
-            ('area_fraction_top', np.float32, 'fraction of area seen by the top PMT array')
+            ('area_fraction_top', np.float32, 'fraction of area seen by the top PMT array'),
+            ('tight_coincidence', np.int16, 'Hits within tight range of mean'),
+            ('n_saturated_channels',      np.int16, 'Total number of saturated channels'),
+            ('tight_coincidence_channel', np.int16, 'PMT channel within tight range of mean'),
         )
 
     @staticmethod

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -47,6 +47,8 @@ class PeakBasics(strax.Plugin):
             'max_pmt'), np.int16),
         (('Area of signal in the largest-contributing PMT (PE)',
             'max_pmt_area'), np.float32),
+        (('Total number of saturated channels',
+          'n_saturated_channels'), np.int16),
         (('Width (in ns) of the central 50% area of the peak',
             'range_50p_area'), np.float32),
         (('Width (in ns) of the central 90% area of the peak',
@@ -78,6 +80,7 @@ class PeakBasics(strax.Plugin):
         r['max_pmt'] = np.argmax(p['area_per_channel'], axis=1)
         r['max_pmt_area'] = np.max(p['area_per_channel'], axis=1)
         r['tight_coincidence'] = p['tight_coincidence']
+        r['n_saturated_channels'] = p['n_saturated_channels']
 
         n_top = self.config['n_top_pmts']
         area_top = p['area_per_channel'][:, :n_top].sum(axis=1)

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -64,6 +64,8 @@ class PeakBasics(strax.Plugin):
           'rise_time'), np.float32),
         (('Hits within tight range of mean',
           'tight_coincidence'), np.int16),
+        (('PMT channel within tight range of mean',
+          'tight_coincidence_channel'), np.int16),
         (('Classification of the peak(let)',
           'type'), np.int8)
     ]
@@ -80,6 +82,7 @@ class PeakBasics(strax.Plugin):
         r['max_pmt'] = np.argmax(p['area_per_channel'], axis=1)
         r['max_pmt_area'] = np.max(p['area_per_channel'], axis=1)
         r['tight_coincidence'] = p['tight_coincidence']
+        r['tight_coincidence_channel'] = p['tight_coincidence_channel']
         r['n_saturated_channels'] = p['n_saturated_channels']
 
         n_top = self.config['n_top_pmts']

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -28,7 +28,7 @@ class PeakBasics(strax.Plugin):
     arrays.
     NB: This plugin can therefore be loaded as a pandas DataFrame.
     """
-    __version__ = "0.0.9"
+    __version__ = "0.1.0"
     parallel = True
     depends_on = ('peaks',)
     provides = 'peak_basics'

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -805,7 +805,7 @@ class Peaks(strax.Plugin):
     data_kind = 'peaks'
     provides = 'peaks'
     parallel = True
-    save_when = strax.SaveWhen.NEVER
+    save_when = strax.SaveWhen.EXPLICIT
 
     __version__ = '0.1.2'
 

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -606,6 +606,9 @@ class PeakletClassificationHighEnergy(PeakletClassification):
     strax.Option('gain_model',
                  help='PMT gain model. Specify as '
                       '(str(model_config), str(version), nT-->boolean'),
+    strax.Option('merge_without_s1', default=True,
+                 help="If true, S1s will be igored during the merging. "
+                      "It's now possible for a S1 to be inside a S2 post merging"),
 )
 class MergedS2s(strax.OverlapWindowPlugin):
     """
@@ -615,7 +618,7 @@ class MergedS2s(strax.OverlapWindowPlugin):
     depends_on = ('peaklets', 'peaklet_classification', 'lone_hits')
     data_kind = 'merged_s2s'
     provides = 'merged_s2s'
-    __version__ = '0.3.0'
+    __version__ = '0.3.1'
 
     def setup(self):
         self.to_pe = straxen.get_correction_from_cmt(self.run_id,
@@ -629,6 +632,9 @@ class MergedS2s(strax.OverlapWindowPlugin):
                     + self.config['s2_merge_max_duration'])
 
     def compute(self, peaklets, lone_hits):
+        if self.config['merge_without_s1']:
+            peaklets = peaklets[peaklets['type'] != 1]
+
         if len(peaklets) <= 1:
             return np.zeros(0, dtype=peaklets.dtype)
 
@@ -784,7 +790,11 @@ class MergedS2sHighEnergy(MergedS2s):
 @export
 @strax.takes_config(
     strax.Option('diagnose_sorting', track=False, default=False,
-                 help="Enable runtime checks for sorting and disjointness"))
+                 help="Enable runtime checks for sorting and disjointness"),
+    strax.Option('merge_without_s1', default=True,
+                 help="If true, S1s will be igored during the merging. "
+                      "It's now possible for a S1 to be inside a S2 post merging"),
+)
 class Peaks(strax.Plugin):
     """
     Merge peaklets and merged S2s such that we obtain our peaks
@@ -797,7 +807,7 @@ class Peaks(strax.Plugin):
     parallel = True
     save_when = strax.SaveWhen.NEVER
 
-    __version__ = '0.1.1'
+    __version__ = '0.1.2'
 
     def infer_dtype(self):
         return self.deps['peaklets'].dtype_for('peaklets')
@@ -805,13 +815,24 @@ class Peaks(strax.Plugin):
     def compute(self, peaklets, merged_s2s):
         # Remove fake merged S2s from dirty hack, see above
         merged_s2s = merged_s2s[merged_s2s['type'] != FAKE_MERGED_S2_TYPE]
-
-        peaks = strax.replace_merged(peaklets, merged_s2s)
+        
+        if self.config['merge_without_s1']:
+            is_s1 = peaklets['type'] == 1
+            peaks = strax.replace_merged(peaklets[~is_s1], merged_s2s)
+            peaks = strax.sort_by_time(np.concatenate([peaklets[is_s1],
+                                                       peaks]))
+        else:
+            peaks = strax.replace_merged(peaklets, merged_s2s)
 
         if self.config['diagnose_sorting']:
             assert np.all(np.diff(peaks['time']) >= 0), "Peaks not sorted"
-            assert np.all(peaks['time'][1:]
-                          >= strax.endtime(peaks)[:-1]), "Peaks not disjoint"
+            if self.config['merge_without_s1']:
+                to_check = peaks['type'] != 1
+            else:
+                to_check = peaks['type'] != FAKE_MERGED_S2_TYPE
+
+            assert np.all(peaks['time'][to_check][1:]
+                            >= strax.endtime(peaks)[to_check][:-1]), "Peaks not disjoint"
         return peaks
 
 

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -885,7 +885,7 @@ def get_tight_coin(hit_max_times, hit_channel, peak_max_times, left, right,
 
     # loop over peaks
     for p_i, p_t in enumerate(peak_max_times):
-
+        channels_seen[:] = 0
         # loop over hits starting from the last one we left at
         for left_hit_i in range(left_hit_i, len(hit_max_times)):
 
@@ -898,8 +898,11 @@ def get_tight_coin(hit_max_times, hit_channel, peak_max_times, left, right,
             # stop the loop when we know we're outside the range
             if d > right:
                 n_coin_channel[p_i] = np.sum(channels_seen)
-                channels_seen[:] = 0
                 break
+        
+        # Add channel information in case there are no hits beyond 
+        # the last peak:
+        n_coin_channel[p_i] = np.sum(channels_seen)
 
     return n_coin_hit, n_coin_channel
 

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -92,7 +92,7 @@ class Peaklets(strax.Plugin):
     parallel = 'process'
     compressor = 'zstd'
 
-    __version__ = '0.4.1'
+    __version__ = '0.5.0'
 
     def infer_dtype(self):
         return dict(peaklets=strax.peak_dtype(
@@ -618,7 +618,7 @@ class MergedS2s(strax.OverlapWindowPlugin):
     depends_on = ('peaklets', 'peaklet_classification', 'lone_hits')
     data_kind = 'merged_s2s'
     provides = 'merged_s2s'
-    __version__ = '0.3.1'
+    __version__ = '0.4.0'
 
     def setup(self):
         self.to_pe = straxen.get_correction_from_cmt(self.run_id,

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -234,11 +234,15 @@ class Peaklets(strax.Plugin):
         peaklet_max_times = (
                 peaklets['time']
                 + np.argmax(peaklets['data'], axis=1) * peaklets['dt'])
-        peaklets['tight_coincidence'] = get_tight_coin(
+        tight_coincidence, tight_coincidence_channel = get_tight_coin(
             hit_max_times,
+            hitlets['channel'],
             peaklet_max_times,
             self.config['tight_coincidence_window_left'],
             self.config['tight_coincidence_window_right'])
+        
+        peaklets['tight_coincidence'] = tight_coincidence
+        peaklets['tight_coincidence_channel'] = tight_coincidence_channel
 
         if self.config['diagnose_sorting'] and len(r):
             assert np.diff(r['time']).min(initial=1) >= 0, "Records not sorted"


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
In this PR we do 3 things:

- Add `n_saturated_channel` information to peak_basics and propagate the information upwards to event_basics.
- Propagate the information about `tight_coincidence` up to event_basics
- Add a new `tight_coincidence_channel` field which contains the tight coincidence based on number of contributing PMTs instead of hits.

For the last change I modified `get_tight_coincidence` and I also updated the peak_merging accordingly in https://github.com/AxFoundation/strax/pull/551. Further, I added a test for `get_tight_coincidence` which tests both the normal `tight_coincidence` and the channel based one. 

Some of the test in this PR will currently, fail as we have to merge https://github.com/AxFoundation/strax/pull/551 first and updated our peak-level test data.

Some disadvantage of this PR: We need to reprocess starting with peaklets if we want to include a channel based tight coincidence.