### PR TITLE
Remove Shadow&Ambience plugin SaveWhen.EXPLICIT

### DIFF
--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -803,7 +803,6 @@ class EventShadow(strax.Plugin):
     __version__ = '0.1.4'
     depends_on = ('event_basics', 'peak_basics', 'peak_shadow')
     provides = 'event_shadow'
-    save_when = strax.SaveWhen.EXPLICIT
 
     def infer_dtype(self):
         dtype = []
@@ -883,7 +882,6 @@ class EventAmbience(strax.Plugin):
     __version__ = '0.0.4'
     depends_on = ('event_basics', 'peak_basics', 'peak_ambience')
     provides = 'event_ambience'
-    save_when = strax.SaveWhen.EXPLICIT
 
     @property
     def origin_dtype(self):

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -803,6 +803,7 @@ class EventShadow(strax.Plugin):
     __version__ = '0.1.4'
     depends_on = ('event_basics', 'peak_basics', 'peak_shadow')
     provides = 'event_shadow'
+    save_when = strax.SaveWhen.EXPLICIT
 
     def infer_dtype(self):
         dtype = []

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -803,7 +803,6 @@ class EventShadow(strax.Plugin):
     __version__ = '0.1.4'
     depends_on = ('event_basics', 'peak_basics', 'peak_shadow')
     provides = 'event_shadow'
-    save_when = strax.SaveWhen.EXPLICIT
 
     def infer_dtype(self):
         dtype = []

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -497,6 +497,7 @@ class PeakShadow(strax.OverlapWindowPlugin):
         return result
 
     @staticmethod
+    @np.errstate(invalid='ignore')
     def getsigma(sigma_and_baseline, s2):
         # The parameter of HalfCauchy, which is a function of S2 area
         return sigma_and_baseline[0] / np.sqrt(s2) + sigma_and_baseline[1]

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -348,6 +348,7 @@ class PeakShadow(strax.OverlapWindowPlugin):
     __version__ = '0.1.5'
     depends_on = ('peak_basics', 'peak_positions')
     provides = 'peak_shadow'
+    save_when = strax.SaveWhen.EXPLICIT
 
     shadow_time_window_backward = straxen.URLConfig(
         default=int(1e9),
@@ -549,6 +550,7 @@ class PeakAmbience(strax.OverlapWindowPlugin):
     depends_on = ('lone_hits', 'peak_basics', 'peak_positions')
     provides = 'peak_ambience'
     data_kind = 'peaks'
+    save_when = strax.SaveWhen.EXPLICIT
 
     ambience_time_window_backward = straxen.URLConfig(
         default=int(2e6),

--- a/straxen/plugins/peak_processing.py
+++ b/straxen/plugins/peak_processing.py
@@ -348,7 +348,6 @@ class PeakShadow(strax.OverlapWindowPlugin):
     __version__ = '0.1.5'
     depends_on = ('peak_basics', 'peak_positions')
     provides = 'peak_shadow'
-    save_when = strax.SaveWhen.EXPLICIT
 
     shadow_time_window_backward = straxen.URLConfig(
         default=int(1e9),
@@ -550,7 +549,6 @@ class PeakAmbience(strax.OverlapWindowPlugin):
     depends_on = ('lone_hits', 'peak_basics', 'peak_positions')
     provides = 'peak_ambience'
     data_kind = 'peaks'
-    save_when = strax.SaveWhen.EXPLICIT
 
     ambience_time_window_backward = straxen.URLConfig(
         default=int(2e6),


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Remove `save_when` attribute of `PeakShadow`, `EventShadow`, `PeakAmbience`, `EventAmbience` plugins. 

Motivation: When analysts are loading `event_shadow` of calibration data, the `save_when = strax.SaveWhen.EXPLICIT` `PeakShadow` plugins will be stored in RAM and RAM can not hold that large amount of data. 

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_
