### PR TITLE
Pymongo requirement should be `<4.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy~=1.19.5
 packaging
-pymongo<=3.12.0
+pymongo<4.0.0
 strax>=1.1.2
 utilix>=0.5.3
 # tensorflow>=2.3.0  # Optional, to (re)do posrec


### PR DESCRIPTION
See title

As explained in https://github.com/XENONnT/straxen/issues/782 we don't want to have `pymongo>=4.0` but we can have e.g. `pymongo==3.12.1`