### PR TITLE
Tests for WFSim contexts

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -289,7 +289,7 @@ def xenonnt_simulation(
         parameters for truth/raw_records from from fax_config file istead of CMT
     :param overwrite_from_fax_file_proc:  If true sets detector processing
         parameters after raw_records(peaklets/events/etc) from from fax_config
-        file istead of CMT
+        file instead of CMT
     :param cmt_option_overwrite_sim: Dictionary to overwrite CMT settings for
         the detector simulation part.
     :param cmt_option_overwrite_proc: Dictionary to overwrite CMT settings for

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -256,7 +256,7 @@ def xenonnt_simulation(
                 _config_overlap=immutabledict(
                             drift_time_gate='electron_drift_time_gate',
                             drift_velocity_liquid='electron_drift_velocity',
-                            electron_lifetime_liquid='elife'  # see issue#864
+                            electron_lifetime_liquid='elife',
                 ),
                 **kwargs):
     """
@@ -268,7 +268,7 @@ def xenonnt_simulation(
     refer to detector simulation parameters.
 
     Arguments having _proc in their name refer to detector parameters that
-    are used for processing of simulations as done to the real datector
+    are used for processing of simulations as done to the real detector
     data. This means starting from already existing raw_records and finishing
     with higher level data, such as peaks, events etc.
 
@@ -340,8 +340,8 @@ def xenonnt_simulation(
     cmt_options_full = straxen.get_corrections.get_cmt_options(st)
 
     # prune to just get the strax options
-    cmt_options = { key: val['strax_option'] 
-                    for key, val in cmt_options_full.items()}
+    cmt_options = {key: val['strax_option']
+                   for key, val in cmt_options_full.items()}
 
     # First, fix gain model for simulation
     st.set_config({'gain_model_mc': 
@@ -385,8 +385,8 @@ def xenonnt_simulation(
                     st.config[cmt_field] = fax_config[fax_field]
                 else:
                     # FIXME: Remove once all cmt configs are URLConfigs
-                    st.config[cmt_field] = ( cmt_options[cmt_field][0] + '_constant',
-                                         fax_config[fax_field])
+                    st.config[cmt_field] = (cmt_options[cmt_field][0] + '_constant',
+                                            fax_config[fax_field])
             if overwrite_from_fax_file_sim:
                 # CMT name allowed to be different from the config name
                 # WFSim needs the cmt name
@@ -426,7 +426,7 @@ def xenonnt_simulation(
             # WFSim needs the cmt name
             cmt_name = cmt_options_full[option]['correction']
             st.config[option] = (cmt_name + '_constant', 
-                                cmt_option_overwrite_proc[option])
+                                 cmt_option_overwrite_proc[option])
     # Only for simulations
     st.set_config({"event_info_function": "disabled"})
 

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -246,7 +246,7 @@ def xenonnt_simulation(
                 wfsim_registry='RawRecordsFromFaxNT',
                 cmt_run_id_sim=None,
                 cmt_run_id_proc=None,
-                cmt_version='global_v5',
+                cmt_version='global_ONLINE',
                 fax_config='fax_config_nt_design.json',
                 overwrite_from_fax_file_sim=False,
                 overwrite_from_fax_file_proc=False,

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -95,17 +95,31 @@ class TestSimContextNT(unittest.TestCase):
         st.search_field('time')
 
     def test_nt_sim_context_alt(self):
+        """Some examples of how to run with a custom WFSim context"""
         self.context(cmt_run_id_sim='008000', cmt_run_id_proc='008001')
         self.context(cmt_run_id_sim='008000',
                      cmt_option_overwrite_sim={'elife': 1e6})
-        self.context(cmt_run_id_sim='008000',
-                     cmt_option_overwrite_sim={'elife': 1e6},
-                     cmt_option_overwrite_proc={'elife': 1e5},
-                     overwrite_fax_file_sim=True,
-                     overwrite_fax_file_proc=True,
-                     )
+
         self.context(cmt_run_id_sim='008000',
                      overwrite_fax_file_sim={'elife': 1e6})
+
+    def test_nt_diverging_context_options(self):
+        """
+        Test diverging options. Idea is that you can use different
+        settings for processing and generating data, should have been
+        handled by RawRecordsFromWFsim but is now hacked into the
+        xenonnt_simulation context
+
+        Just to show how convoluted this syntax for the
+        xenonnt_simulation context / CMT is...
+        """
+        self.context(cmt_run_id_sim='008000',
+                     cmt_option_overwrite_sim={'elife': ('elife_constant', 1e6, True)},
+                     cmt_option_overwrite_proc={'elife': ('elife_constant', 1e5, True)},
+                     overwrite_from_fax_file_proc=True,
+                     overwrite_from_fax_file_sim=True,
+                     _config_overlap={'electron_lifetime_liquid': 'elife'},
+                     )
 
     def test_nt_sim_context_bad_inits(self):
         with self.assertRaises(RuntimeError):

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -99,7 +99,11 @@ class TestSimContextNT(unittest.TestCase):
         self.context(cmt_run_id_sim='008000',
                      cmt_option_overwrite_sim={'elife': 1e6})
         self.context(cmt_run_id_sim='008000',
-                     overwrite_fax_file_proc={'elife': 1e6})
+                     cmt_option_overwrite_sim={'elife': 1e6},
+                     cmt_option_overwrite_proc={'elife': 1e5},
+                     overwrite_fax_file_sim=True,
+                     overwrite_fax_file_proc=True,
+                     )
         self.context(cmt_run_id_sim='008000',
                      overwrite_fax_file_sim={'elife': 1e6})
 

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -18,10 +18,10 @@ def test_xenonnt_online():
     st.search_field('time')
 
 
+@unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
 def test_xennonnt():
-    if straxen.utilix_is_configured():
-        st = xenonnt(_database_init=False)
-        st.search_field('time')
+    st = xenonnt(_database_init=False)
+    st.search_field('time')
 
 
 def test_xenonnt_led():
@@ -94,6 +94,7 @@ class TestSimContextNT(unittest.TestCase):
         st = self.context(cmt_run_id_sim='008000')
         st.search_field('time')
 
+    @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
     def test_nt_sim_context_alt(self):
         """Some examples of how to run with a custom WFSim context"""
         self.context(cmt_run_id_sim='008000', cmt_run_id_proc='008001')
@@ -103,6 +104,7 @@ class TestSimContextNT(unittest.TestCase):
         self.context(cmt_run_id_sim='008000',
                      overwrite_fax_file_sim={'elife': 1e6})
 
+    @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
     def test_nt_diverging_context_options(self):
         """
         Test diverging options. Idea is that you can use different

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -99,7 +99,9 @@ class TestSimContextNT(unittest.TestCase):
         self.context(cmt_run_id_sim='008000',
                      cmt_option_overwrite_sim={'elife': 1e6})
         self.context(cmt_run_id_sim='008000',
-                     cmt_option_overwrite_proc={'elife': 1e6})
+                     overwrite_fax_file_proc={'elife': 1e6})
+        self.context(cmt_run_id_sim='008000',
+                     overwrite_fax_file_sim={'elife': 1e6})
 
     def test_nt_sim_context_bad_inits(self):
         with self.assertRaises(RuntimeError):

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -80,7 +80,34 @@ def test_xenon1t_led():
     st.search_field('time')
 
 
