### PR TITLE
Bump peaklets version

### DIFF
--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -96,7 +96,7 @@ class Peaklets(strax.Plugin):
     parallel = 'process'
     compressor = 'zstd'
 
-    __version__ = '1.0.0'
+    __version__ = '0.6.0'
 
     def infer_dtype(self):
         return dict(peaklets=strax.peak_dtype(

--- a/straxen/plugins/peaklet_processing.py
+++ b/straxen/plugins/peaklet_processing.py
@@ -96,7 +96,7 @@ class Peaklets(strax.Plugin):
     parallel = 'process'
     compressor = 'zstd'
 
-    __version__ = '0.5.0'
+    __version__ = '1.0.0'
 
     def infer_dtype(self):
         return dict(peaklets=strax.peak_dtype(


### PR DESCRIPTION
Bump the peaklets version. The hash for peaklets did not change between v1.1.3 and v1.2.1, but the dtype did, leading to errors when loading previously-processed data. This should fix those errors by forcing a new hash.