### PR TITLE
Fix nv testing data

### DIFF
--- a/straxen/test_utils.py
+++ b/straxen/test_utils.py
@@ -108,7 +108,7 @@ def nt_test_context(target_context='xenonnt_online',
     st = getattr(straxen.contexts, target_context)(**kwargs)
     st._plugin_class_registry['raw_records'].__version__ = "MOCKTESTDATA"  # noqa
     st.storage = [strax.DataDirectory('./strax_test_data')]
-    download_test_data('https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/1d3706d4b47cbd23b5cae66d5e258bb84487ad01/strax_files/012882-raw_records-z7q2d2ye2t.tar')  # noqa
+    download_test_data('https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/5adc84d935db5cd4afc751fed18dd04012886580/strax_files/012882-raw_records-z7q2d2ye2t.tar')  # noqa
     assert st.is_stored(nt_test_run_id, 'raw_records'), os.listdir(st.storage[-1].path)
 
     to_remove = list(deregister)

--- a/straxen/test_utils.py
+++ b/straxen/test_utils.py
@@ -103,12 +103,12 @@ def _is_on_pytest():
 
 
 def nt_test_context(target_context='xenonnt_online',
-                    deregister = ('peak_veto_tags', 'events_tagged'),
+                    deregister=('peak_veto_tags', 'events_tagged'),
                     **kwargs):
     st = getattr(straxen.contexts, target_context)(**kwargs)
     st._plugin_class_registry['raw_records'].__version__ = "MOCKTESTDATA"  # noqa
     st.storage = [strax.DataDirectory('./strax_test_data')]
-    download_test_data('https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/5adc84d935db5cd4afc751fed18dd04012886580/strax_files/012882-raw_records-z7q2d2ye2t.tar')  # noqa
+    download_test_data('https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/f0d177401e11408b273564f0e29df77528e83d26/strax_files/012882-raw_records-z7q2d2ye2t.tar')  # noqa
     assert st.is_stored(nt_test_run_id, 'raw_records'), os.listdir(st.storage[-1].path)
 
     to_remove = list(deregister)

--- a/tests/test_mini_analyses.py
+++ b/tests/test_mini_analyses.py
@@ -32,6 +32,10 @@ class TestMiniAnalyses(unittest.TestCase):
     checking if plots et cetera make sense, just if the code is not
     broken (e.g. because for changes in dependencies like matplotlib or
     bokeh)
+
+    NB! If this tests fails locally (but not on github-CI), please do:
+    `rm strax_test_data`
+    You might be an old version of test data.
     """
     # They were added on 25/10/2021 and may be outdated by now
     _expected_test_results = {
@@ -386,14 +390,16 @@ class TestMiniAnalyses(unittest.TestCase):
                      "No db access, cannot test!")
     def test_nv_event_display(self):
         """
-        Test NV event display for a time range without data (should fail)
+        Test NV event display for a single event.
         """
-        self.st.make(nt_test_run_id, 'events_nv')
-        ev_nv = self.st.get_array(nt_test_run_id, 'event_positions_nv')
-        self.assertFalse(ev_nv, "this test assumes NV events are empty")
-        with self.assertRaises(ValueError):
-            self.st.plot_nveto_event_display(nt_test_run_id,
-                                             time_within=self.first_peak)
+        events_nv = self.st.get_array(nt_test_run_id, 'events_nv')
+        warning = ("Do 'rm ./strax_test_data' since your *_nv test "
+                   "data in that folder is messing up this test.")
+        self.assertTrue(len(events_nv), warning)
+        self.st.make(nt_test_run_id, 'event_positions_nv')
+        self.st.plot_nveto_event_display(nt_test_run_id,
+                                         time_within=events_nv[0]
+                                         )
 
 
 def test_plots():


### PR DESCRIPTION
# What does this PR do
Fix some CI testing for nv data. 

## Why/how?
I noticed that the coverage for some NV algorithms was particularly low. This was surprising since @mzks was so kind to provide some data in https://github.com/XENONnT/strax_auxiliary_files/pull/26. I noticed that in https://github.com/XENONnT/straxen/pull/709 I probably pasted the wrong URL, because of which I was still pulling some old data.

## Important note on local testing
As discussed in https://github.com/XENONnT/straxen/pull/703, the setup comes with a caveat. Any changes in the test data results in your `./strax_test_data` folder caching data that I did not erase after testing. This means that after this merge, you have to clean this folder yourself otherwise it will keep using the old data which is incompatible. I added an as clear as possible explanation in the test failure. I only found out because I was surprised this test was failing and had forgotten this myself as well. 