### PR TITLE
Add perpendicular wires handling info and function

### DIFF
--- a/straxen/common.py
+++ b/straxen/common.py
@@ -24,7 +24,7 @@ export, __all__ = strax.exporter()
 __all__ += ['straxen_dir', 'first_sr1_run', 'tpc_r', 'tpc_z', 'aux_repo',
             'n_tpc_pmts', 'n_top_pmts', 'n_hard_aqmon_start', 'ADC_TO_E',
             'n_nveto_pmts', 'n_mveto_pmts', 'tpc_pmt_radius', 'cryostat_outer_radius',
-            'INFINITY_64BIT_SIGNED']
+            'perp_wire_angle', 'perp_wire_x_rot_pos','INFINITY_64BIT_SIGNED']
 
 straxen_dir = os.path.dirname(os.path.abspath(
     inspect.getfile(inspect.currentframe())))
@@ -58,11 +58,13 @@ TSTART_FIRST_CORRECTLY_CABLED_RUN = 1596036001000000000
 INFINITY_64BIT_SIGNED = 9223372036854775807
 
 @export
-def rotate_perp_wires(x_obs, y_obs):
-    """Returns x and y in the rotated plane where the perpendicular wires
-    area vertically aligned (parallel to the y-axis)."""
-    x_rot = np.cos(perp_wire_angle) * x_obs - np.sin(perp_wire_angle) * y_obs
-    y_rot = np.sin(perp_wire_angle) * x_obs + np.cos(perp_wire_angle) * y_obs
+def rotate_perp_wires(x_obs, y_obs, angle_extra = 0):
+    """Returns x and y in the rotated plane where the perpendicular wires 
+    area vertically aligned (parallel to the y-axis). Accepts addid to the 
+    rotation angle with `angle_extra` [deg]"""
+    angle_extra_rad = np.deg2rad(angle_extra)
+    x_rot = np.cos(perp_wire_angle + angle_extra_rad) * x_obs - np.sin(perp_wire_angle + angle_extra_rad) * y_obs
+    y_rot = np.sin(perp_wire_angle + angle_extra_rad) * x_obs + np.cos(perp_wire_angle + angle_extra_rad) * y_obs
     return x_rot, y_rot
 
 @export

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -43,6 +43,9 @@ n_mveto_pmts = 84
 
 tpc_pmt_radius = 7.62 / 2  # cm
 
+perp_wire_angle = np.deg2rad(30)
+perp_wire_x_rot_pos = 13.06 #[cm]
+
 # Convert from ADC * samples to electrons emitted by PMT
 # see pax.dsputils.adc_to_pe for calculation. Saving this number in straxen as
 # it's needed in analyses
@@ -54,6 +57,13 @@ TSTART_FIRST_CORRECTLY_CABLED_RUN = 1596036001000000000
 
 INFINITY_64BIT_SIGNED = 9223372036854775807
 
+@export
+def rotate_perp_wires(x_obs, y_obs):
+    """Returns x and y in the rotated plane where the perpendicular wires
+    area vertically aligned (parallel to the y-axis)."""
+    x_rot = np.cos(perp_wire_angle) * x_obs - np.sin(perp_wire_angle) * y_obs
+    y_rot = np.sin(perp_wire_angle) * x_obs + np.cos(perp_wire_angle) * y_obs
+    return x_rot, y_rot
 
 @export
 def pmt_positions(xenon1t=False):


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
  * Include easy to access perpendicular wires info: rotation angle in relation to standard x axis and x position on the rotated plane (vertical perpendicular wires).
  * Add function to convert from standard (x,y) to (x_rotated, y_rotated), where in the rotated plane the perpendicular wires are vertically aligned.
## Can you briefly describe how it works?
  - Defines the useful variables `perp_wire_angle ` and `perp_wire_x_rot_pos ` for easy access on plugins, cuts and analysis.
  - Defines the function `rotate_perp_wires(x_obs, y_obs)` which rotates the x,y plane to make the perpendicular wires parallel to the y-axis. Takes x and y values (both flt, np arrays or pd series) and returns the corresponding values for rotated x and rotated y.
## Can you give a minimal working example (or illustrate with a figure)?
```fake_x_obs = np.linspace(-10,10,100)
fake_y_right_obs = np.tan(np.deg2rad(60))*fake_x_obs-5
fake_y_left_obs = np.tan(np.deg2rad(60))*fake_x_obs+5

fake_x_rot_right,fake_y_rot_right = rotate_perp_wires(fake_x_obs, fake_y_right_obs)
fake_x_rot_left, fake_y_rot_left = rotate_perp_wires(fake_x_obs, fake_y_left_obs)
```
![rotated_coordinates_perp_wires_pr](https://user-images.githubusercontent.com/20727577/141483368-abbe3de7-430c-4b2b-ac53-aec4abd0896f.png)

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
