### PR TITLE
Update online_monitor_nv to v0.0.3

### DIFF
--- a/straxen/plugins/online_monitor.py
+++ b/straxen/plugins/online_monitor.py
@@ -185,7 +185,11 @@ class OnlinePeakMonitor(strax.Plugin):
         track=False, 
         type=immutabledict,
         help="immutabledict mapping subdetector to (min, max) \
-              channel number.")
+              channel number."), 
+    strax.Option(
+        'events_nv_area_bounds',
+        type=tuple, default=(-0.5, 130.5),
+        help='Boundaries area histogram of events_nv_area_per_chunk [PE]')
 )
 class OnlineMonitorNV(strax.Plugin):
     """
@@ -203,7 +207,7 @@ class OnlineMonitorNV(strax.Plugin):
     depends_on = ('hitlets_nv', 'events_nv')
     provides = 'online_monitor_nv'
     data_kind = 'online_monitor_nv'
-    __version__ = '0.0.2'
+    __version__ = '0.0.3'
     rechunk_on_save = False
 
     def infer_dtype(self):
@@ -217,7 +221,9 @@ class OnlineMonitorNV(strax.Plugin):
             (('hitlets_nv per channel', 'hitlets_nv_per_channel'),
              (np.int64, n_pmt)),
             (('events_nv per chunk', 'events_nv_per_chunk'),
-             np.int64)
+             np.int64),
+            (('events_nv_area per chunk', 'events_nv_area_per_chunk'),
+             np.int64, 130)
         ]
         return dtype
 
@@ -237,4 +243,10 @@ class OnlineMonitorNV(strax.Plugin):
         
         # Count number of events_nv per chunk
         res['events_nv_per_chunk'] = len(events_nv)
+        
+        # Get histogram of events_nv_area per chunk
+        min_bin, max_bin = self.config['events_nv_area_bounds']
+        res['events_nv_area_per_chunk'], _ = np.histogram(events_nv['area'], 
+                                                          bins=np.arange(min_bin, max_bin, 1),
+                                                          weights=np.ones(len(events_nv)))
         return res


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
I added events_nv_area_per_chunk to for monitoring nVeto detector. 

## Can you briefly describe how it works?
A histogram of events_nv['area'] is created for plotting.

## Can you give a minimal working example (or illustrate with a figure)?
You can find a plot here https://xenonnt.slack.com/files/U01T382KYHL/F02HYDQT9JQ/image.png

_Please include the following if applicable:_
  - [X] _Tests to check the (new) code is working as desired._

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
