### PR TITLE
Set check_broken=False for RucioFrontend.find

### DIFF
--- a/straxen/rucio.py
+++ b/straxen/rucio.py
@@ -122,6 +122,13 @@ class RucioFrontend(strax.StorageFrontend):
 
         raise strax.DataNotAvailable
 
+    def find(self, key: strax.DataKey,
+             write=False,
+             check_broken=False,
+             allow_incomplete=False,
+             fuzzy_for=tuple(), fuzzy_for_options=tuple()):
+        return super().find(key, write, check_broken, allow_incomplete, fuzzy_for, fuzzy_for_options)
+
     def get_rse_prefix(self, rse):
         if HAVE_ADMIX:
             prefix = admix.rucio.get_rse_prefix(rse)


### PR DESCRIPTION

## What does the code in this PR do / what does it improve?
This PR changes the default `check_broken` kwarg in the find method to `False` for this particular frontend. Otherwise, `_get_metadata` gets called for the backend, which in the case of the RucioRemoteBackend means having to download a metadata file for no particular reason. 

As an example, below is equivalent to how things stand currently:
```
st = straxen.contexts.xenonnt_online(_include_rucio_remote=True)
key = st.key_for('020287', 'raw_records')
sf = st.storage[-1]
sf.find(key, check_broken=True)
```
As you can see, this will download the metadata file at the `find` step. This is due to [this line](https://github.com/AxFoundation/strax/blob/d23a605ab8171d89209aeb10f9d2f86b456a212e/strax/storage/common.py#L268) in strax.

The reason this is not ideal is that `strax.Context.available_for_run`, e.g., calls the `find` method with the default value for `check_broken`. So, as it currently stands with default `check_broken=True`, the `available_for_run` will download metadata files for every datatype that it can. We don't want this as it slows down `available_for_run` substantially. 

To see the difference, you can try running `st.available_for_run` before/after this change. 