-@unittest.skipIf('ALLOW_WFSIM_TEST' not in os.environ, "if you want test wfsim context do `export 'ALLOW_WFSIM_TEST'=1`")
+# Simulation contexts are only tested when special flags are set
+
+@unittest.skipIf('ALLOW_WFSIM_TEST' not in os.environ,
+                 "if you want test wfsim context do `export 'ALLOW_WFSIM_TEST'=1`")
+class TestSimContextNT(unittest.TestCase):
+    @staticmethod
+    def context(*args, **kwargs):
+        kwargs.setdefault('cmt_version', 'global_ONLINE')
+        return straxen.contexts.xenonnt_simulation(*args, **kwargs)
+
+    def test_nt_sim_context_main(self):
+        st = self.context(cmt_run_id_sim='008000')
+        st.search_field('time')
+
+    def test_nt_sim_context_alt(self):
+        self.context(cmt_run_id_sim='008000', cmt_run_id_proc='008001')
+        self.context(cmt_run_id_sim='008000',
+                     cmt_option_overwrite_sim={'elife': 1e6})
+        self.context(cmt_run_id_sim='008000',
+                     cmt_option_overwrite_proc={'elife': 1e6})
+
+    def test_nt_sim_context_bad_inits(self):
+        with self.assertRaises(RuntimeError):
+            self.context(cmt_run_id_sim=None, cmt_run_id_proc=None,)
+
+
+@unittest.skipIf('ALLOW_WFSIM_TEST' not in os.environ,
+                 "if you want test wfsim context do `export 'ALLOW_WFSIM_TEST'=1`")
 def test_sim_context():
-    st = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='008000', cmt_version='global_ONLINE')
+    st = straxen.contexts.xenon1t_simulation()
     st.search_field('time')


### PR DESCRIPTION
Add a test for WFSim context that at least the basic code runs.

Additionally global_v5 is not compatible with this straxen version at the time of writing, maybe we should change it to ONLINE instead (as I did in this PR)

Coverage
![afbeelding](https://user-images.githubusercontent.com/22295914/147091462-40225d05-034d-412f-947c-cdcdd885c9dc.png)
to
![afbeelding](https://user-images.githubusercontent.com/22295914/147091490-f43381f7-cbb7-459b-a4fe-017bb100276a.png)
