### PR TITLE
Bump numpy

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -28,6 +28,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Checkout repo
         uses: actions/checkout@v2
+      - name: pre-install requirements
+        run: pip install -r requitements.txt
       - name: Install straxen
         run: python setup.py install
       - name: Test import

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: pre-install requirements
-        run: pip install -r requitements.txt
+        run: pip install -r requirements.txt
       - name: Install straxen
         run: python setup.py install
       - name: Test import

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -19,7 +19,7 @@ matplotlib==3.5.1
 multihist==0.6.4
 npshmex==0.2.1                                  # Strax dependency
 numba==0.54.1                                   # Strax dependency
-numpy==1.19.5
+numpy==1.20.3
 packaging==21.3
 pandas==1.3.2                                   # Strax dependency
 panel==0.12.6                                   # Bokeh dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy~=1.19.5
+numpy
 packaging
 pymongo<4.0.0
 strax>=1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ pymongo<4.0.0
 requests
 strax>=1.1.2
 utilix>=0.5.3
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy<1.22
+numba>=0.50.0
+numpy
 packaging
 pymongo<4.0.0
 strax>=1.1.2
@@ -9,7 +10,6 @@ utilix>=0.5.3
 bokeh>=2.2.3
 multihist>=0.6.3
 immutabledict
-numba>=0.50.0
 requests
 commentjson
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<1.22
 packaging
 pymongo<4.0.0
 strax>=1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,17 @@
+strax>=1.1.2
+bokeh>=2.2.3
+commentjson
+gitpython
+immutabledict
+matplotlib
+multihist>=0.6.3
 numba>=0.50.0
 numpy
 packaging
 pymongo<4.0.0
-strax>=1.1.2
+requests
 utilix>=0.5.3
+
 # tensorflow>=2.3.0  # Optional, to (re)do posrec
 # holoviews          # Optional, to enable wf display
 # datashader         # Optional, to enable wf display
-bokeh>=2.2.3
-multihist>=0.6.3
-immutabledict
-requests
-commentjson
-matplotlib
-gitpython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-strax>=1.1.2
+# datashader         # Optional, to enable wf display
+# holoviews          # Optional, to enable wf display
+# tensorflow>=2.3.0  # Optional, to (re)do posrec
 bokeh>=2.2.3
 commentjson
 gitpython
@@ -10,8 +12,6 @@ numpy
 packaging
 pymongo<4.0.0
 requests
+strax>=1.1.2
 utilix>=0.5.3
 
-# tensorflow>=2.3.0  # Optional, to (re)do posrec
-# holoviews          # Optional, to enable wf display
-# datashader         # Optional, to enable wf display


### PR DESCRIPTION
Bump numpy if possible to avoid https://github.com/XENONnT/straxen/security/dependabot/extra_requirements/requirements-tests.txt/numpy/open

In this PR, we remove the requirement of keeping numpy <1.21 imposed by numba