### PR TITLE
URLConfig not in strax

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -24,6 +24,7 @@ packaging==20.8
 pandas==1.3.2                                   # Strax dependency
 panel==0.12.1                                   # Bokeh dependency
 psutil==5.8.0                                   # Strax dependency
+pymongo==3.12.0
 pytest==6.2.5
 pytest-cov==3.0.0
 scikit-learn==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy~=1.19.5
 packaging~=20.8
+pymongo<=3.12.0
 strax>=1.1.2
 utilix>=0.5.3
 # tensorflow>=2.3.0  # Optional, to (re)do posrec

--- a/straxen/__init__.py
+++ b/straxen/__init__.py
@@ -16,7 +16,7 @@ from .rundb import *
 from .scada import *
 from .bokeh_utils import *
 from .rucio import *
-
+from .url_config import *
 from . import plugins
 from .plugins import *
 

--- a/straxen/mongo_storage.py
+++ b/straxen/mongo_storage.py
@@ -112,6 +112,7 @@ class GridFsInterface:
         doc = self.get_query_config(config)
         doc.update({
             'added': datetime.now(tz=pytz.utc),
+            
         })
         return doc
 
@@ -247,6 +248,7 @@ class MongoUploader(GridFsInterface):
         :param abs_path: str, the absolute path of the file 
         """
         doc = self.document_format(config)
+        doc['md5'] = self.compute_md5(abs_path)
         if not os.path.exists(abs_path):
             raise CouldNotLoadError(f'{abs_path} does not exits')
 

--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -278,7 +278,7 @@ class RunDB(strax.StorageFrontend):
             projection=projection)
         for doc in strax.utils.tqdm(
                 cursor, desc='Fetching run info from MongoDB',
-                total=cursor.count()):
+                total=self.collection.count_documents(query)):
             del doc['_id']
             if self.reader_ini_name_is_mode:
                 doc['mode'] = \

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -165,7 +165,7 @@ class URLConfig(strax.Config):
         
         return self.dispatch(url, **kwargs)
  
-@strax.URLConfig.register('cmt')
+@URLConfig.register('cmt')
 def get_correction(name, run_id=None, version='ONLINE', detector='nt', **kwargs):
     '''Get value for name from CMT
     '''
@@ -173,14 +173,14 @@ def get_correction(name, run_id=None, version='ONLINE', detector='nt', **kwargs)
         raise ValueError('Attempting to fetch a correction without a run id.')
     return straxen.get_correction_from_cmt(run_id, ( name, version, detector=='nt'))
 
-@strax.URLConfig.register('resource')
+@URLConfig.register('resource')
 def get_resource(name, fmt='text', **kwargs):
     '''Fetch a straxen resource
     '''
     return straxen.get_resource(name, fmt=fmt)
 
 
-@strax.URLConfig.register('fsspec')
+@URLConfig.register('fsspec')
 def read_file(path, **kwargs):
     '''Support fetching files from arbitrary filesystems
     '''
@@ -188,13 +188,13 @@ def read_file(path, **kwargs):
         content = f.read()
     return content
 
-@strax.URLConfig.register('json')
+@URLConfig.register('json')
 def read_json(content, **kwargs):
     ''' Load json string as a python object
     '''
     return json.loads(content)
 
-@strax.URLConfig.register('take')
+@URLConfig.register('take')
 def get_key(container, take=None, **kwargs):
     ''' return a single element of a container
     '''
@@ -202,7 +202,7 @@ def get_key(container, take=None, **kwargs):
         return container
     return container[take]
 
-@strax.URLConfig.register('format')
+@URLConfig.register('format')
 def format_arg(arg, **kwargs):
     '''apply pythons builtin format function to a string
     '''

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -1,10 +1,8 @@
-
 import json
 import strax
 import fsspec
 import pandas as pd
 import straxen
-from numpy import isin
 import inspect
 from urllib.parse import urlparse, parse_qs
 from ast import literal_eval
@@ -38,7 +36,7 @@ class URLConfig(strax.Config):
         """
         :param cache: number of values to keep in cache, 
                       if set to True will cache all values
-        :param \**kwargs: additional keyword arguments accepted by strax.Option              
+        :param **kwargs: additional keyword arguments accepted by strax.Option
         """
         self.final_type = OMITTED
         super().__init__(**kwargs)
@@ -79,7 +77,7 @@ class URLConfig(strax.Config):
         overrides are passed to any protocol whos signature can accept them.
         """
         
