### PR TITLE
Test for rucio-documents in the rundb

### DIFF
--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -243,7 +243,6 @@ class RunDB(strax.StorageFrontend):
         projection.update({
             k: True
             for k in f'name number'.split()})
-
         results_dict = dict()
         for doc in self.collection.find(
                 {**run_query, **dq}, projection=projection):

--- a/straxen/rundb.py
+++ b/straxen/rundb.py
@@ -243,6 +243,7 @@ class RunDB(strax.StorageFrontend):
         projection.update({
             k: True
             for k in f'name number'.split()})
+
         results_dict = dict()
         for doc in self.collection.find(
                 {**run_query, **dq}, projection=projection):

--- a/tests/test_database_frontends.py
+++ b/tests/test_database_frontends.py
@@ -149,6 +149,8 @@ class TestRunDBFrontend(unittest.TestCase):
             r = self.test_run_ids[0]
             keys = [self.st.key_for(r, t) for t in self.all_targets]
             self.rundb_sf.find_several(keys, fuzzy_for=self.all_targets)
+        with self.assertRaises(strax.DataNotAvailable):
+            self.rundb_sf.find(self.st.key_for('_super-run', self.all_targets[0]))
 
     def test_rucio_format(self):
         """Test that document retrieval works for rucio files in the RunDB"""


### PR DESCRIPTION
Add a test for rundb integration of rucio documents.

Coverage
![afbeelding](https://user-images.githubusercontent.com/22295914/147091205-a890f6ed-21aa-471a-a4b4-7ae67cb35fd9.png)
to
![afbeelding](https://user-images.githubusercontent.com/22295914/147091220-7fa3df94-82ce-4cc7-b29f-1d2bf85ac508.png)

