### PR TITLE
Add main peaks' shadow for event shadow

### DIFF
--- a/straxen/plugins/event_shadow.py
+++ b/straxen/plugins/event_shadow.py
@@ -20,7 +20,7 @@ class EventShadow(strax.Plugin):
 
     def infer_dtype(self):
         dtype = [('s1_shadow', np.float32, 'main s1 shadow [PE/ns]'),
-                 ('s2_shadow', np.float32, 'mian s2 shadow [PE/ns]'),
+                 ('s2_shadow', np.float32, 'main s2 shadow [PE/ns]'),
                  ('shadow', np.float32, 'shadow of event [PE/ns]'),
                  ('pre_s2_area', np.float32, 'previous s2 area [PE]'),
                  ('shadow_dt', np.int64, 'time diffrence to the previous s2 [ns]'),

--- a/straxen/plugins/event_shadow.py
+++ b/straxen/plugins/event_shadow.py
@@ -9,7 +9,7 @@ class EventShadow(strax.Plugin):
     This plugin can calculate shadow at event level.
     It depends on peak-level shadow.
     The event-level shadow is its first S2 peak's shadow.
-    If no S2 peaks, the event shadow will be nan. 
+    If no S2 peaks, the event shadow will be nan.
     It also gives the position infomation of the previous S2s
     and main peaks' shadow.
     """


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Specify the main peaks' shadow because later some cuts may implement on S1 or S2 peaks. 

## Can you briefly describe how it works?

Find the main S1 and S2 peaks and save them in new fields: `s1_shadow` and `s2_shadow`. This PR does not change the definition of already existing fields. 

## Can you give a minimal working example (or illustrate with a figure)?

[Note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:kexin:sr0_shadow_cut)

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [x] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_
