### PR TITLE
Warn about non-loadable loggers

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -15,7 +15,7 @@ How to use
 For more info, see the documentation:
 https://straxen.readthedocs.io/en/latest/bootstrax.html
 """
-__version__ = '1.1.8'
+__version__ = '1.1.9'
 
 import argparse
 from datetime import datetime, timedelta, timezone
@@ -38,6 +38,7 @@ import straxen
 import threading
 import pandas as pd
 import typing as ty
+import daqnt
 
 parser = argparse.ArgumentParser(
     description="XENONnT online processing manager")
@@ -216,18 +217,9 @@ remove_target_after_fails = dict(events=2,
 ##
 hostname = socket.getfqdn()
 
-try:
-    import daqnt
-    log_name = 'bootstrax_' + hostname + ('' if args.production else '_TESTING')
-    log = daqnt.get_daq_logger(log_name, log_name, level=logging.DEBUG)
-except ModuleNotFoundError as e:
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s %(name)s %(levelname)-8s %(message)s',
-        datefmt='%m-%d %H:%M')
-    log = logging.getLogger()
-    log.warning(f'Cannot start logger! {str(e)}')
 
+log_name = 'bootstrax_' + hostname + ('' if args.production else '_TESTING')
+log = daqnt.get_daq_logger(log_name, log_name, level=logging.DEBUG)
 log.info(f'---\n bootstrax version {__version__}\n---')
 log.info(
     straxen.print_versions(

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -220,12 +220,13 @@ try:
     import daqnt
     log_name = 'bootstrax_' + hostname + ('' if args.production else '_TESTING')
     log = daqnt.get_daq_logger(log_name, log_name, level=logging.DEBUG)
-except ModuleNotFoundError:
+except ModuleNotFoundError as e:
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s %(name)s %(levelname)-8s %(message)s',
         datefmt='%m-%d %H:%M')
     log = logging.getLogger()
+    log.warning(f'Cannot start logger! {str(e)}')
 
 log.info(f'---\n bootstrax version {__version__}\n---')
 log.info(


### PR DESCRIPTION
Small change but logging was stopped briefly because a dependency wasn't installed in daqnt