### PR TITLE
Position shadow sigma set to nan when S2 not positive

### DIFF
--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -497,9 +497,10 @@ class PeakShadow(strax.OverlapWindowPlugin):
         return result
 
     @staticmethod
+    @np.errstate(invalid='ignore')
     def getsigma(sigma_and_baseline, s2):
         # The parameter of HalfCauchy, which is a function of S2 area
-        return sigma_and_baseline[0] / np.sqrt(np.where(s2 > 0, s2, np.nan)) + sigma_and_baseline[1]
+        return sigma_and_baseline[0] / np.sqrt(s2) + sigma_and_baseline[1]
 
     @staticmethod
     @numba.njit

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -342,10 +342,10 @@ class PeakShadow(strax.OverlapWindowPlugin):
     from previous peaks in time.
     It also gives the area and (x,y) of the previous peaks.
     References:
-        * v0.1.6 reference: xenon:xenonnt:ac:prediction:shadow_ambience
+        * v0.1.5 reference: xenon:xenonnt:ac:prediction:shadow_ambience
     """
 
-    __version__ = '0.1.6'
+    __version__ = '0.1.5'
     depends_on = ('peak_basics', 'peak_positions')
     provides = 'peak_shadow'
     save_when = strax.SaveWhen.EXPLICIT

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -342,10 +342,10 @@ class PeakShadow(strax.OverlapWindowPlugin):
     from previous peaks in time.
     It also gives the area and (x,y) of the previous peaks.
     References:
-        * v0.1.5 reference: xenon:xenonnt:ac:prediction:shadow_ambience
+        * v0.1.6 reference: xenon:xenonnt:ac:prediction:shadow_ambience
     """
 
-    __version__ = '0.1.5'
+    __version__ = '0.1.6'
     depends_on = ('peak_basics', 'peak_positions')
     provides = 'peak_shadow'
     save_when = strax.SaveWhen.EXPLICIT
@@ -499,7 +499,7 @@ class PeakShadow(strax.OverlapWindowPlugin):
     @staticmethod
     def getsigma(sigma_and_baseline, s2):
         # The parameter of HalfCauchy, which is a function of S2 area
-        return sigma_and_baseline[0] / np.sqrt(s2) + sigma_and_baseline[1]
+        return sigma_and_baseline[0] / np.sqrt(np.where(s2 > 0, s2, np.nan)) + sigma_and_baseline[1]
 
     @staticmethod
     @numba.njit


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Set Position shadow sigma to nan when S2 is not positive to suppress the warning in processing. 

Solving issue: https://github.com/XENONnT/straxen/issues/966

## Can you briefly describe how it works?

-

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [x] _Does it solve one of the open issues on github?_
