### PR TITLE
Update EnergyEstimates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy~=1.19.5
 packaging~=20.8
+pymongo<=3.12.0
 strax>=1.1.2
 utilix>=0.5.3
 # tensorflow>=2.3.0  # Optional, to (re)do posrec

--- a/straxen/__init__.py
+++ b/straxen/__init__.py
@@ -16,7 +16,7 @@ from .rundb import *
 from .scada import *
 from .bokeh_utils import *
 from .rucio import *
-
+from .url_config import *
 from . import plugins
 from .plugins import *
 

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -20,7 +20,9 @@ corrections_w_file = ['mlp_model', 'cnn_model', 'gcn_model',
                       'fdc_map_mlp', 'fdc_map_cnn', 'fdc_map_gcn']
 
 single_value_corrections = ['elife_xenon1t', 'elife', 'baseline_samples_nv',
-                            'electron_drift_velocity', 'electron_drift_time_gate']
+                            'electron_drift_velocity', 'electron_drift_time_gate',
+                            'se_gain', 'rel_extraction_eff'
+                            ]
 
 arrays_corrections = ['hit_thresholds_tpc', 'hit_thresholds_he',
                       'hit_thresholds_nv', 'hit_thresholds_mv']

--- a/straxen/mongo_storage.py
+++ b/straxen/mongo_storage.py
@@ -112,6 +112,7 @@ class GridFsInterface:
         doc = self.get_query_config(config)
         doc.update({
             'added': datetime.now(tz=pytz.utc),
+            
         })
         return doc
 
@@ -247,6 +248,7 @@ class MongoUploader(GridFsInterface):
         :param abs_path: str, the absolute path of the file 
         """
         doc = self.document_format(config)
+        doc['md5'] = self.compute_md5(abs_path)
         if not os.path.exists(abs_path):
             raise CouldNotLoadError(f'{abs_path} does not exits')
 

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -626,8 +626,10 @@ class CorrectedAreas(strax.Plugin):
     """
     Plugin which applies light collection efficiency maps and electron
     life time to the data.
+
     Computes the cS1/cS2 for the main/alternative S1/S2 as well as the
     corrected life time.
+
     Note:
         Please be aware that for both, the main and alternative S1, the
         area is corrected according to the xy-position of the main S2.
@@ -652,7 +654,7 @@ class CorrectedAreas(strax.Plugin):
                        f'Fraction of area seen by the top PMT array for corrected {peak_name} S2'),
                       (f'{peak_type}cs2_bottom', np.float32,
                        f'Corrected area of {peak_name} S2 in the bottom PMT array [PE]'),
-                      (f'{peak_type}cs2', np.float32, f'Corrected area of {peak_name} S2 [PE]'), ]
+                      (f'{peak_type}cs2', np.float32, f'Corrected area of {peak_name} S2 [PE]'),]
 
         return dtype
 

--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -278,7 +278,7 @@ class RunDB(strax.StorageFrontend):
             projection=projection)
         for doc in strax.utils.tqdm(
                 cursor, desc='Fetching run info from MongoDB',
-                total=cursor.count()):
+                total=self.collection.count_documents(query)):
             del doc['_id']
             if self.reader_ini_name_is_mode:
                 doc['mode'] = \

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -165,7 +165,7 @@ class URLConfig(strax.Config):
         
         return self.dispatch(url, **kwargs)
  
-@strax.URLConfig.register('cmt')
+@URLConfig.register('cmt')
 def get_correction(name, run_id=None, version='ONLINE', detector='nt', **kwargs):
     '''Get value for name from CMT
     '''
@@ -173,14 +173,14 @@ def get_correction(name, run_id=None, version='ONLINE', detector='nt', **kwargs)
         raise ValueError('Attempting to fetch a correction without a run id.')
     return straxen.get_correction_from_cmt(run_id, ( name, version, detector=='nt'))
 
-@strax.URLConfig.register('resource')
+@URLConfig.register('resource')
 def get_resource(name, fmt='text', **kwargs):
     '''Fetch a straxen resource
     '''
     return straxen.get_resource(name, fmt=fmt)
 
 
-@strax.URLConfig.register('fsspec')
+@URLConfig.register('fsspec')
 def read_file(path, **kwargs):
     '''Support fetching files from arbitrary filesystems
     '''
@@ -188,13 +188,13 @@ def read_file(path, **kwargs):
         content = f.read()
     return content
 
-@strax.URLConfig.register('json')
+@URLConfig.register('json')
 def read_json(content, **kwargs):
     ''' Load json string as a python object
     '''
     return json.loads(content)
 
-@strax.URLConfig.register('take')
+@URLConfig.register('take')
 def get_key(container, take=None, **kwargs):
     ''' return a single element of a container
     '''
@@ -202,7 +202,7 @@ def get_key(container, take=None, **kwargs):
         return container
     return container[take]
 
-@strax.URLConfig.register('format')
+@URLConfig.register('format')
 def format_arg(arg, **kwargs):
     '''apply pythons builtin format function to a string
     '''

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -2,6 +2,7 @@
 import json
 import strax
 import fsspec
