### PR TITLE
Allow unused rucio local

### DIFF
--- a/straxen/storage/rucio_local.py
+++ b/straxen/storage/rucio_local.py
@@ -37,10 +37,6 @@ class RucioLocalFrontend(strax.StorageFrontend):
         if path is None:
             local_rse = self.determine_rse()
             if local_rse is None:
-                warnings.warn(
-                    f'{socket.getfqdn()} doesn\'t allow using a local RSE, '
-                    f'{self.__class__.__name__} will do nothing',
-                    UserWarning)
                 self.path = None
                 self.backends = []
                 return

--- a/straxen/storage/rucio_local.py
+++ b/straxen/storage/rucio_local.py
@@ -37,6 +37,10 @@ class RucioLocalFrontend(strax.StorageFrontend):
         if path is None:
             local_rse = self.determine_rse()
             if local_rse is None:
+                warnings.warn(
+                    f'{socket.getfqdn()} doesn\'t allow using a local RSE, '
+                    f'{self.__class__.__name__} will do nothing',
+                    UserWarning)
                 self.path = None
                 self.backends = []
                 return

--- a/tests/storage/test_rucio_local.py
+++ b/tests/storage/test_rucio_local.py
@@ -174,7 +174,8 @@ class TestBasics(unittest.TestCase):
         Test that using a rucio-local frontend on a non-RSE listed site
         doesn't cause issues when registered
         """
-        rucio_local = straxen.RucioLocalFrontend()
+        with self.assertWarns(UserWarning):
+            rucio_local = straxen.RucioLocalFrontend()
         assert rucio_local.path is None
         with self.assertRaises(strax.DataNotAvailable):
             rucio_local.find(self.test_keys[0])

--- a/tests/storage/test_rucio_local.py
+++ b/tests/storage/test_rucio_local.py
@@ -170,13 +170,22 @@ class TestBasics(unittest.TestCase):
     @unittest.skipIf(socket.getfqdn() in straxen.RucioLocalFrontend.local_rses,
                      "Testing useless frontends only works on hosts where it's not supposed to work")
     def test_useless_frontend(self):
-        """Test that using a rucio-local frontend on a non-"""
+        """
+        Test that using a rucio-local frontend on a non-RSE listed site
+        doesn't cause issues when registered
+        """
         rucio_local = straxen.RucioLocalFrontend()
         assert rucio_local.path is None
         with self.assertRaises(strax.DataNotAvailable):
             rucio_local.find(self.test_keys[0])
         # Do a small test that we did not break everything by having a useless fontend
         st = straxen.test_utils.nt_test_context(minimum_run_number=10_000,
-                                                maximum_run_number=10_005)
-        st.storage.append(rucio_local)
+                                                maximum_run_number=10_005,
+                                                include_rucio_local=True,
+                                                keep_default_storage=True,
+                                                )
+        self.assertTrue(
+            str(rucio_local.__class__) in [str(sf.__class__) for sf in st.storage],
+            "Rucio local did not get registered??"
+        )
         st.select_runs()

--- a/tests/storage/test_rucio_local.py
+++ b/tests/storage/test_rucio_local.py
@@ -174,8 +174,7 @@ class TestBasics(unittest.TestCase):
         Test that using a rucio-local frontend on a non-RSE listed site
         doesn't cause issues when registered
         """
-        with self.assertWarns(UserWarning):
-            rucio_local = straxen.RucioLocalFrontend()
+        rucio_local = straxen.RucioLocalFrontend()
         assert rucio_local.path is None
         with self.assertRaises(strax.DataNotAvailable):
             rucio_local.find(self.test_keys[0])

--- a/tests/storage/test_rucio_local.py
+++ b/tests/storage/test_rucio_local.py
@@ -165,3 +165,18 @@ class TestBasics(unittest.TestCase):
         with self.assertRaises(ValueError):
             dummy_class.local_rses.update({'some other!': socket.getfqdn()})
             dummy_class.determine_rse()
+
+    @unittest.skipIf(not straxen.utilix_is_configured(), "No DB access")
+    @unittest.skipIf(socket.getfqdn() in straxen.RucioLocalFrontend.local_rses,
+                     "Testing useless frontends only works on hosts where it's not supposed to work")
+    def test_useless_frontend(self):
+        """Test that using a rucio-local frontend on a non-"""
+        rucio_local = straxen.RucioLocalFrontend()
+        assert rucio_local.path is None
+        with self.assertRaises(strax.DataNotAvailable):
+            rucio_local.find(self.test_keys[0])
+        # Do a small test that we did not break everything by having a useless fontend
+        st = straxen.test_utils.nt_test_context(minimum_run_number=10_000,
+                                                maximum_run_number=10_005)
+        st.storage.append(rucio_local)
+        st.select_runs()


### PR DESCRIPTION
Since it's such a simple fix, I'll just fix #975.

Allow `RucioLocalFrontends` to exists even if they are useless and don't have a backend, in that case, just raise a `DataNotAvailable` in case data is requested