### PR TITLE
Another update to CorrectedAreas: Use CMT tuples instead of URLConfigs

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -463,6 +463,9 @@ x1t_common_config = dict(
     electron_drift_velocity=("electron_drift_velocity_constant", 1.3325e-4),
     max_drift_length=96.9,
     electron_drift_time_gate=("electron_drift_time_gate_constant", 1700),
+    avg_se_gain=('avg_se_gain_constant', 28.2),
+    se_gain=('se_gain_constant', 28.2),
+    rel_extraction_eff=('rel_extraction_eff_constant', 1.0)
 )
 
 

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -370,8 +370,8 @@ def apply_cmt_version(context: strax.Context, cmt_global_version: str):
         # if we are on a fixed offline version, raise an error.
         if "ONLINE" in cmt_global_version:
             warnings.warn("CMT {cmt_global_version} is missing these corrections: {failed_keys}")
-        # else:
-        #     raise CMTVersionError(f"CMT version {cmt_global_version} is not compatible with this straxen version! "
-        #                           f"CMT {cmt_global_version} is missing these corrections: {failed_keys}")
+        else:
+            raise CMTVersionError(f"CMT version {cmt_global_version} is not compatible with this straxen version! "
+                                  f"CMT {cmt_global_version} is missing these corrections: {failed_keys}")
 
     context.set_config(cmt_config)

--- a/straxen/test_utils.py
+++ b/straxen/test_utils.py
@@ -58,7 +58,10 @@ _testing_config_nT = dict(
     hit_min_amplitude='pmt_commissioning_initial',
     hit_min_amplitude_nv=20,
     hit_min_amplitude_mv=80,
-    hit_min_amplitude_he='pmt_commissioning_initial_he'
+    hit_min_amplitude_he='pmt_commissioning_initial_he',
+    se_gain=('se_gain_constant', 1),
+    avg_se_gain=('avg_se_gain_constant', 1),
+    rel_extraction_eff=('eff_constant', 1),
 )
 
 


### PR DESCRIPTION

## What does the code in this PR do / what does it improve?
Same thing as #817, but doesn't use URLConfigs as they are interfering with CMT-related functions like `apply_global_version`, `get_cmt_options`, etc. I think maybe the switch to URLConfigs should wait until CMT2.0, unfortunately :/ 

I will use #817 to instead start switching everythning to URLConfigs, and we can maybe merge it later on along with #816. 

## Can you briefly describe how it works?
It's yet another attempt to get this `tcs2` variable in, but this time using the tuple CMT configs instead of the new URLConfig.


