### PR TITLE
Aqmon hits ordering fix

### DIFF
--- a/straxen/plugins/acqmon_processing.py
+++ b/straxen/plugins/acqmon_processing.py
@@ -18,7 +18,10 @@ T_NO_VETO_FOUND = int(3.6e+12)
 @strax.takes_config(strax.Option('hit_min_amplitude_aqmon', default=50, track=True, infer_type=False,
                                  help='Minimum hit threshold in ADC*counts above baseline'),
                     strax.Option('baseline_samples_aqmon', default=10, track=True, infer_type=False,
-                                 help='Number of samples to use at the start of the pulse to determine the baseline'))
+                                 help='Number of samples to use at the start of the pulse to determine the baseline'),
+                    strax.Option('check_raw_record_aqmon_overlaps', default=True, track=False, infer_type=False,
+                                 help='Crash if any of the pulses in raw_records_aqmon overlap with others '
+                                      'in the same channel'))
 class AqmonHits(strax.Plugin):
     """ Find hits in acquisition monitor data. These hits could be
         then used by other plugins for deadtime calculations,

--- a/straxen/plugins/acqmon_processing.py
+++ b/straxen/plugins/acqmon_processing.py
@@ -20,8 +20,8 @@ T_NO_VETO_FOUND = int(3.6e+12)
                     strax.Option('baseline_samples_aqmon', default=10, track=True, infer_type=False,
                                  help='Number of samples to use at the start of the pulse to determine the baseline'))
 class AqmonHits(strax.Plugin):
-    """ Find hits in acquisition monitor data. These hits could be 
-        then used by other plugins for deadtime calculations, 
+    """ Find hits in acquisition monitor data. These hits could be
+        then used by other plugins for deadtime calculations,
         GPS SYNC analysis, etc.
     """
     __version__ = '0.0.6'
@@ -35,8 +35,11 @@ class AqmonHits(strax.Plugin):
     save_when = strax.SaveWhen.TARGET
 
     def compute(self, raw_records_aqmon):
+        if self.config['check_raw_record_aqmon_overlaps']:
+            straxen.check_overlaps(raw_records_aqmon, n_channels=808)
+
         rec = strax.raw_to_records(raw_records_aqmon)
-        strax.sort_by_time(rec)
+        rec = strax.sort_by_time(rec)
         strax.zero_out_of_bounds(rec)
         strax.baseline(rec, baseline_samples=self.config['baseline_samples_aqmon'], flip=True)
         aqmon_hits = strax.find_hits(rec, min_amplitude=self.config['hit_min_amplitude_aqmon'])


### PR DESCRIPTION
# What does the code in this PR do / what does it improve?
aqmon_hits are now ordered by time, as expected. Also, we check if the raw_records_aqmon are assigned wrong times so that we get overlapping records.

# Can you briefly describe how it works?
We thought we'd order aqmon_hits by time, already. As the strax.sort_by_time method returns the result instead of an in place change, so far we didn't. [This is fixed](https://github.com/XENONnT/straxen/blob/9d7539a517c306460380a6cb284ddb6db733bf0f/straxen/plugins/acqmon_processing.py#L45).
As done with raw_records already, we also check here that there are no overlapping records, which can lead to time-ordering issues again. (as done in [the other case](https://github.com/XENONnT/straxen/blob/e341819beb9b44eba0b734397c02777e8131f9b4/straxen/plugins/pulse_processing.py#L178), this check can be turned off via a strax-option)

# Comment
Time ordering would currently only lead to issues if, within one channel, time-ordering is not given. However, if records from two different channels are swapped, this doesn't do anything.
As we always expect our data to be ordered by time in strax and to prevent funny things from happening, it doesn't hurt to make sure everything is correctly ordered.
