### PR TITLE
only find rucio from dali

### DIFF
--- a/straxen/storage/rundb.py
+++ b/straxen/storage/rundb.py
@@ -28,7 +28,7 @@ class RunDB(strax.StorageFrontend):
     storage_type = strax.StorageType.LOCAL
     # Dict of alias used in rundb: regex on hostname
     hosts = {
-        'dali': r'^dali.*rcc.*',
+        'dali': r'^dali.*rcc.*|fried.rice.edu',
     }
 
     provide_run_metadata = True

--- a/straxen/storage/rundb.py
+++ b/straxen/storage/rundb.py
@@ -124,9 +124,13 @@ class RunDB(strax.StorageFrontend):
             if re.match(regex, self.hostname):
                 self.available_query.append({'host': host_alias})
 
-        if self.rucio_path is not None:
+        # When querying for rucio, add that it should be dali-userdisk (when on dali)
+        if (self.rucio_path is not None and
+                any(
+                    re.match(regex, self.hostname)
+                    for regex in self.hosts.values()
+                )):
             self.backends.append(RucioLocalBackend(self.rucio_path))
-            # When querying for rucio, add that it should be dali-userdisk
             self.available_query.append({'host': 'rucio-catalogue',
                                          'location': 'UC_DALI_USERDISK',
                                          'status': 'transferred',

--- a/tests/storage/test_database_frontends.py
+++ b/tests/storage/test_database_frontends.py
@@ -89,6 +89,10 @@ class TestRunDBFrontend(unittest.TestCase):
             print(f'rm {self.path}')
             shutil.rmtree(self.path)
 
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.database[cls.collection_name].drop()
+
     @property
     def collection(self):
         return self.database[self.collection_name]

--- a/tests/storage/test_database_frontends.py
+++ b/tests/storage/test_database_frontends.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 import pymongo
 import datetime
+import socket
 
 
 def mongo_uri_not_set():
@@ -56,6 +57,20 @@ class TestRunDBFrontend(unittest.TestCase):
                                      )
         cls.rundb_sf.client = client
         cls.rundb_sf.collection = collection
+
+        # Extra test for regexes
+        class RunDBTestLocal(straxen.RunDB):
+            """Change class to mathc current host too"""
+            hosts = {'bla': f'{socket.getfqdn()}'}
+
+        cls.rundb_sf_with_current_host = RunDBTestLocal(readonly=False,
+                                                        runid_field='number',
+                                                        new_data_path=cls.path,
+                                                        minimum_run_number=-1,
+                                                        rucio_path='./strax_test_data',
+                                                        )
+        cls.rundb_sf_with_current_host.client = client
+        cls.rundb_sf_with_current_host.collection = collection
 
         cls.st = strax.Context(register=[Records, Peaks],
                                storage=[cls.rundb_sf],
@@ -152,7 +167,7 @@ class TestRunDBFrontend(unittest.TestCase):
         with self.assertRaises(strax.DataNotAvailable):
             self.rundb_sf.find(self.st.key_for('_super-run', self.all_targets[0]))
         with self.assertRaises(strax.DataNotAvailable):
-            self.rundb_sf._find(self.st.key_for('_super-run',self.all_targets[0]),
+            self.rundb_sf._find(self.st.key_for('_super-run', self.all_targets[0]),
                                 write=False,
                                 allow_incomplete=False,
                                 fuzzy_for = [],
@@ -178,17 +193,31 @@ class TestRunDBFrontend(unittest.TestCase):
 
         # Make sure we get the backend key using the _find option
         self.assertTrue(
-            self.rundb_sf._find(key,
-                                write=False,
-                                allow_incomplete=False,
-                                fuzzy_for=None,
-                                fuzzy_for_options=None,
-                                )[1] == did,
+            self.rundb_sf_with_current_host._find(
+                key,
+                write=False,
+                allow_incomplete=False,
+                fuzzy_for=None,
+                fuzzy_for_options=None,
+            )[1] == did,
         )
+        with self.assertRaises(strax.DataNotAvailable):
+            # Now, this same test should fail if we have a rundb SF
+            # without our host added to the regex
+            self.rundb_sf._find(
+                key,
+                write=False,
+                allow_incomplete=False,
+                fuzzy_for=None,
+                fuzzy_for_options=None,
+            )
         with self.assertRaises(strax.DataNotAvailable):
             # Although we did insert a document, we should get a data
             # not available error as we did not actually save any data
             # on the rucio folder
+            self.rundb_sf_with_current_host.find(key)
+        with self.assertRaises(strax.DataNotAvailable):
+            # Same, just double checking!
             self.rundb_sf.find(key)
 
 


### PR DESCRIPTION
Small patch to only find rucio data when we are actually on dali

Small sanity check:
```python
(dev_strax) [angevaare@dali-login1 straxen]$ python
Python 3.10.0 (default, Dec 21 2021, 13:36:04) [GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import straxen
>>> straxen.print_versions()
cutax is not installed
Host dali-login1.rcc.local
 module version                                                 path                               git
 python  3.10.0 /home/angevaare/miniconda3/envs/dev_strax/bin/python                              None
  strax   1.1.7       /home/angevaare/software/dev_strax/strax/strax           branch:master | db14f80
straxen   1.6.0   /home/angevaare/software/dev_strax/straxen/straxen branch:outside_dali_fix | fd04d67
>>> st = straxen.contexts.xenonnt_online()
>>> st.storage[0].backends
[<strax.storage.files.FileSytemBackend object at 0x7f10b56e2950>, <straxen.storage.rucio_local.RucioLocalBackend object at 0x7f10b569e4d0>]
>>> st.storage[0].available_query
[{'host': 'dali-login1.rcc.local'}, {'host': 'dali'}, {'host': 'rucio-catalogue', 'location': 'UC_DALI_USERDISK', 'status': 'transferred'}]
``` 