### PR TITLE
Add cmt tests and fix bug in apply_cmt_version

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -20,7 +20,7 @@ multihist==0.6.4
 npshmex==0.2.1                                  # Strax dependency
 numba==0.54.1                                   # Strax dependency
 numpy==1.19.5
-packaging==20.8
+packaging==21.3
 pandas==1.3.2                                   # Strax dependency
 panel==0.12.6                                   # Bokeh dependency
 psutil==5.8.0                                   # Strax dependency

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -337,6 +337,8 @@ def xenonnt_simulation(
 
     # Replace default cmt options with cmt_run_id tag + cmt run id
     cmt_options = straxen.get_corrections.get_cmt_options(st)
+    # prune to just get the strax options
+    cmt_options = {key: val['strax_option'] for key, val in cmt_options.items()}
 
     # First, fix gain model for simulation
     st.set_config({'gain_model_mc': 

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -29,11 +29,14 @@ arrays_corrections = ['hit_thresholds_tpc', 'hit_thresholds_he',
 posrec_corrections_basenames = ['s1_xyz_map', 'fdc_map', 's2_xy_map']
 
 
+@export
 class CMTVersionError(Exception):
     pass
 
+
 class CMTnanValueError(Exception):
     pass
+
 
 @export
 class CorrectionsManagementServices():
@@ -330,7 +333,7 @@ def args_idx(x):
 
 
 @strax.Context.add_method
-def apply_cmt_version(context: strax.Context, cmt_global_version: str):
+def apply_cmt_version(context: strax.Context, cmt_global_version: str) -> None:
     """Sets all the relevant correction variables
     :param cmt_global_version: A specific CMT global version, or 'latest' to get the newest one
     :returns None

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -353,17 +353,19 @@ def apply_cmt_version(context: strax.Context, cmt_global_version: str):
     cmt_config = dict()
     failed_keys = []
 
-    for option, value in cmt_options.items():
+    for option, option_info in cmt_options.items():
+        # name of the CMT correction, this is not always equal to the strax option
+        correction_name = option_info['correction']
+        # actual config option
+        # this could be either a CMT tuple or a URLConfig
+        value = option_info['strax_option']
+
         # might need to modify correction name to include position reconstruction algo
-        # if the config is a URL, get the correction name in CMT
-        if isinstance(value, str) and 'cmt://' in value:
-            correction_name = correction_name_from_urlstring(value)
-        # if it's still a tuple, it's the first element
-        else:
-            correction_name = value[0]
-            # this is a bit of a mess, but posrec configs are treated differently in the tuples
-            if correction_name in posrec_corrections_basenames:
-                correction_name += f"_{posrec_algo}"
+        # this is a bit of a mess, but posrec configs are treated differently in the tuples
+        # URL configs should already include the posrec suffix
+        # (it's real mess -- we should drop tuple configs)
+        if correction_name in posrec_corrections_basenames:
+            correction_name += f"_{posrec_algo}"
 
         # now see if our correction is in our local_versions dict
         if correction_name in local_versions:
@@ -373,7 +375,8 @@ def apply_cmt_version(context: strax.Context, cmt_global_version: str):
             else:
                 new_value = (value[0], local_versions[correction_name], value[2])
         else:
-            failed_keys.append(correction_name)
+            if correction_name not in failed_keys:
+                failed_keys.append(correction_name)
             continue
 
         cmt_config[option] = new_value
@@ -385,7 +388,7 @@ def apply_cmt_version(context: strax.Context, cmt_global_version: str):
 
         # only raise a warning if we are working with the online context
         if cmt_global_version == "global_ONLINE":
-            warnings.warn(msg)
+            warnings.warn(msg, UserWarning)
         else:
             raise CMTVersionError(msg)
 
@@ -399,11 +402,3 @@ def replace_url_version(url, version):
     args = [f"{k}={v}" for k, v in kwargs.items()]
     args_str = "&".join(args)
     return f'{url[:args_idx(url)]}?{args_str}'
-
-
-def correction_name_from_urlstring(url):
-    # only care about what happens after cmt
-    before_url, cmt, after_url = url.partition('cmt://')
-    tmp_config = straxen.URLConfig(default=after_url)
-    new_url, kwargs = tmp_config.split_url_kwargs(after_url)
-    return tmp_config.dispatch(new_url, **kwargs)

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -1,7 +1,7 @@
 import numpy as np
 import strax
 import straxen
-from warnings import warn
+import typing as ty
 from functools import wraps
 from straxen.corrections_services import corrections_w_file
 from straxen.corrections_services import single_value_corrections
@@ -153,7 +153,7 @@ def _is_cmt_option(run_id, config):
     return is_cmt
 
 
-def get_cmt_options(context):
+def get_cmt_options(context: strax.Context) -> ty.Dict[str, ty.Dict[str, tuple]]:
     """
     Function which loops over all plugin configs and returns dictionary
     with option name as key and a nested dict of CMT correction name and strax option as values.
@@ -166,6 +166,10 @@ def get_cmt_options(context):
 
     for data_type, plugin in context._plugin_class_registry.items():
         for option_key, option in plugin.takes_config.items():
+            if option_key in cmt_options:
+                # let's not do work twice if needed by > 1 plugin
+                continue
+
             if (option_key in context.config and
                     is_cmt_option(context.config[option_key])):
                 opt = context.config[option_key]

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -156,7 +156,7 @@ def _is_cmt_option(run_id, config):
 def get_cmt_options(context):
     """
     Function which loops over all plugin configs and returns dictionary
-    with option name as key and a nested dict of CMT correction name and version as values.
+    with option name as key and a nested dict of CMT correction name and strax option as values.
 
     :param context: Context with registered plugins.
     """

--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -167,13 +167,10 @@ def get_cmt_options(context):
     for data_type, plugin in context._plugin_class_registry.items():
         for option_key, option in plugin.takes_config.items():
             if (option_key in context.config and
-                    is_cmt_option(context.config[option_key])
-            ):
+                    is_cmt_option(context.config[option_key])):
                 opt = context.config[option_key]
-
             elif is_cmt_option(option.default):
                 opt = option.default
-
             else:
                 continue
 
@@ -188,13 +185,13 @@ def get_cmt_options(context):
                 version = kwargs.get('version', 'ONLINE')
                 cmt_options[option_key] = {'correction': correction_name,
                                            'version': version,
-                                           'strax_option': opt
+                                           'strax_option': opt,
                                            }
 
             else:
                 cmt_options[option_key] = {'correction': opt[0],
                                            'version': opt[1],
-                                           'strax_option':  opt
+                                           'strax_option': opt,
                                            }
     return cmt_options
 

--- a/tests/test_cmt.py
+++ b/tests/test_cmt.py
@@ -141,3 +141,19 @@ def test_is_cmt_option():
     """
     dummy_option = ('hit_thresholds_tpc', 'ONLINE', True)
     assert straxen.is_cmt_option(dummy_option), 'Structure of CMT options changed!'
+
+    dummy_url_config = 'cmt://correction?version=ONLINE&run_id=plugin.run_id'
+    assert straxen.is_cmt_option(dummy_url_config), 'Structure of CMT options changed!'
+
+
+def test_replace_url_version():
+    """
+    Tests the replace_url_version function which is important in apply_cmt_version
+    """
+    url = 'cmt://elife?version=ONLINE?run_id=plugin.run_id'
+    url_check = 'cmt://elife?version=v1?run_id=plugin.run_id'
+    url_test = straxen.replace_url_version(url, 'v1')
+    if url_check != url_test:
+        msg = "replace_url_version did not do its job! " \
+              f"it returns:\n{url_test}\nwhen it should return:\n{url_check}"
+        raise AssertionError(msg)

--- a/tests/test_cmt.py
+++ b/tests/test_cmt.py
@@ -150,9 +150,9 @@ def test_replace_url_version():
     """
     Tests the replace_url_version function which is important in apply_cmt_version
     """
-    url = 'cmt://elife?version=ONLINE?run_id=plugin.run_id'
-    url_check = 'cmt://elife?version=v1?run_id=plugin.run_id'
-    url_test = straxen.replace_url_version(url, 'v1')
+    url = 'cmt://elife?version=ONLINE&run_id=plugin.run_id'
+    url_check = 'cmt://elife?version=v1&run_id=plugin.run_id'
+    url_test = straxen.corrections_services.replace_url_version(url, 'v1')
     if url_check != url_test:
         msg = "replace_url_version did not do its job! " \
               f"it returns:\n{url_test}\nwhen it should return:\n{url_check}"

--- a/tests/test_cmt.py
+++ b/tests/test_cmt.py
@@ -147,13 +147,11 @@ def test_is_cmt_option():
 
 
 def test_replace_url_version():
-    """
-    Tests the replace_url_version function which is important in apply_cmt_version
-    """
+    """Tests the replace_url_version function which is important in apply_cmt_version"""
     url = 'cmt://elife?version=ONLINE&run_id=plugin.run_id'
     url_check = 'cmt://elife?version=v1&run_id=plugin.run_id'
     url_test = straxen.corrections_services.replace_url_version(url, 'v1')
     if url_check != url_test:
-        msg = "replace_url_version did not do its job! " \
-              f"it returns:\n{url_test}\nwhen it should return:\n{url_check}"
-        raise AssertionError(msg)
+        raise AssertionError("replace_url_version did not do its job! "
+                             f"it returns:\n{url_test}\nwhen it should return:\n{url_check}"
+                             )

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -86,6 +86,7 @@ def test_sim_context():
     st.search_field('time')
 
 
+@unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
 def test_offline():
     st = xenonnt('latest')
-    dtypes = st.provided_dtypes()
+    st.provided_dtypes()

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -62,7 +62,8 @@ def test_offline():
           f'incompatible with {set(cmt_versions)-set(success_for)}')
 
     test = unittest.TestCase()
-    test.assertTrue(len(success_for) > 1)
+    # We should always work for one offline and the online version
+    test.assertTrue(len(success_for) >= 2)
 
 
 ##

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -84,3 +84,8 @@ def test_xenon1t_led():
 def test_sim_context():
     st = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='008000', cmt_version='global_ONLINE')
     st.search_field('time')
+
+
+def test_offline():
+    st = xenonnt('latest')
+    dtypes = st.provided_dtypes()

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -42,6 +42,29 @@ def test_nt_is_nt_online():
         assert str(nt_key) == str(nt_online_key)
 
 
+@unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
+def test_offline():
+    """
+    Let's try and see which CMT versions are compatible with this straxen
+    version
+    """
+    cmt = straxen.CorrectionsManagementServices()
+    cmt_versions = list(cmt.global_versions)[::-1]
+    print(cmt_versions)
+    success_for = []
+    for global_version in cmt_versions:
+        try:
+            xenonnt(global_version)
+            success_for.append(global_version)
+        except straxen.CMTVersionError:
+            pass
+    print(f'This straxen version works with {success_for} but is '
+          f'incompatible with {set(cmt_versions)-set(success_for)}')
+
+    test = unittest.TestCase()
+    test.assertTrue(len(success_for) > 1)
+
+
 ##
 # XENON1T
 ##
@@ -79,14 +102,12 @@ def test_xenon1t_led():
     st = xenon1t_led()
     st.search_field('time')
 
+##
+# WFSim
+##
+
 
 @unittest.skipIf('ALLOW_WFSIM_TEST' not in os.environ, "if you want test wfsim context do `export 'ALLOW_WFSIM_TEST'=1`")
 def test_sim_context():
     st = straxen.contexts.xenonnt_simulation(cmt_run_id_sim='008000', cmt_version='global_ONLINE')
     st.search_field('time')
-
-
-@unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
-def test_offline():
-    st = xenonnt('latest')
-    st.provided_dtypes()


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
- Adds more testing to address #834
- Fixes a bug where URL configs were not evaluated correctly when determining the correction name in `apply_cmt_version`

## Can you briefly describe how it works?
I removed the function `correction_name_from_urlstring` and implemented the same logic into `get_cmt_options`, which was @jmosbacher's initial suggestion in #817(sorry! should have listened then). This allows us to evaluate e.g. `plugin.attribute` when determining the correction name, which is a change I implemented later on in #817 but clearly did not test thoroughly enough. 

This changes slightly what `get_cmt_options` returns, and thus could be a breaking change. I think I have addressed the change in the 2 places where `get_cmt_options` is called in straxen. Now it returns a dictionary that looks something like this: 

```
{
...,
 'electron_drift_time_gate': {'correction': 'electron_drift_time_gate',
  'version': 'ONLINE',
  'strax_option': ('electron_drift_time_gate', 'ONLINE', True)},
'elife': {'correction': 'elife',
  'version': 'ONLINE',
  'strax_option': 'cmt://elife?version=ONLINE&run_id=plugin.run_id'},
...
}
```

where the `'correction'` and `'version'` fields of the dict are the CMT name and version of the correction, respectively, and `'strax_option'` is what actually gets passed to strax. The aim of this is to try to help deal with issues we are seeing with mixture of URL configs and CMT tuple configs. 

