### PR TITLE
Avoid plugin initialization when applying global version

### DIFF
--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -181,11 +181,15 @@ def get_cmt_options(context: strax.Context) -> ty.Dict[str, ty.Dict[str, tuple]]
             # check if it's a URLConfig
             if isinstance(opt, str) and 'cmt://' in opt:
                 before_cmt, cmt, after_cmt = opt.partition('cmt://')
-                p = context.get_single_plugin(runid_test_str, data_type)
+                p = context._get_plugins((data_type,), runid_test_str)[data_type]
+                context._set_plugin_config(p, runid_test_str, tolerant=False)
+                del p.run_id
+
                 p.config[option_key] = after_cmt
-                correction_name = getattr(p, option_key)
-                # make sure the correction name does not depend on runid
-                if runid_test_str in correction_name:
+                try:
+                    correction_name = getattr(p, option_key)
+                except AttributeError:
+                    # make sure the correction name does not depend on runid
                     raise RuntimeError("Correction names should not depend on runids! "
                                        f"Please check your option for {option_key}")
 


### PR DESCRIPTION
The way the `get_cmt_options` function currently handles URLConfigs is by loading the relevant plugin and using it to help evaluate the correction name in the CMT database. This is because the correction name may depend on other plugin variables.
This causes some issues:

1. Many plugins load data from the file DB during plugin initialization in their `setup()` method. This makes DB access a requirement for creating a context from a global version. 
2. Some plugins import heavy requirements such a tensorflow in their setup method. Initializing the plugin at context creation add memory overhead as well as longer load times.
3. Some plugins allocate large amounts of memory in their setup, increasing the memory footprint even in cases where the plugin is not used.

This PR avoids this by initializing the plugin without the setup() step, the run_id is also removed from the plugin to ensure an error is raised if the CMT config name depends on the run. This is a more robust test than the current test whether the run id itself appears in the name.
