### PR TITLE
add small tool to extract run comments from database

### DIFF
--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -244,6 +244,26 @@ class TimeWidgets:
         return time, time_ns
 
 
+@strax.Context.add_method
+def extract_latest_comment(self):
+    """
+    Extract the latest comment in the runs-database. This just adds info to st.runs
+
+    Example:
+        st.extract_latest_comment()
+        st.select_runs(available=('raw_records'))
+    """
+    if self.runs is None or 'comments' not in self.runs.keys():
+        self.context_config['store_run_fields'] = tuple(
+            list(self.context_config['store_run_fields']) + ['comments']
+        )
+        self.scan_runs(store_fields=('comments',))
+        latest_comments = [(c[-1]['comment'] if hasattr(c, '__len__') else '') for c in
+                           self.runs['comments']]
+        self.runs['comments'] = latest_comments
+    return self.runs
+
+
 @export
 def convert_array_to_df(array: np.ndarray) -> pd.DataFrame:
     """

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -60,3 +60,26 @@ class TestBasics(unittest.TestCase):
 
         n = self.st.count_rr(self.run_id)
         assert n > 100
+
+    def test_extract_latest_comment(self,
+                                    context='xenonnt_online',
+                                    test_for_target='raw_records'
+                                    ):
+        if context == 'xenonnt_online' and not straxen.utilix_is_configured():
+            return
+        st = getattr(straxen.contexts, context)()
+        assert hasattr(st, 'extract_latest_comment'), "extract_latest_comment not added to context?"
+        st.extract_latest_comment()
+        assert st.runs is not None, "No registry build?"
+        assert 'comments' in st.runs.keys()
+        st.select_runs(available=test_for_target)
+        if context == 'demo':
+            assert len(st.runs)
+        assert f'{test_for_target}_available' in st.runs.keys()
+
+    def test_extract_latest_comment_lone_hits(self):
+        """Run the test for some target that is not in the default availability check"""
+        self.test_extract_latest_comment(test_for_target='lone_hits')
+
+    def test_extract_latest_comment_demo(self):
+        self.test_extract_latest_comment(context='demo')


### PR DESCRIPTION

##What does the code in this PR do / what does it improve / Can you briefly describe how it works?
Load the comments field from the database and extract the latest comment.

## Can you give a minimal working example (or illustrate with a figure)?
![afbeelding](https://user-images.githubusercontent.com/22295914/137127952-61d9d969-e2bd-408f-a47b-7377d6239077.png)

