### PR TITLE
Unittest for DAQreader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # XENON secrets: run database passwords, S3 keys, etc.
 # Though these are readonly, they should not be committed to a public repo.
 xenon_secrets.py
+.xenon_config
 
 # Jupyter
 .ipynb_checkpoints
@@ -11,6 +12,8 @@ xenon_secrets.py
 *.npy
 *.blosc
 *.h5
+live_data
+daq_test_data
 strax_data
 strax_test_data
 from_fake_daq

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -54,8 +54,6 @@ class ArtificialDeadtimeInserted(UserWarning):
                  help="Time (ns) between pulses indicating a safe break "
                       "in the datastream -- gaps of this size cannot be "
                       "interior to peaklets."),
-    strax.Option('erase', default=False, track=False, infer_type=False,
-                 help="Delete reader data after processing"),
     strax.Option('channel_map', track=False, type=immutabledict, infer_type=False,
                  help="immutabledict mapping subdetector to (min, max) "
                       "channel number."))
@@ -270,9 +268,6 @@ class DAQReader(strax.Plugin):
                                             self._artificial_dead_time(
                                                 start=dead_time_start,
                                                 end=break_time, dt=self.dt_max)]))
-
-        if self.config['erase']:
-            shutil.rmtree(path)
         return result, break_time
 
     def _artificial_dead_time(self, start, end, dt):

--- a/tests/test_daq_reader.py
+++ b/tests/test_daq_reader.py
@@ -35,6 +35,16 @@ class TestDAQReader(unittest.TestCase):
     """
     Test DAQReader with a few chunks of amstrax data:
     https://github.com/XAMS-nikhef/amstrax
+
+
+    This class is structured with three parts:
+      - A. The test(s) where we execute some tests to make sure the
+      DAQ-reader works well;
+      - B. Setup and teardown logic which downloads/removes test data if
+      we run this test so that we get a fresh sample of data every time
+      we run this test;
+      - C. Some utility functions for part A and B (like setting the
+      context etc).
     """
 
     run_id = '999999'
@@ -43,8 +53,7 @@ class TestDAQReader(unittest.TestCase):
     rundoc_file = 'https://raw.githubusercontent.com/XAMS-nikhef/amstrax_files/73681f112d748f6cd0e95045970dd29c44e983b0/data/rundoc_999999.json'  # noqa
     data_file = 'https://raw.githubusercontent.com/XAMS-nikhef/amstrax_files/73681f112d748f6cd0e95045970dd29c44e983b0/data/999999.tar'  # noqa
 
