### PR TITLE
Adding code comments for corrected z position

### DIFF
--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -532,6 +532,8 @@ class EventPositions(strax.Plugin):
                        'r_field_distortion_correction': delta_r,
                        'theta': np.arctan2(orig_pos[:, 1], orig_pos[:, 0]),
                        'z_naive': z_obs,
+                       # using z_obs in agreement with the dtype description
+                       # the FDC for z (z_cor) is found to be not reliable (see #527)
                        'z': z_obs,
                        'z_field_distortion_correction': delta_z
                        })


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
This is adding a few lines of code to make the situation for the z-coordinate clearer. We stopped using FDC on z some time ago as seen in #527 and related PRs.

The variable descriptions given in the dtype also reflect the current situation
```
        ('x', np.float32,
         'Interaction x-position, field-distortion corrected (cm)'),
        ('y', np.float32,
         'Interaction y-position, field-distortion corrected (cm)'),
        ('z', np.float32,
         'Interaction z-position, using mean drift velocity only (cm)'),
```
z is given as **only using drift velocity** (no FDC).

See also #762 