### PR TITLE
Fix bug in the binomial CDF of event_patternfit

### DIFF
--- a/straxen/plugins/event_patternfit.py
+++ b/straxen/plugins/event_patternfit.py
@@ -404,7 +404,9 @@ def binom_pmf(k, n, p):
 def binom_cdf(k, n, p):
     if k >= n:
         return 1.0
-    return numba_betainc(n - k, k + 1, 1.0 - p)
+    cd = numba_betainc(n,  1, 1.0 - p)
+    norm = 1. - cd
+    return numba_betainc(n - k, k + 1, 1.0 - p)/norm - cd/norm
 
 
 @numba.njit

--- a/straxen/plugins/event_patternfit.py
+++ b/straxen/plugins/event_patternfit.py
@@ -45,7 +45,7 @@ class EventPatternFit(strax.Plugin):
     
     depends_on = ('event_area_per_channel', 'event_basics', 'event_positions')
     provides = 'event_pattern_fit'
-    __version__ = '0.1.2'
+    __version__ = '0.1.3'
 
     # Getting S1 AFT maps
     s1_aft_map = straxen.URLConfig( 

--- a/tests/test_patternfit.py
+++ b/tests/test_patternfit.py
@@ -1,0 +1,19 @@
+import unittest
+from hypothesis import strategies, given, settings, example
+from straxen.plugins.event_patternfit import binom_pmf, binom_cdf
+
+
+@settings(deadline=None)
+@given(strategies.floats(0.,1.),strategies.floats(1e-3,1.-1e-3),strategies.floats(1.,1000))
+@example(1.,0.45,10.) #AFT_observed, AFT_expected (from xyz), S1_total
+def test_patternfit_stats(aftobs, aft, s1tot):
+    #PDF is positive:
+    s1top = aftobs*s1tot
+    assert(0. <= binom_pmf(s1top, s1tot, aft))
+    #CDF is positive, between 0 and 1, and 0 at 0 and 1 at s1tot:
+    assert(0. <= binom_cdf(s1top, s1tot, aft))
+    assert(binom_cdf(s1top, s1tot, aft) <=1.)
+    assert(0. == binom_cdf(0., s1tot, aft))
+    assert(1. == binom_cdf(s1tot, s1tot, aft))
+
+

--- a/tests/test_patternfit.py
+++ b/tests/test_patternfit.py
@@ -15,5 +15,3 @@ def test_patternfit_stats(aftobs, aft, s1tot):
     assert(binom_cdf(s1top, s1tot, aft) <=1.)
     assert(0. == binom_cdf(0., s1tot, aft))
     assert(1. == binom_cdf(s1tot, s1tot, aft))
-
-


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
The binom_CDF as written evaluates to 0.17 when the AFT is 0-- this gives the wrong p-values. 

## Can you briefly describe how it works?
This PR subtracts away the previous CDF at 0 and scales the remaining CDF to be normalised (returns 1 at AFT=1)

## Can you give a minimal working example (or illustrate with a figure)?
See tests

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [x] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired. (works locally)

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
