### PR TITLE
Tweaks to #1015

### DIFF
--- a/straxen/plugins/bayes_peak_classification.py
+++ b/straxen/plugins/bayes_peak_classification.py
@@ -78,7 +78,7 @@ def compute_wf_and_quantiles(peaks: np.ndarray, bayes_n_nodes: int):
     
 
 @numba.njit(cache=True)
-def _compute_wf_and_quantiles_new(data, sample_length, bayes_n_nodes: int):
+def _compute_wf_and_quantiles(data, sample_length, bayes_n_nodes: int):
     waveforms = np.zeros((len(data), bayes_n_nodes))
     quantiles = np.zeros((len(data), bayes_n_nodes))
 

--- a/straxen/plugins/bayes_peak_classification.py
+++ b/straxen/plugins/bayes_peak_classification.py
@@ -2,6 +2,7 @@ import numpy as np
 import numba
 import strax
 import straxen
+from scipy.special import logsumexp
 
 
 class BayesPeakClassification(strax.Plugin):
@@ -24,7 +25,7 @@ class BayesPeakClassification(strax.Plugin):
     dtype = (strax.time_fields
              + [('ln_prob_s1', np.float32, 'S1 ln probability')]
              + [('ln_prob_s2', np.float32, 'S2 ln probability')]
-            )
+             )
 
     # Descriptor configs
     bayes_config_file = straxen.URLConfig(
@@ -60,20 +61,20 @@ class BayesPeakClassification(strax.Plugin):
         result['ln_prob_s1'] = ln_prob_s1
         result['ln_prob_s2'] = ln_prob_s2
         return result
-    
-    
+
+
 def compute_wf_and_quantiles(peaks: np.ndarray, bayes_n_nodes: int):
     """
-    Compute waveforms and quantiles for a given number of nodes(atributes)
+    Compute waveforms and quantiles for a given number of nodes(attributes)
     :param peaks:
-    :param bayes_n_nodes: number of nodes or atributes
+    :param bayes_n_nodes: number of nodes or attributes
     :return: waveforms and quantiles
     """
     data = peaks['data'].copy()
     data[data < 0.0] = 0.0
     dt = peaks['dt']
     return _compute_wf_and_quantiles(data, dt, bayes_n_nodes)
-    
+
 
 @numba.njit(cache=True)
 def _compute_wf_and_quantiles(data, sample_length, bayes_n_nodes: int):
@@ -82,6 +83,7 @@ def _compute_wf_and_quantiles(data, sample_length, bayes_n_nodes: int):
 
     num_samples = data.shape[1]
     step_size = int(num_samples/bayes_n_nodes)
+    steps = np.arange(0, num_samples+1, step_size)
     inter_points = np.linspace(0., 1.-(1./bayes_n_nodes), bayes_n_nodes)
     cumsum_steps = np.zeros(bayes_n_nodes + 1, dtype=np.float64)
     frac_of_cumsum = np.zeros(num_samples + 1)
@@ -90,59 +92,27 @@ def _compute_wf_and_quantiles(data, sample_length, bayes_n_nodes: int):
         # reset buffers
         frac_of_cumsum[:] = 0
         cumsum_steps[:] = 0
-        
+
         frac_of_cumsum[1:] = np.cumsum(waveform)
         frac_of_cumsum[1:] = frac_of_cumsum[1:]/frac_of_cumsum[-1]
-        
+
         cumsum_steps[:-1] = np.interp(inter_points, frac_of_cumsum, sample_number_div_dt * dt)
         cumsum_steps[-1] = sample_number_div_dt[-1] * dt
         quantiles[i] = cumsum_steps[1:] - cumsum_steps[:-1]
 
         for j in range(bayes_n_nodes):
-            for k in range(j, j+1):
-                waveforms[i][j] += waveform[k]
+            waveforms[i][j] = np.sum(waveform[steps[j]:steps[j+1]])
         waveforms[i] /= (step_size*dt)
-    
+
     return waveforms, quantiles
 
 
-@numba.njit
-def _get_log_posterior(nodes, n_bins, n_classes, cpt, wf_len, wf_values):
-    ln_posterior = np.zeros((wf_len, nodes, n_classes))
-    for i in range(nodes):
-        distribution = cpt[i, :n_bins, :]
-        ln_posterior[:, i, :] = np.log(distribution[wf_values[:, i], :])
-    return ln_posterior
-
-
-@numba.njit
-def _logsumexp_axis1(arr, axis=1):
-    """~20x faster than scipy.special.logsumexp(*, axis=1)"""
-    if axis == 1:
-        res = np.zeros(len(arr), dtype=np.float64)
-        for i, a in enumerate(arr):
-            res[i] = np.log(sum(np.e**a))
-        return res
-    raise ValueError
-
-
-@numba.njit
-def _set_2d_to_zero_or_max_val(values, max_val):
-    for k, w in enumerate(values):
-        for kk, ww in enumerate(w):
-            if ww < 0:
-                values[k][kk] = 0
-            if ww > max_val:                
-                values[k][kk] = max_val
-
-
-@numba.njit(cache=True)
-def compute_inference(bins: int, 
+def compute_inference(bins: int,
                       bayes_n_nodes: int,
                       cpt: np.ndarray,
                       n_bayes_classes: int,
                       class_prior: np.ndarray,
-                      waveforms: np.ndarray, 
+                      waveforms: np.ndarray,
                       quantiles: np.ndarray):
     """
     Bin the waveforms and quantiles according to Bayes bins and compute inference
@@ -161,13 +131,17 @@ def compute_inference(bins: int,
     quantile_bin_edges = bins[1, :][bins[1, :] > -1]
     quantile_num_bin_edges = len(quantile_bin_edges)
     waveform_values = np.digitize(waveforms, bins=waveform_bin_edges)-1
-    _set_2d_to_zero_or_max_val(waveform_values, np.int64(waveform_num_bin_edges - 2))
+    _set_2d_to_zero_or_max_val(waveform_values,
+                               min_val=0,
+                               max_val=np.int64(waveform_num_bin_edges - 2))
 
     quantile_values = np.digitize(quantiles, bins=quantile_bin_edges)-1
-    _set_2d_to_zero_or_max_val(quantile_values, np.int64(quantile_num_bin_edges - 2))
+    _set_2d_to_zero_or_max_val(quantile_values,
+                               min_val=0,
+                               max_val=np.int64(quantile_num_bin_edges - 2))
 
     wf_posterior = _get_log_posterior(
-        nodes=bayes_n_nodes, 
+        nodes=bayes_n_nodes,
         n_bins=waveform_num_bin_edges-1,
         n_classes=n_bayes_classes,
         cpt=cpt[:bayes_n_nodes],
@@ -175,7 +149,7 @@ def compute_inference(bins: int,
         wf_values=waveform_values
     )
     quantile_posterior = _get_log_posterior(
-        nodes=bayes_n_nodes, 
+        nodes=bayes_n_nodes,
         n_bins=quantile_num_bin_edges-1,
         n_classes=n_bayes_classes,
         cpt=cpt[bayes_n_nodes:],
@@ -189,7 +163,30 @@ def compute_inference(bins: int,
     lnposterior_sumsamples = np.sum(lnposterior, axis=1)
     lnposterior_sumsamples = lnposterior_sumsamples + np.log(class_prior)
 
-    normalization = _logsumexp_axis1(lnposterior_sumsamples, axis=1)
+    # If you need to numbafy, use
+    # github.com/XENONnT/straxen/blob/c06a611a5a4289c65b9830fc1e68027149b6a5fd/straxen/plugins/bayes_peak_classification.py#L119  # noqa
+    normalization = logsumexp(lnposterior_sumsamples, axis=1)
     ln_prob_s1 = lnposterior_sumsamples[:, 0]-normalization
     ln_prob_s2 = lnposterior_sumsamples[:, 1]-normalization
     return ln_prob_s1, ln_prob_s2
+
+
+@numba.njit
+def _get_log_posterior(nodes, n_bins, n_classes, cpt, wf_len, wf_values):
+    """Wrapper for extracting the ln posterior inside compute_inference"""
+    ln_posterior = np.zeros((wf_len, nodes, n_classes))
+    for i in range(nodes):
+        distribution = cpt[i, :n_bins, :]
+        ln_posterior[:, i, :] = np.log(distribution[wf_values[:, i], :])
+    return ln_posterior
+
+
+@numba.njit
+def _set_2d_to_zero_or_max_val(values, min_val, max_val):
+    """Clipping between min_val and max_val for 2d array"""
+    for k, w in enumerate(values):
+        for kk, ww in enumerate(w):
+            if ww < min_val:
+                values[k][kk] = min_val
+            if ww > max_val:
+                values[k][kk] = max_val

--- a/straxen/plugins/bayes_peak_classification.py
+++ b/straxen/plugins/bayes_peak_classification.py
@@ -108,7 +108,7 @@ def _compute_wf_and_quantiles(data, sample_length, bayes_n_nodes: int):
     return waveforms, quantiles
 
 @numba.njit
-def _get_log_posterior_sum(nodes, n_bins, n_classes, cpt, wf_len, wf_values):
+def _get_log_posterior(nodes, n_bins, n_classes, cpt, wf_len, wf_values):
     lnposterior = np.zeros((wf_len, nodes, n_classes))    
     for i in range(nodes):
         distribution = cpt[i, :n_bins, :]
@@ -147,7 +147,7 @@ def compute_inference(bins: int,
     quantile_values[quantile_values < 0] = int(0)
     quantile_values[quantile_values > int(quantile_num_bin_edges - 2)] = int(quantile_num_bin_edges - 2)
 
-    wf_posterior = get_log_posterior(
+    wf_posterior = _get_log_posterior(
         nodes=bayes_n_nodes, 
         n_bins=waveform_num_bin_edges-1,
         n_classes=n_bayes_classes,
@@ -155,7 +155,7 @@ def compute_inference(bins: int,
         wf_len=len(waveforms),
         wf_values=waveform_values
     )
-    quantile_posterior = get_log_posterior(
+    quantile_posterior = _get_log_posterior(
         nodes=bayes_n_nodes, 
         n_bins=quantile_num_bin_edges-1,
         n_classes=n_bayes_classes,

--- a/straxen/plugins/bayes_peak_classification.py
+++ b/straxen/plugins/bayes_peak_classification.py
@@ -57,7 +57,7 @@ class BayesPeakClassification(strax.Plugin):
                                                    self.n_bayes_classes, self.class_prior,
                                                    waveforms, quantiles)
         result['time'] = peaks['time']
-        result['endtime'] = peaks['time'] + peaks['dt'] * peaks['length']
+        result['endtime'] = strax.endtime(peaks)
         result['ln_prob_s1'] = ln_prob_s1
         result['ln_prob_s2'] = ln_prob_s2
         return result
@@ -88,12 +88,12 @@ def _compute_wf_and_quantiles(data, sample_length, bayes_n_nodes: int):
     cumsum_steps = np.zeros(bayes_n_nodes + 1, dtype=np.float64)
     frac_of_cumsum = np.zeros(num_samples + 1)
     sample_number_div_dt = np.arange(0, num_samples+1, 1)
-    for i, (waveform, dt) in enumerate(zip(data, sample_length)):
+    for i, (samples, dt) in enumerate(zip(data, sample_length)):
         # reset buffers
         frac_of_cumsum[:] = 0
         cumsum_steps[:] = 0
 
-        frac_of_cumsum[1:] = np.cumsum(waveform)
+        frac_of_cumsum[1:] = np.cumsum(samples)
         frac_of_cumsum[1:] = frac_of_cumsum[1:]/frac_of_cumsum[-1]
 
         cumsum_steps[:-1] = np.interp(inter_points, frac_of_cumsum, sample_number_div_dt * dt)
@@ -101,7 +101,7 @@ def _compute_wf_and_quantiles(data, sample_length, bayes_n_nodes: int):
         quantiles[i] = cumsum_steps[1:] - cumsum_steps[:-1]
 
         for j in range(bayes_n_nodes):
-            waveforms[i][j] = np.sum(waveform[steps[j]:steps[j+1]])
+            waveforms[i][j] = np.sum(samples[steps[j]:steps[j+1]])
         waveforms[i] /= (step_size*dt)
 
     return waveforms, quantiles
@@ -117,7 +117,7 @@ def compute_inference(bins: int,
     """
     Bin the waveforms and quantiles according to Bayes bins and compute inference
     :param bins: Bayes bins
-    :param bayes_n_nodes: number of nodes or atributes
+    :param bayes_n_nodes: number of nodes or attributes
     :param cpt: conditional probability tables
     :param n_bayes_classes: number of classes
     :param class_prior: class_prior
@@ -131,15 +131,55 @@ def compute_inference(bins: int,
     quantile_bin_edges = bins[1, :][bins[1, :] > -1]
     quantile_num_bin_edges = len(quantile_bin_edges)
     waveform_values = np.digitize(waveforms, bins=waveform_bin_edges)-1
-    _set_2d_to_zero_or_max_val(waveform_values,
-                               min_val=0,
-                               max_val=np.int64(waveform_num_bin_edges - 2))
+    waveform_values = np.clip(waveform_values, 0, waveform_num_bin_edges - 2)
 
     quantile_values = np.digitize(quantiles, bins=quantile_bin_edges)-1
-    _set_2d_to_zero_or_max_val(quantile_values,
-                               min_val=0,
-                               max_val=np.int64(quantile_num_bin_edges - 2))
+    quantile_values = np.clip(quantile_values, 0, quantile_num_bin_edges - 2)
 
+    lnposterior = get_log_posterior(bayes_n_nodes,
+                                    waveforms,
+                                    cpt,
+                                    waveform_num_bin_edges,
+                                    quantile_num_bin_edges,
+                                    n_bayes_classes,
+                                    waveform_values,
+                                    quantile_values,
+                                    )
+
+    lnposterior_sumsamples = np.sum(lnposterior, axis=1)
+    lnposterior_sumsamples = lnposterior_sumsamples + np.log(class_prior)
+
+    # If you need to numbafy, use
+    # github.com/XENONnT/straxen/blob/c06a611a5a4289c65b9830fc1e68027149b6a5fd/straxen/plugins/bayes_peak_classification.py#L119  # noqa
+    normalization = logsumexp(lnposterior_sumsamples, axis=1)
+    ln_prob_s1 = lnposterior_sumsamples[:, 0]-normalization
+    ln_prob_s2 = lnposterior_sumsamples[:, 1]-normalization
+    return ln_prob_s1, ln_prob_s2
+
+
+def get_log_posterior(bayes_n_nodes: int,
+                      waveforms: np.ndarray,
+                      cpt: np.ndarray,
+                      waveform_num_bin_edges: int,
+                      quantile_num_bin_edges: int,
+                      n_bayes_classes: int,
+                      waveform_values: np.ndarray,
+                      quantile_values: np.ndarray,
+                      ) -> np.ndarray:
+    """
+    # TODO, add a description what we are computing here
+
+    :param bayes_n_nodes: number of nodes or attributes
+    :param waveforms: waveforms
+    :param cpt: conditional probability tables
+    :param waveform_num_bin_edges: number of bins for waveforms
+    :param quantile_num_bin_edges:number of bins for quantiles
+    :param n_bayes_classes: number of classes
+    :param waveform_values: digitized waveforms
+    :param quantile_values: digitized quantiles
+    :return: log-posterior for waveforms and quantiles. NB! This is not
+        normalized
+    """
     wf_posterior = _get_log_posterior(
         nodes=bayes_n_nodes,
         n_bins=waveform_num_bin_edges-1,
@@ -160,16 +200,7 @@ def compute_inference(bins: int,
     lnposterior = np.zeros((len(waveforms), bayes_n_nodes*2, n_bayes_classes))
     lnposterior[:, :bayes_n_nodes] = wf_posterior
     lnposterior[:, bayes_n_nodes:] = quantile_posterior
-    lnposterior_sumsamples = np.sum(lnposterior, axis=1)
-    lnposterior_sumsamples = lnposterior_sumsamples + np.log(class_prior)
-
-    # If you need to numbafy, use
-    # github.com/XENONnT/straxen/blob/c06a611a5a4289c65b9830fc1e68027149b6a5fd/straxen/plugins/bayes_peak_classification.py#L119  # noqa
-    normalization = logsumexp(lnposterior_sumsamples, axis=1)
-    ln_prob_s1 = lnposterior_sumsamples[:, 0]-normalization
-    ln_prob_s2 = lnposterior_sumsamples[:, 1]-normalization
-    return ln_prob_s1, ln_prob_s2
-
+    return lnposterior
 
 @numba.njit
 def _get_log_posterior(nodes, n_bins, n_classes, cpt, wf_len, wf_values):
@@ -179,14 +210,3 @@ def _get_log_posterior(nodes, n_bins, n_classes, cpt, wf_len, wf_values):
         distribution = cpt[i, :n_bins, :]
         ln_posterior[:, i, :] = np.log(distribution[wf_values[:, i], :])
     return ln_posterior
-
-
-@numba.njit
-def _set_2d_to_zero_or_max_val(values, min_val, max_val):
-    """Clipping between min_val and max_val for 2d array"""
-    for k, w in enumerate(values):
-        for kk, ww in enumerate(w):
-            if ww < min_val:
-                values[k][kk] = min_val
-            if ww > max_val:
-                values[k][kk] = max_val


### PR DESCRIPTION
# No thrills tweaks to #1015 
Few tweaks to #1015 unrolling a few for loops to numba and simplifying a few functions.

## Performance `~ +10%`
A rather meager performance update w.r.t. #1015. If we really want to be faster, we should probably cast the handling of the `cpt` values in the `wf_posterior` and `quantile_posterior` in some different way.
![afbeelding](https://user-images.githubusercontent.com/22295914/164063676-21746071-f079-498b-a048-5d7e21260c76.png)

## Results
`ln_prob_s1` and `ln_prob_s2` are conserved w.r.t. #1015 and ` straxen | 1.6.1 | /cvmfs/xenon.opensciencegrid.org/releases/nT/d...` with the caveat of the slight numerical changed Daniel mentioned earlier

![afbeelding](https://user-images.githubusercontent.com/22295914/164064103-d7fad142-d07b-4759-84d9-fbf1daaea227.png)