-    # Tests
-    # -----
+    # # Part A. the actual tests
     def test_make(self) -> None:
         """
         Test if we can run the daq-reader without chrashing and if we
@@ -87,8 +96,7 @@ class TestDAQReader(unittest.TestCase):
         with self.assertRaises(ValueError):
             st.make(self.run_id, 'raw_records')
 
-    # Setup of tests like getting data and removing it after the test
-    # ---------------------------------------------------------------
+    # # Part B. data-download and cleanup
     @classmethod
     def setUpClass(cls) -> None:
         st = strax.Context()
@@ -119,8 +127,7 @@ class TestDAQReader(unittest.TestCase):
             shutil.rmtree(data_path)
             print(f'rm {data_path}')
 
-    # Small utility functions needed in setup
-    # ---------------------------------------------------------------
+    # # Part C. Some utility functions for A & B
     def download_test_data(self):
         download_test_data(self.data_file)
         self.assertTrue(os.path.exists(self.live_data_path))

--- a/tests/test_daq_reader.py
+++ b/tests/test_daq_reader.py
@@ -1,0 +1,146 @@
+import datetime
+import os
+import shutil
+import unittest
+import strax
+from straxen import download_test_data, get_resource
+from straxen.plugins.daqreader import ArtificialDeadtimeInserted, DAQReader, ARTIFICIAL_DEADTIME_CHANNEL
+from datetime import timezone
+from time import sleep
+
+
+class DummyDAQReader(DAQReader):
+    """Dummy version of DAQReader with different provides and different lineage"""
+    __version__ = 'test_0.0.0'
+    provides = ['raw_records',
+                'raw_records_nv',
+                'raw_records_aqmon',
+                ]
+    data_kind = dict(zip(provides, provides))
+    depends_on = tuple()
+    parallel = 'process'
+    chunk_target_size_mb = 50
+    rechunk_on_save = False
+
+    def _path(self, chunk_i):
+        path = super()._path(chunk_i)
+        print(f'looked for {chunk_i} on {path}. Is found = {os.path.exists(path)}')
+        return path
+
+
+class TestDAQReader(unittest.TestCase):
+    """
+    Test DAQReader with a few chunks of amstrax data:
+    https://github.com/XAMS-nikhef/amstrax
+    """
+    run_id = '999999'
+    run_doc_name = 'rundoc_999999.json'
+    live_data_path = f'./live_data/{run_id}'
+    rundoc_file = 'https://raw.githubusercontent.com/XAMS-nikhef/amstrax_files/73681f112d748f6cd0e95045970dd29c44e983b0/data/rundoc_999999.json'  # noqa
+    data_file = 'https://raw.githubusercontent.com/XAMS-nikhef/amstrax_files/73681f112d748f6cd0e95045970dd29c44e983b0/data/999999.tar'  # noqa
+
+    # Tests
+    # -----
+    def test_make(self) -> None:
+        """
+        Test if we can run the daq-reader without chrashing and if we
+        actually stored the data after making it.
+        """
+        run_id = self.run_id
+        for target, plugin_class in self.st._plugin_class_registry.items():
+            self.st.make(run_id, target)
+            sleep(0.5)  # allow os to rename the file
+            if plugin_class.save_when >= strax.SaveWhen.TARGET:
+                self.assertTrue(
+                    self.st.is_stored(run_id, target)
+                )
+
+    def test_insert_deadtime(self):
+        """
+        In the DAQ reader, we need a mimimium quiet period to say where
+        we can start/end a chunk. Test that this information gets
+        propagated to the ARTIFICIAL_DEADTIME_CHANNEL (in
+        raw-records-aqmon) if we set this value to an unrealistic value
+        of 0.5 s.
+        """
+        st = self.st
+        st.set_config({'safe_break_in_pulses': int(0.5e9)})
+
+        with self.assertWarns(ArtificialDeadtimeInserted):
+            self.st.make(self.run_id, 'raw_records')
+        #
+        rr_aqmon = st.get_array(self.run_id, 'raw_records_aqmon')
+        self.assertTrue(len(rr_aqmon))
+
+    # Setup of tests like getting data and removing it after the test
+    # ---------------------------------------------------------------
+    @classmethod
+    def setUpClass(cls) -> None:
+        st = strax.Context()
+        st.register(DummyDAQReader)
+        st.storage = [strax.DataDirectory('./daq_test_data')]
+        st.set_config({'daq_input_dir': cls.live_data_path})
+        cls.st = st
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        path_live = f'live_data/{cls.run_id}'
+        if os.path.exists(path_live):
+            shutil.rmtree(path_live)
+            print(f'rm {path_live}')
+
+    def setUp(self) -> None:
+        if not os.path.exists(self.live_data_path):
+            print(f'Fetch {self.live_data_path}')
+            self.get_test_data()
+        rd = self.get_metadata()
+        st = self.set_context_config(self.st, rd)
+        self.st = st
+        self.assertFalse(self.st.is_stored(self.run_id, 'raw_records'))
+
+    def tearDown(self) -> None:
+        data_path = self.st.storage[0].path
+        if os.path.exists(data_path):
+            shutil.rmtree(data_path)
+            print(f'rm {data_path}')
+
+    # Small utility functions needed in setup
+    # ---------------------------------------------------------------
+    def get_test_data(self):
+        download_test_data(self.data_file)
+        self.assertTrue(os.path.exists(self.live_data_path))
+
+    def get_metadata(self):
+        md = get_resource(self.rundoc_file, fmt='json')
+        # This is a flat dict but we need to have a datetime object,
+        # since this is only a test, let's just replace it with a
+        # placeholder
+        md['start'] = datetime.datetime.now()
+        return md
+
+    @staticmethod
+    def set_context_config(st, run_doc):
+        """Update context with fields needed by the DAQ reader"""
+        daq_config = run_doc['daq_config']
+        st.set_context_config(dict(forbid_creation_of=tuple()))
+        st.set_config({
+            'channel_map':
+                dict(
+                    # (Minimum channel, maximum channel)
+                    # Channels must be listed in a ascending order!
+                    tpc=(0, 1),
+                    nveto=(1, 2),
+                    aqmon=(ARTIFICIAL_DEADTIME_CHANNEL, ARTIFICIAL_DEADTIME_CHANNEL+1),
+                )})
+        update_config = {
+            'readout_threads': daq_config['processing_threads'],
+            'record_length': daq_config['strax_fragment_payload_bytes'] // 2,
+            'max_digitizer_sampling_time': 10,
+            'run_start_time': run_doc['start'].replace(tzinfo=timezone.utc).timestamp(),
+            'daq_chunk_duration': int(daq_config['strax_chunk_length'] * 1e9),
+            'daq_overlap_chunk_duration': int(daq_config['strax_chunk_overlap'] * 1e9),
+            'compressor': daq_config.get('compressor', 'lz4')
+            }
+        print(f'set config to {update_config}')
+        st.set_config(update_config)
+        return st

--- a/tests/test_daq_reader.py
+++ b/tests/test_daq_reader.py
@@ -9,6 +9,7 @@ from straxen.plugins.daqreader import ArtificialDeadtimeInserted, \
 from datetime import timezone, datetime
 from time import sleep
 
+
 class DummyDAQReader(DAQReader):
     """Dummy version of DAQReader with different provides and different lineage"""
     provides = ['raw_records',
@@ -16,14 +17,11 @@ class DummyDAQReader(DAQReader):
                 'raw_records_aqmon',
                 ]
     dummy_version = strax.Config(
-        default=0,
+        default=None,
         track=True,
-        type=int,
-        help="Number of samples per raw_record",
+        help="Extra option to make sure that we are getting a different lineage if we want to",
     )
     data_kind = dict(zip(provides, provides))
-    parallel = 'process'
-    chunk_target_size_mb = 50
     rechunk_on_save = False
 
     def _path(self, chunk_i):


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
 - This PR adds a test for the DAQReader. We should have added this _much_ earlier but now it's finally here.
 - Remove the `erase` option. It's one horribly bad idea to ever, ever do this.

## Can you briefly describe how it works?
Download some test data from [Nikhefs XAMS ](https://github.com/XAMS-nikhef/amstrax)experiment also using redax from https://github.com/XAMS-nikhef/amstrax_files

This data is ideal as we only have a few chunks and only a few channels

## Can you give a minimal working example (or illustrate with a figure)?
Please see `tests/test_daq_reader.py` 

## Time info
The entire test takes about 10 s.

## Coverage
![afbeelding](https://user-images.githubusercontent.com/22295914/146529407-e7d45f64-ac89-42f6-a734-46e79d3e4620.png)
