### PR TITLE
Add `strax.Context` documentation, fix #439

### DIFF
--- a/docs/source/build_context_doc.py
+++ b/docs/source/build_context_doc.py
@@ -1,0 +1,34 @@
+import os
+this_dir = os.path.dirname(os.path.realpath(__file__))
+
+
+base_doc = """
+========
+Contexts
+========
+The contexts are a class from strax and used everywhere in straxen
+
+Below, all of the contexts functions are shown including the 
+`minianalyses <https://straxen.readthedocs.io/en/latest/tutorials/mini_analyses.html?`_
+
+
+Contexts documentation
+----------------------
+
+.. automodule:: strax.context
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+"""
+
+
+def main():
+    """Maybe we one day want to expend this, but for now, let's start with this"""
+    out = base_doc
+    with open(this_dir + f'/reference/context.rst', mode='w') as f:
+        f.write(out)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/source/build_context_doc.py
+++ b/docs/source/build_context_doc.py
@@ -13,7 +13,7 @@ Below, all of the contexts functions are shown including the
 
 Contexts documentation
 ----------------------
-Auto generated documention of all the context functions
+Auto generated documention of all the context functions including minianalyses
 
 
 .. automodule:: strax.context

--- a/docs/source/build_context_doc.py
+++ b/docs/source/build_context_doc.py
@@ -9,11 +9,12 @@ Contexts
 The contexts are a class from strax and used everywhere in straxen
 
 Below, all of the contexts functions are shown including the 
-`minianalyses <https://straxen.readthedocs.io/en/latest/tutorials/mini_analyses.html?`_
-
+`minianalyses <https://straxen.readthedocs.io/en/latest/tutorials/mini_analyses.html>`_
 
 Contexts documentation
 ----------------------
+Auto generated documention of all the context functions
+
 
 .. automodule:: strax.context
    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -196,3 +196,5 @@ def setup(app):
     import build_datastructure_doc
     build_datastructure_doc.build_datastructure_doc(True)
     build_datastructure_doc.build_datastructure_doc(False)
+    import build_context_doc
+    build_context_doc.main()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,6 +54,7 @@ Straxen is the analysis framework for XENONnT, built on top of the generic `stra
 
     reference/datastructure_1T
 
+
 .. toctree::
     :maxdepth: 2
     :caption: scripts
@@ -67,6 +68,14 @@ Straxen is the analysis framework for XENONnT, built on top of the generic `stra
 
     scada_interface
     tutorials/ScadaInterfaceExample.ipynb
+
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Context and minianalyses
+
+    reference/context
+
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/reference/context.rst
+++ b/docs/source/reference/context.rst
@@ -1,0 +1,18 @@
+
+========
+Contexts
+========
+The contexts are a class from strax and used everywhere in straxen
+
+Below, all of the contexts functions are shown including the 
+`minianalyses <https://straxen.readthedocs.io/en/latest/tutorials/mini_analyses.html?`_
+
+
+Contexts documentation
+----------------------
+
+.. automodule:: strax.context
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/source/reference/straxen.plugins.rst
+++ b/docs/source/reference/straxen.plugins.rst
@@ -68,14 +68,6 @@ straxen.plugins.event\_processing module
    :undoc-members:
    :show-inheritance:
 
-straxen.plugins.event\_shadow module
-------------------------------------
-
-.. automodule:: straxen.plugins.event_shadow
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 straxen.plugins.led\_calibration module
 ---------------------------------------
 

--- a/docs/source/reference/straxen.rst
+++ b/docs/source/reference/straxen.rst
@@ -165,6 +165,14 @@ straxen.units module
    :undoc-members:
    :show-inheritance:
 
+straxen.url\_config module
+--------------------------
+
+.. automodule:: straxen.url_config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -450,7 +450,6 @@ x1t_common_config = dict(
     # Peaks
     # Smaller right extension since we applied the filter
     peak_right_extension=30,
-    s1_max_rise_time=60,
     s1_max_rise_time_post100=150,
     s1_min_coincidence=3,
     # Events*
@@ -463,7 +462,7 @@ x1t_common_config = dict(
     se_gain=28.2,
     avg_se_gain=28.2,
     rel_extraction_eff=1.0,
-    s1_xyz_map=f'itp_map://resource://{pax_file("XENON1T_s1_xyz_lce_true_kr83m_SR1_pax-680_fdc-3d_v0.json")}?fmt=json',
+    s1_xyz_map=f'itp_map://resource://{pax_file("XENON1T_s1_xyz_lce_true_kr83m_SR1_pax-680_fdc-3d_v0.json")}?fmt=json',  # noqa
     s2_xy_map=f'itp_map://resource://{pax_file("XENON1T_s2_xy_ly_SR1_v2.2.json")}?fmt=json',
     g1=0.1426,
     g2=11.55/(1 - 0.63),


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Fix issue #439, add all the context functions on one place

## Can you briefly describe how it works?
Now it's just a function that adds the strax.Context class with all the minianalyses added!

## Can you give a minimal working example (or illustrate with a figure)?
See the (new) documentation tests on PRs: 
https://straxen--851.org.readthedocs.build/en/851/

I've now added it here:
![afbeelding](https://user-images.githubusercontent.com/22295914/146966434-a29a3116-8df9-4730-8d0e-e637b8833e69.png)
