### PR TITLE
Add a few special cases

### DIFF
--- a/straxen/plugins/double_scatter.py
+++ b/straxen/plugins/double_scatter.py
@@ -57,7 +57,7 @@ class EventInfoDouble(strax.MergeOnlyPlugin):
                          'cs1': 'cs1_a',
                          'cs2': 'cs2_a',
                          'alt_s1_delay': 'ds_s1_dt',
-                         'alt_s2_delay': 'ds_s2_dt'
+                         'alt_s2_delay': 'ds_s2_dt',
                          'cs2_wo_elifecorr': 'cs2_a_wo_elifecorr',
                          'alt_cs2_wo_elifecorr': 'cs2_b_wo_elifecorr',
                          'cs2_area_fraction_top': 'cs2_a_area_fraction_top',

--- a/straxen/plugins/double_scatter.py
+++ b/straxen/plugins/double_scatter.py
@@ -46,7 +46,7 @@ class EventInfoDouble(strax.MergeOnlyPlugin):
       - Adds s1_b_distinct_channels, which can be tricky to compute
         (since it requires going back to peaks)
     """
-    __version__ = '0.1.0'
+    __version__ = '0.1.1'
     depends_on = ['event_info', 'distinct_channels']
     save_when = strax.SaveWhen.EXPLICIT
     

--- a/straxen/plugins/double_scatter.py
+++ b/straxen/plugins/double_scatter.py
@@ -56,8 +56,14 @@ class EventInfoDouble(strax.MergeOnlyPlugin):
                          'alt_cs2': 'cs2_b',
                          'cs1': 'cs1_a',
                          'cs2': 'cs2_a',
-                         'alt_s1_delay':'ds_s1_dt',
-                         'alt_s2_delay':'ds_s2_dt'}
+                         'alt_s1_delay': 'ds_s1_dt',
+                         'alt_s2_delay': 'ds_s2_dt'
+                         'cs2_wo_elifecorr': 'cs2_a_wo_elifecorr',
+                         'alt_cs2_wo_elifecorr': 'cs2_b_wo_elifecorr',
+                         'cs2_area_fraction_top': 'cs2_a_area_fraction_top',
+                         'alt_cs2_area_fraction_top': 'cs2_b_area_fraction_top',
+                         'cs2_bottom': 'cs2_a_bottom',
+                         'alt_cs2_bottom': 'cs2_b_bottom'}
         if orig_name in special_cases:
             return special_cases[orig_name]
 


### PR DESCRIPTION
The renaming for variables starting with cs1/cs2 is made via explicitly written special cases. Those were not updated for a few added fields. 
See https://straxen.readthedocs.io/en/latest/reference/datastructure_nT.html#event-info-double