### PR TITLE
Make EE correction recognized by CMT and apply a correction

### DIFF
--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -655,9 +655,8 @@ class CorrectedAreas(strax.Plugin):
         help='Actual SE gain for a given run (allows for time dependence)')
 
     # relative extraction efficiency which can change with time and modeled by CMT.
-    # defaults to no correction
     rel_extraction_eff = straxen.URLConfig(
-        default=1.0,
+        default='cmt://rel_extraction_eff?version=ONLINE&run_id=plugin.run_id',
         help='Relative extraction efficiency for this run (allows for time dependence)')
 
     def infer_dtype(self):


### PR DESCRIPTION
When using the global_v6 through cutax with for example
```
import cutax
st = cutax.contexts.xenonnt_v6()
st.config["rel_extraction_eff"]
```
the `rel_extraction_eff` is not recognized by `st.apply_cmt_version()`. So we either have to change the default in the context to CMT or the default in the plugin to CMT. Here I propose a change in the plugin to have it similar to SE correction.

Thanks @jmosbacher and @WenzDaniel for the correspondence.

In long term we will need to add something better like having all defaults at one place.