### PR TITLE
use a small test data file

### DIFF
--- a/straxen/__init__.py
+++ b/straxen/__init__.py
@@ -26,6 +26,9 @@ from . import analyses
 # Otherwise we have straxen.demo() etc.
 from . import contexts
 
+from . import test_utils
+from test_utils import *
+
 try:
     from . import holoviews_utils
     from .holoviews_utils import *

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -2,7 +2,6 @@ import ast
 import configparser
 import gzip
 import inspect
-import io
 import commentjson
 import json
 import os
@@ -11,7 +10,6 @@ import pickle
 import dill
 import socket
 import sys
-import tarfile
 import urllib.request
 import tqdm
 import numpy as np
@@ -55,6 +53,7 @@ LAST_MISCABLED_RUN = 8796
 TSTART_FIRST_CORRECTLY_CABLED_RUN = 1596036001000000000
 
 INFINITY_64BIT_SIGNED = 9223372036854775807
+
 
 @export
 def pmt_positions(xenon1t=False):
@@ -298,16 +297,6 @@ def get_secret(x):
 
 
 @export
-def download_test_data():
-    """Downloads strax test data to strax_test_data in the current directory"""
-    blob = get_resource('https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/353b2c60a01e96f67e4ba544ce284bd91241964d/strax_files/strax_test_data_straxv1.1.0.tar',  #  noqa
-                        fmt='binary')
-    f = io.BytesIO(blob)
-    tf = tarfile.open(fileobj=f)
-    tf.extractall()
-
-
-@export
 def get_livetime_sec(context, run_id, things=None):
     """Get the livetime of a run in seconds. If it is not in the run metadata,
     estimate it from the data-level metadata of the data things.
@@ -353,26 +342,8 @@ def pre_apply_function(data, run_id, target, function_name='pre_apply_function')
 
 
 def _overwrite_testing_function_file(function_file):
-    """For testing purposes allow this function file to be loaded from HOME/testing_folder"""
-    if not straxen._is_on_pytest():
-        # If we are not on a pytest, never try using a local file.
-        return function_file
-
-    home = os.environ.get('HOME')
-    if home is None:
-        # Impossible to load from non-existent folder
-        return function_file
-
-    testing_file = os.path.join(home, function_file)
-
-    if os.path.exists(testing_file):
-        # For testing purposes allow loading from 'home/testing_folder'
-        warn(f'Using local function: {function_file} from {testing_file}! '
-             f'If you are not integrated testing on github you should '
-             f'absolutely remove this file. (See #559)')
-        function_file = testing_file
-
-    return function_file
+    warn('Use straxen.test_utils._overwrite_testing_function_file')
+    return straxen._overwrite_testing_function_file(function_file)
 
 
 @export

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -7,7 +7,6 @@ import sys
 import warnings
 import datetime
 import pytz
-from os import environ as os_environ
 from importlib import import_module
 from git import Repo, InvalidGitRepositoryError
 from configparser import NoSectionError
@@ -276,9 +275,3 @@ def convert_array_to_df(array: np.ndarray) -> pd.DataFrame:
     """
     keys = [key for key in array.dtype.names if array[key].ndim == 1]
     return pd.DataFrame(array[keys])
-
-
-@export
-def _is_on_pytest():
-    """Check if we are on a pytest"""
-    return 'PYTEST_CURRENT_TEST' in os_environ

