### PR TITLE
set  runid_test_str=0000

### DIFF
--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -162,7 +162,7 @@ def get_cmt_options(context: strax.Context) -> ty.Dict[str, ty.Dict[str, tuple]]
     """
 
     cmt_options = {}
-    runid_test_str = 'norunids!'
+    runid_test_str = '0000'
 
     for data_type, plugin in context._plugin_class_registry.items():
         for option_key, option in plugin.takes_config.items():


### PR DESCRIPTION
This should fix #938.
set runid_test_str = '0000'
in the get_cmt_options function

This will prevent failures in cases where the run id is actually used to fetch a correction from CMT in the plugin setup() method