-        # seperate the protocol name from the path
+        # separate the protocol name from the path
         protocol, _, path =  url.partition(self.SCHEME_SEP)
 
         # find the corresponding protocol method
@@ -109,13 +107,13 @@ class URLConfig(strax.Config):
         """
         path, _, _ = url.partition(self.QUERY_SEP)
         kwargs = {}
-        for k,v in parse_qs(urlparse(url).query).items():
+        for k, v in parse_qs(urlparse(url).query).items():
             # values of query arguments are evaluated as lists
             # split logic depending on length
             n = len(v)
             if not n:
                 kwargs[k] = None
-            elif n==1:
+            elif n == 1:
                 kwargs[k] = parse_val(v[0])
             else:
                 kwargs[k] = map(parse_val, v)
@@ -131,7 +129,7 @@ class URLConfig(strax.Config):
         if any([str(p).startswith('**') for p in params.values()]):
             # if func accepts wildcard kwargs, return all
             return kwargs
-        return {k:v for k,v in kwargs.items() if k in params}
+        return {k: v for k, v in kwargs.items() if k in params}
 
     def fetch(self, plugin):
         '''override the Config.fetch method
@@ -151,12 +149,12 @@ class URLConfig(strax.Config):
             # as string-literal config and returned as is
             return url
 
-        # sperate out the query part of the URL which 
+        # separate out the query part of the URL which
         # will become the method kwargs
         url, url_kwargs = self.split_url_kwargs(url)
 
         kwargs = {}
-        for k,v in url_kwargs.items():
+        for k, v in url_kwargs.items():
             if isinstance(v, str) and v.startswith(self.PLUGIN_ATTR_PREFIX):
                 # kwarg is referring to a plugin attribute, lets fetch it
                 kwargs[k] = getattr(plugin, v[len(self.PLUGIN_ATTR_PREFIX):], v)
@@ -169,7 +167,7 @@ class URLConfig(strax.Config):
     @classmethod
     def protocol_descr(cls):
         rows = []
-        for k,v in cls._LOOKUP.items():
+        for k, v in cls._LOOKUP.items():
             row = {
                 'name': f"{k}://",
                 'description': v.__doc__,
@@ -190,7 +188,7 @@ def get_correction(name, run_id=None, version='ONLINE', detector='nt', **kwargs)
     '''
     if run_id is None:
         raise ValueError('Attempting to fetch a correction without a run id.')
-    return straxen.get_correction_from_cmt(run_id, ( name, version, detector=='nt'))
+    return straxen.get_correction_from_cmt(run_id, (name, version, detector=='nt'))
 
 
 @URLConfig.register('resource')

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -2,6 +2,7 @@
 import json
 import strax
 import fsspec
+import pandas as pd
 import straxen
 from numpy import isin
 import inspect
@@ -164,7 +165,25 @@ class URLConfig(strax.Config):
                 kwargs[k] = v
         
         return self.dispatch(url, **kwargs)
- 
+    
+    @classmethod
+    def protocol_descr(cls):
+        rows = []
+        for k,v in cls._LOOKUP.items():
+            row = {
+                'name': f"{k}://",
+                'description': v.__doc__,
+                'signature': str(inspect.signature(v)),
+            }
+            rows.append(row)
+        return pd.DataFrame(rows)
+
+    @classmethod
+    def print_protocols(cls):
+        df = cls.protocol_descr()
+        print(df)
+
+
 @URLConfig.register('cmt')
 def get_correction(name, run_id=None, version='ONLINE', detector='nt', **kwargs):
     '''Get value for name from CMT

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -106,7 +106,7 @@ class URLConfig(strax.Config):
     def split_url_kwargs(self, url):
         """split a url into path and kwargs
         """
-        path, _, _ = url.rpartition(self.QUERY_SEP)
+        path, _, _ = url.partition(self.QUERY_SEP)
         kwargs = {}
         for k,v in parse_qs(urlparse(url).query).items():
             # values of query arguments are evaluated as lists

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -192,6 +192,7 @@ def get_correction(name, run_id=None, version='ONLINE', detector='nt', **kwargs)
         raise ValueError('Attempting to fetch a correction without a run id.')
     return straxen.get_correction_from_cmt(run_id, ( name, version, detector=='nt'))
 
+
 @URLConfig.register('resource')
 def get_resource(name, fmt='text', **kwargs):
     '''Fetch a straxen resource
@@ -207,11 +208,13 @@ def read_file(path, **kwargs):
         content = f.read()
     return content
 
+
 @URLConfig.register('json')
 def read_json(content, **kwargs):
     ''' Load json string as a python object
     '''
     return json.loads(content)
+
 
 @URLConfig.register('take')
 def get_key(container, take=None, **kwargs):
@@ -221,9 +224,9 @@ def get_key(container, take=None, **kwargs):
         return container
     return container[take]
 
+
 @URLConfig.register('format')
 def format_arg(arg, **kwargs):
     '''apply pythons builtin format function to a string
     '''
     return arg.format(**kwargs)
-    

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -1,4 +1,5 @@
 import json
+from typing import Container
 import strax
 import fsspec
 import pandas as pd
@@ -183,7 +184,7 @@ class URLConfig(strax.Config):
 
 
 @URLConfig.register('cmt')
-def get_correction(name, run_id=None, version='ONLINE', detector='nt', **kwargs):
+def get_correction(name: str, run_id: str=None, version: str='ONLINE', detector: str='nt', **kwargs):
     '''Get value for name from CMT
     '''
     if run_id is None:
@@ -192,14 +193,14 @@ def get_correction(name, run_id=None, version='ONLINE', detector='nt', **kwargs)
 
 
 @URLConfig.register('resource')
-def get_resource(name, fmt='text', **kwargs):
+def get_resource(name: str, fmt: str='text', **kwargs):
     '''Fetch a straxen resource
     '''
     return straxen.get_resource(name, fmt=fmt)
 
 
 @URLConfig.register('fsspec')
-def read_file(path, **kwargs):
+def read_file(path: str, **kwargs):
     '''Support fetching files from arbitrary filesystems
     '''
     with fsspec.open(path, **kwargs) as f:
@@ -208,14 +209,14 @@ def read_file(path, **kwargs):
 
 
 @URLConfig.register('json')
-def read_json(content, **kwargs):
+def read_json(content: str, **kwargs):
     ''' Load json string as a python object
     '''
     return json.loads(content)
 
 
 @URLConfig.register('take')
-def get_key(container, take=None, **kwargs):
+def get_key(container: Container, take=None, **kwargs):
     ''' return a single element of a container
     '''
     if take is None:
@@ -224,7 +225,7 @@ def get_key(container, take=None, **kwargs):
 
 
 @URLConfig.register('format')
-def format_arg(arg, **kwargs):
+def format_arg(arg: str, **kwargs):
     '''apply pythons builtin format function to a string
     '''
     return arg.format(**kwargs)

--- a/tests/test_mongo_interactions.py
+++ b/tests/test_mongo_interactions.py
@@ -7,6 +7,7 @@ not show up in Pull Requests.
 import straxen
 import os
 import unittest
+from pymongo import ReadPreference
 
 
 @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
@@ -71,7 +72,9 @@ def test_online_monitor(target='online_peak_monitor', max_tries=3):
         if max_run is not None:
             # One run failed before, lets try a more recent one.
             query.update({'number': {"$gt": int(max_run)}})
-        some_run = om.db[om.col_name].find_one(query,
+        collection = om.db[om.col_name].with_options(
+                        read_preference=ReadPreference.SECONDARY_PREFERRED)
+        some_run = collection.find_one(query,
                                                projection={'number': 1,
                                                            'metadata': 1,
                                                            'lineage_hash': 1,

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -1,7 +1,9 @@
 
+import json
 import strax
 import straxen
 import numpy as np
+import fsspec
 from warnings import warn
 from straxen.test_utils import nt_test_context, nt_test_run_id
 import unittest
@@ -15,7 +17,6 @@ class TestPlugin(strax.Plugin):
     
     def compute(self):
         pass
-
 
 class TestURLConfig(unittest.TestCase):
     def setUp(self):
@@ -47,6 +48,13 @@ class TestURLConfig(unittest.TestCase):
         self.st.set_config({'test_config': 'format://{run_id}?run_id=plugin.run_id'})
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
         self.assertEqual(p.test_config , nt_test_run_id)
+    
+    def test_fsspec_protocol(self):
+        with fsspec.open('memory://test_file.json', mode='w') as f:
+            json.dump({"value": 999}, f)
+        self.st.set_config({'test_config': 'take://json://fsspec://memory://test_file.json?take=value'})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config , 999)
 
     def test_chained(self):
         self.st.set_config({'test_config': 'take://json://[1,2,3]?take=0'})

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -1,0 +1,54 @@
+
+import strax
+import straxen
+import numpy as np
+from warnings import warn
+from straxen.test_utils import nt_test_context, nt_test_run_id
+import unittest
+
+
+class TestPlugin(strax.Plugin):
+    depends_on = ()
+    dtype = strax.time_fields
+    provides = ('test_data',)
+    test_config = straxen.URLConfig(default=42,)
+    
+    def compute(self):
+        pass
+
+
+class TestURLConfig(unittest.TestCase):
+    def setUp(self):
+        st = nt_test_context()
+        st.register(TestPlugin)
+        self.st = st
+
+    def test_default(self):
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config , 42)
+
+    def test_literal(self):
+        self.st.set_config({'test_config': 666})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config , 666)
+
+    def test_cmt_protocol(self):
+        self.st.set_config({'test_config': 'cmt://elife?version=v1&run_id=plugin.run_id'})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertTrue(abs(p.test_config-219203.49884000001)<1e-2)
+
+    def test_json_protocol(self):
+        self.st.set_config({'test_config': 'json://[1,2,3]'})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config , [1,2,3])
+
+    def test_format_protocol(self):
+        self.st.set_config({'test_config': 'format://{run_id}?run_id=plugin.run_id'})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config , nt_test_run_id)
+
+    def test_chained(self):
+        self.st.set_config({'test_config': 'take://json://[1,2,3]?take=0'})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config , 1)
+    

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -32,6 +32,7 @@ class TestURLConfig(unittest.TestCase):
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
         self.assertEqual(p.test_config , 666)
 
+    @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test CMT.")
     def test_cmt_protocol(self):
         self.st.set_config({'test_config': 'cmt://elife?version=v1&run_id=plugin.run_id'})
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -1,10 +1,7 @@
-
 import json
 import strax
 import straxen
-import numpy as np
 import fsspec
-from warnings import warn
 from straxen.test_utils import nt_test_context, nt_test_run_id
 import unittest
 
@@ -14,9 +11,10 @@ class TestPlugin(strax.Plugin):
     dtype = strax.time_fields
     provides = ('test_data',)
     test_config = straxen.URLConfig(default=42,)
-    
+
     def compute(self):
         pass
+
 
 class TestURLConfig(unittest.TestCase):
     def setUp(self):
@@ -26,12 +24,12 @@ class TestURLConfig(unittest.TestCase):
 
     def test_default(self):
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
-        self.assertEqual(p.test_config , 42)
+        self.assertEqual(p.test_config, 42)
 
     def test_literal(self):
         self.st.set_config({'test_config': 666})
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
-        self.assertEqual(p.test_config , 666)
+        self.assertEqual(p.test_config, 666)
 
     @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test CMT.")
     def test_cmt_protocol(self):
@@ -42,22 +40,25 @@ class TestURLConfig(unittest.TestCase):
     def test_json_protocol(self):
         self.st.set_config({'test_config': 'json://[1,2,3]'})
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
-        self.assertEqual(p.test_config , [1,2,3])
+        self.assertEqual(p.test_config, [1,2,3])
 
     def test_format_protocol(self):
         self.st.set_config({'test_config': 'format://{run_id}?run_id=plugin.run_id'})
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
-        self.assertEqual(p.test_config , nt_test_run_id)
-    
+        self.assertEqual(p.test_config, nt_test_run_id)
+
     def test_fsspec_protocol(self):
         with fsspec.open('memory://test_file.json', mode='w') as f:
             json.dump({"value": 999}, f)
-        self.st.set_config({'test_config': 'take://json://fsspec://memory://test_file.json?take=value'})
+        self.st.set_config(
+            {'test_config': 'take://json://fsspec://memory://test_file.json?take=value'})
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
-        self.assertEqual(p.test_config , 999)
+        self.assertEqual(p.test_config, 999)
 
     def test_chained(self):
         self.st.set_config({'test_config': 'take://json://[1,2,3]?take=0'})
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
-        self.assertEqual(p.test_config , 1)
-    
+        self.assertEqual(p.test_config, 1)
+
+    def test_print_protocol_desc(self):
+        straxen.URLConfig.print_protocols()


### PR DESCRIPTION
There is a small bug here, I presume from this PR originating in strax or vice versa? 

In current release, I get:

```
>>> from straxen.url_config import URLConfig
[lots of UserWarnings...]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/cvmfs/xenon.opensciencegrid.org/releases/nT/development/anaconda/envs/XENONnT_development/lib/python3.8/site-packages/straxen/url_config.py", line 168, in <module>
    @strax.URLConfig.register('cmt')
AttributeError: module 'strax' has no attribute 'URLConfig'
```

This PR should fix this bug. 