+import pandas as pd
 import straxen
 from numpy import isin
 import inspect
@@ -164,7 +165,25 @@ class URLConfig(strax.Config):
                 kwargs[k] = v
         
         return self.dispatch(url, **kwargs)
- 
+    
+    @classmethod
+    def protocol_descr(cls):
+        rows = []
+        for k,v in cls._LOOKUP.items():
+            row = {
+                'name': f"{k}://",
+                'description': v.__doc__,
+                'signature': str(inspect.signature(v)),
+            }
+            rows.append(row)
+        return pd.DataFrame(rows)
+
+    @classmethod
+    def print_protocols(cls):
+        df = cls.protocol_descr()
+        print(df)
+
+
 @URLConfig.register('cmt')
 def get_correction(name, run_id=None, version='ONLINE', detector='nt', **kwargs):
     '''Get value for name from CMT

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -106,7 +106,7 @@ class URLConfig(strax.Config):
     def split_url_kwargs(self, url):
         """split a url into path and kwargs
         """
-        path, _, _ = url.rpartition(self.QUERY_SEP)
+        path, _, _ = url.partition(self.QUERY_SEP)
         kwargs = {}
         for k,v in parse_qs(urlparse(url).query).items():
             # values of query arguments are evaluated as lists

--- a/tests/test_mongo_interactions.py
+++ b/tests/test_mongo_interactions.py
@@ -7,6 +7,7 @@ not show up in Pull Requests.
 import straxen
 import os
 import unittest
+from pymongo import ReadPreference
 
 
 @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
@@ -71,7 +72,9 @@ def test_online_monitor(target='online_peak_monitor', max_tries=3):
         if max_run is not None:
             # One run failed before, lets try a more recent one.
             query.update({'number': {"$gt": int(max_run)}})
-        some_run = om.db[om.col_name].find_one(query,
+        collection = om.db[om.col_name].with_options(
+                        read_preference=ReadPreference.SECONDARY_PREFERRED)
+        some_run = collection.find_one(query,
                                                projection={'number': 1,
                                                            'metadata': 1,
                                                            'lineage_hash': 1,

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -1,0 +1,54 @@
+
+import strax
+import straxen
+import numpy as np
+from warnings import warn
+from straxen.test_utils import nt_test_context, nt_test_run_id
+import unittest
+
+
+class TestPlugin(strax.Plugin):
+    depends_on = ()
+    dtype = strax.time_fields
+    provides = ('test_data',)
+    test_config = straxen.URLConfig(default=42,)
+    
+    def compute(self):
+        pass
+
+
+class TestURLConfig(unittest.TestCase):
+    def setUp(self):
+        st = nt_test_context()
+        st.register(TestPlugin)
+        self.st = st
+
+    def test_default(self):
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config , 42)
+
+    def test_literal(self):
+        self.st.set_config({'test_config': 666})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config , 666)
+
+    def test_cmt_protocol(self):
+        self.st.set_config({'test_config': 'cmt://elife?version=v1&run_id=plugin.run_id'})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertTrue(abs(p.test_config-219203.49884000001)<1e-2)
+
+    def test_json_protocol(self):
+        self.st.set_config({'test_config': 'json://[1,2,3]'})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config , [1,2,3])
+
+    def test_format_protocol(self):
+        self.st.set_config({'test_config': 'format://{run_id}?run_id=plugin.run_id'})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config , nt_test_run_id)
+
+    def test_chained(self):
+        self.st.set_config({'test_config': 'take://json://[1,2,3]?take=0'})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config , 1)
+    

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -32,6 +32,7 @@ class TestURLConfig(unittest.TestCase):
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
         self.assertEqual(p.test_config , 666)
 
+    @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test CMT.")
     def test_cmt_protocol(self):
         self.st.set_config({'test_config': 'cmt://elife?version=v1&run_id=plugin.run_id'})
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
This updates the EnergyEstimates plugin to use the new [descriptor config](https://github.com/AxFoundation/strax/pull/550) format, and also adds a few more variables which might be useful parameter spaces to plot things in: 

 - `n_electrons` which is cs2/g2, and includes relative changes in SE gain and extraction efficiency. 
 - `n_photons` which is cs1/g1
 - `tcs2` which is a 'time-corrected' S2 which allows for relative changes in SE gain and extraction efficiency to be corrected for at S2 level. 

It also adds a variable to the CMT hardcoded list. 

The goal is to make it a bit easier to compare data from times when detector conditions might be slightly different, like described in @Jianyu010's [note](https://xe1t-wiki.lngs.infn.it/doku.php?id=jlong:sr0_ramp_up_kr_se_study)

## Can you briefly describe how it works?
It's rather straightforward, just adds a few more config options (which will go through CMT, work in progress) and then makes correction.

## Can you give a minimal working example (or illustrate with a figure)?
I tested it locally when modifying this plugin on top of straxen v1.1.3.  I still need to test it on straxen master, but I don't anticipate issues. 