--- a/straxen/test_utils.py
+++ b/straxen/test_utils.py
@@ -1,0 +1,60 @@
+import strax
+import straxen
+import tarfile
+import io
+import os
+from warnings import warn
+from os import environ as os_environ
+
+export, __all__ = strax.exporter()
+
+
+@export
+def download_test_data(test_data='https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/353b2c60a01e96f67e4ba544ce284bd91241964d/strax_files/strax_test_data_straxv1.1.0.tar',  #  noqa
+                       ):
+    """Downloads strax test data to strax_test_data in the current directory"""
+    blob = straxen.common.get_resource(test_data, fmt='binary')
+    f = io.BytesIO(blob)
+    tf = tarfile.open(fileobj=f)
+    tf.extractall()
+
+
+def _overwrite_testing_function_file(function_file):
+    """For testing purposes allow this function file to be loaded from HOME/testing_folder"""
+    if not _is_on_pytest():
+        # If we are not on a pytest, never try using a local file.
+        return function_file
+
+    home = os.environ.get('HOME')
+    if home is None:
+        # Impossible to load from non-existent folder
+        return function_file
+
+    testing_file = os.path.join(home, function_file)
+
+    if os.path.exists(testing_file):
+        # For testing purposes allow loading from 'home/testing_folder'
+        warn(f'Using local function: {function_file} from {testing_file}! '
+             f'If you are not integrated testing on github you should '
+             f'absolutely remove this file. (See #559)')
+        function_file = testing_file
+
+    return function_file
+
+
+@export
+def _is_on_pytest():
+    """Check if we are on a pytest"""
+    return 'PYTEST_CURRENT_TEST' in os_environ
+
+
+nt_test_run_id = '012882'
+
+
+def nt_test_context(target_context='xenonnt_online',
+                    **kwargs):
+    st = getattr(straxen.contexts, target_context)(**kwargs)
+    st._plugin_class_registry['raw_records'].__version__ = "MOCKTESTDATA"
+    st.storage = [strax.DataDirectory('./strax_test_data')]
+    download_test_data('https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/8b304bde43260eb47b4d666c244a386ac5a25b51/strax_files/012882-raw_records-z7q2d2ye2t.tar')
+    return st

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -4,6 +4,7 @@ import numpy as np
 from immutabledict import immutabledict
 import straxen
 from straxen.common import pax_file, aux_repo
+from straxen.test_utils import nt_test_run_id
 ##
 # Tools
 ##
@@ -49,7 +50,7 @@ testing_config_1T = dict(
     electron_drift_time_gate=("electron_drift_time_gate_constant", 1700),
 )
 
-test_run_id_nT = '008900'
+nt_test_run_id = '008900'
 test_run_id_1T = '180423_1021'
 
 
@@ -128,7 +129,7 @@ forbidden_plugins = tuple([p for p in
 
 def _run_plugins(st,
                  make_all=False,
-                 run_id=test_run_id_nT,
+                 run_id=nt_test_run_id,
                  **proces_kwargs):
     """
     Try all plugins (except the DAQReader) for a given context (st) to see if
@@ -276,16 +277,18 @@ def test_nT(ncores=1):
     if ncores == 1:
         print('-- nT lazy mode --')
     init_database = straxen.utilix_is_configured(warning_message=False)
-    st = straxen.contexts.xenonnt_online(_database_init=init_database,
-                                         use_rucio=False)
+    st = straxen.test_utils.nt_test_context(
+        _database_init=init_database,
+        use_rucio=False,
+    )
     offline_gain_model = ("to_pe_placeholder", True)
     _update_context(st, ncores, fallback_gains=offline_gain_model, nt=True)
     # Lets take an abandoned run where we actually have gains for in the CMT
-    _run_plugins(st, make_all=True, max_workers=ncores, run_id=test_run_id_nT)
+    _run_plugins(st, make_all=True, max_workers=ncores, run_id=nt_test_run_id)
     # Test issue #233
     st.search_field('cs1')
     # Test of child plugins:
-    _test_child_options(st, test_run_id_nT)
+    _test_child_options(st, nt_test_run_id)
     print(st.context_config)
 
 


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Add a small test file from wfsim to run tests with the nT data structure that allows a more fully testing of the plugins.

The test file is from WFSim, the lineage patched to be. 
```python
    "lineage": {
        "raw_records_mv": [
            "DAQReader",
            "MOCKTESTDATA",
            {}
        ]
    },
```
There is only one chunk (5 MB)

A few events should be produced from this file.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
