### PR TITLE
WFSim registry as argument for simulations context

### DIFF
--- a/straxen/common.py
+++ b/straxen/common.py
@@ -533,36 +533,6 @@ def _swap_values_in_array(data_arr, buffer, items, replacements):
     return buffer
 
 
-@export
-def deregister_if_not_simulated(context, check_for_endswith=('_nv', '_mv')):
-    """
-    Given a context, remove nv/mv plugins if their raw records are not simulated
-    :param context: A fully initialized context where the simulation
-        plugin must provide "truth"
-    :param check_for_endswith: Check for these patterns. If no
-        raw-records of this kind are created, remove any other plugin
-        that ends with these strings from the context
-    :return: The cleaned-up context
-    """
-    simulated = context._plugin_class_registry['truth'].provides
-    for endswith in check_for_endswith:
-        if f'raw_records{endswith}' not in simulated:
-            remove_from_registry(context, endswith)
-    return context
-
-def remove_from_registry(context, endswith):
-    """Remove plugins if their name ends with a given string"""
-    for p in list(context._plugin_class_registry.keys()):
-        if p.endswith(endswith):
-            del context._plugin_class_registry[p]
-        elif ('events_tagged' in context._plugin_class_registry[p].provides or
-              'peak_veto_tags' in context._plugin_class_registry[p].provides):
-            # These plugins are known to mix nv/mv/tpc
-            del context._plugin_class_registry[p]
-    
-    return context
-
-
 ##
 # Old XENON1T Stuff
 ##

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -311,7 +311,7 @@ def xenonnt_simulation(
     st.register(getattr(wfsim, wfsim_registry))
 
     # Make sure that the non-simulated raw-record types are not requested
-    st = deregister_if_not_simulated(st)
+    st.deregister_plugins_with_missing_dependencies()
 
     if straxen.utilix_is_configured(
             warning_message='Bad context as we cannot set CMT since we '
@@ -558,4 +558,5 @@ def xenon1t_simulation(output_folder='./strax_data'):
             **x1t_common_config),
         **x1t_context_config)
     st.register(wfsim.RawRecordsFromFax1T)
+    st.deregister_plugins_with_missing_dependencies()
     return st


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

We enable the WFSim registry as a string argument for the simulations context, so that we can build the different (cutax) contexts we need from this one.

- [x] _Updated docstring(s)_
