### PR TITLE
Start testing with PluginTestingSuite, fix #881

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -523,6 +523,7 @@ x1t_common_config = dict(
     peak_right_extension=30,
     s1_max_rise_time_post100=150,
     s1_min_coincidence=3,
+    event_s1_min_coincidence=3,
     # Events*
     left_event_extension=int(0.3e6),
     right_event_extension=int(1e6),

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -1,11 +1,10 @@
-from re import X
 import strax
 import numpy as np
 import numba
 import straxen
 from .position_reconstruction import DEFAULT_POSREC_ALGO
 from straxen.common import pax_file, get_resource, first_sr1_run
-from straxen.get_corrections import get_correction_from_cmt, get_cmt_resource, is_cmt_option
+from straxen.get_corrections import get_cmt_resource, is_cmt_option
 from straxen.itp_map import InterpolatingMap
 export, __all__ = strax.exporter()
 

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -83,11 +83,11 @@ class Events(strax.OverlapWindowPlugin):
         if self.config['s1_min_coincidence'] > self.config['event_s1_min_coincidence']:
             raise ValueError('Peak s1 coincidence requirement should be smaller '
                              'or equal to event_s1_min_coincidence')
-        self.right_extension = self.config['right_event_extension']
         self.drift_time_max = int(self.config['max_drift_length'] / self.electron_drift_velocity)
         # Left_extension and right_extension should be computed in setup to be
         # reflected in cutax too.
         self.left_extension = self.config['left_event_extension'] + self.drift_time_max
+        self.right_extension = self.config['right_event_extension']
 
     def get_window_size(self):
         # Take a large window for safety, events can have long tails

--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -35,11 +35,12 @@ export, __all__ = strax.exporter()
                  default=True, type=bool,
                  help='If true exclude S1s as triggering peaks.',
                  ),
-    strax.Option(
-        name='event_s1_min_coincidence',
-        default=2, infer_type=False,
-        help="Event level S1 min coincidence. Should be >= s1_min_coincidence "
-             "in the peaklet classification"),
+    strax.Option(name='event_s1_min_coincidence',
+                 default=2, infer_type=False,
+                 help="Event level S1 min coincidence. Should be >= "
+                      "s1_min_coincidence in the peaklet classification"),
+    strax.Option(name='s1_min_coincidence', default=2, type=int,
+                 help="Minimum tight coincidence necessary to make an S1"),
 )
 class Events(strax.OverlapWindowPlugin):
     """
@@ -79,11 +80,14 @@ class Events(strax.OverlapWindowPlugin):
     events_seen = 0
 
     def setup(self):
+        if self.config['s1_min_coincidence'] > self.config['event_s1_min_coincidence']:
+            raise ValueError('Peak s1 coincidence requirement should be smaller '
+                             'or equal to event_s1_min_coincidence')
+        self.right_extension = self.config['right_event_extension']
         self.drift_time_max = int(self.config['max_drift_length'] / self.electron_drift_velocity)
         # Left_extension and right_extension should be computed in setup to be
         # reflected in cutax too.
         self.left_extension = self.config['left_event_extension'] + self.drift_time_max
-        self.right_extension = self.config['right_event_extension']
 
     def get_window_size(self):
         # Take a large window for safety, events can have long tails

--- a/tests/plugins/README.md
+++ b/tests/plugins/README.md
@@ -1,3 +1,32 @@
 # Test for plugins
 
-In this directory, we 
+In this directory, we accumulate tests for the plugins we are using. 
+This makes data-manipulation and plugin configuration tests development easy.
+
+## Writing new tests
+Write a new test by adding a `.py` file and write a function that should be run in the testing suite by adding this decorator:
+```python
+from _core import PluginTestAccumulator
+
+
+@PluginTestAccumulator.register('test_example')
+def test_example(self, # You should always accept self as an argument!
+                ):
+    raise ValueError('Test failed')
+```
+
+Make sure that the new `.py`-file is imported in the `test_plugins.py` file (see explanation below).
+
+## Example
+See for example this ![event_building.py](event_building.py)-file. Here we add a test that works on event_basics (by changing a few configurations and checking that the output is roughly what we expect.
+
+
+## Why this organization (technical - only for developers)
+At the time of writing, there are ~132 different dependencies. Testing them does require quite some computational power if we all want to compute them, especially if we want to start computation from scratch (to avoid trying to a test that turns out to rely on data that was scrambled).
+
+A few design consideration were taken into account:
+ - We want a single class with a `tearDownClass`-method to clean up the data after running. If we would have many classes doing this, you would end up producing the same data many times. If you don't have a `tearDownClass` with storage cleanup, you could end up working on cached data which can cause a lot of frustration  https://github.com/XENONnT/straxen/pull/923.
+ - Add a modular approach where new tests can be added (in a for loop). While [subtests](https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests) should be a nice tool for doing this, it turns out to be not as transparent as it claims. Furthermore, you somehow still need to have the entire class in one file, whereas we'd lile to split these tests into small, targeted files.
+ - In order to accumulate the test functions, we made a dedicated class `PluginTestAccumulator` that just is a dump for the tests that we write in various places. We can't very cleanly re-import `unittest.TestCase`-classes, it seems to break the `pytest` (not doing proper setup- and teardowns).
+
+With this setup, we can very easily write tests at any level of data without doing a lot of re-computes of already stored data while providing a simple infrastructure for developers.

--- a/tests/plugins/README.md
+++ b/tests/plugins/README.md
@@ -1,0 +1,2 @@
+# Test for plugins
+In this directory, we 

--- a/tests/plugins/README.md
+++ b/tests/plugins/README.md
@@ -41,7 +41,7 @@ A few design considerations were taken into account:
    While [subtests](https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests) 
    should be a nice tool for doing this, it turns out to be not as transparent 
    as it claims. Furthermore, you somehow still need to have the entire class 
-   in one file, whereas we'd lile to split these tests into small, targeted 
+   in one file, whereas we'd like to split these tests into small, targeted 
    files.
  - In order to accumulate the test functions, we made a dedicated class 
    `PluginTestAccumulator` that just is a dump for the tests that we write in

--- a/tests/plugins/README.md
+++ b/tests/plugins/README.md
@@ -4,7 +4,8 @@ In this directory, we accumulate tests for the plugins we are using.
 This makes data-manipulation and plugin configuration tests development easy.
 
 ## Writing new tests
-Write a new test by adding a `.py` file and write a function that should be run in the testing suite by adding this decorator:
+Write a new test by adding a `.py` file and write a function that should be run
+in the testing suite by adding this decorator:
 ```python
 from _core import PluginTestAccumulator
 
@@ -15,18 +16,38 @@ def test_example(self, # You should always accept self as an argument!
     raise ValueError('Test failed')
 ```
 
-Make sure that the new `.py`-file is imported in the `test_plugins.py` file (see explanation below).
+Make sure that the new `.py`-file is imported in the `test_plugins.py` file 
+(see explanation below).
 
 ## Example
-See for example this ![event_building.py](event_building.py)-file. Here we add a test that works on event_basics (by changing a few configurations and checking that the output is roughly what we expect.
+See for example this ![event_building.py](event_building.py)-file. Here we add 
+a test that works on event_basics (by changing a few configurations and 
+checking that the output is roughly what we expect.
 
 
 ## Why this organization (technical - only for developers)
-At the time of writing, there are ~132 different dependencies. Testing them does require quite some computational power if we all want to compute them, especially if we want to start computation from scratch (to avoid trying to a test that turns out to rely on data that was scrambled).
+At the time of writing, there are ~132 different dependencies. Testing them 
+does require quite some computational power if we all want to compute them, 
+especially if we want to start computation from scratch (to avoid trying to a 
+test that turns out to rely on data that was scrambled).
 
 A few design consideration were taken into account:
- - We want a single class with a `tearDownClass`-method to clean up the data after running. If we would have many classes doing this, you would end up producing the same data many times. If you don't have a `tearDownClass` with storage cleanup, you could end up working on cached data which can cause a lot of frustration  https://github.com/XENONnT/straxen/pull/923.
- - Add a modular approach where new tests can be added (in a for loop). While [subtests](https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests) should be a nice tool for doing this, it turns out to be not as transparent as it claims. Furthermore, you somehow still need to have the entire class in one file, whereas we'd lile to split these tests into small, targeted files.
- - In order to accumulate the test functions, we made a dedicated class `PluginTestAccumulator` that just is a dump for the tests that we write in various places. We can't very cleanly re-import `unittest.TestCase`-classes, it seems to break the `pytest` (not doing proper setup- and teardowns).
+ - We want a single class with a `tearDownClass`-method to clean up the data 
+   after running. If we would have many classes doing this, you would end up 
+   producing the same data many times. If you don't have a `tearDownClass` with
+   storage cleanup, you could end up working on cached data which can cause a 
+   lot of frustration  https://github.com/XENONnT/straxen/pull/923.
+ - Add a modular approach where new tests can be added (in a for loop). 
+   While [subtests](https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests) 
+ - should be a nice tool for doing this, it turns out to be not as transparent 
+   as it claims. Furthermore, you somehow still need to have the entire class 
+   in one file, whereas we'd lile to split these tests into small, targeted 
+   files.
+ - In order to accumulate the test functions, we made a dedicated class 
+   `PluginTestAccumulator` that just is a dump for the tests that we write in
+   various places. We can't very cleanly re-import `unittest.TestCase`-classes,
+   it seems to break the `pytest` (not doing proper setup- and teardowns).
 
-With this setup, we can very easily write tests at any level of data without doing a lot of re-computes of already stored data while providing a simple infrastructure for developers.
+With this setup, we can very easily write tests at any level of data without 
+doing a lot of re-computes of already stored data while providing a simple 
+infrastructure for developers.

--- a/tests/plugins/README.md
+++ b/tests/plugins/README.md
@@ -1,2 +1,3 @@
 # Test for plugins
+
 In this directory, we 

--- a/tests/plugins/README.md
+++ b/tests/plugins/README.md
@@ -22,7 +22,7 @@ Make sure that the new `.py`-file is imported in the `test_plugins.py` file
 ## Example
 See for example this ![event_building.py](event_building.py)-file. Here we add 
 a test that works on event_basics (by changing a few configurations and 
-checking that the output is roughly what we expect.
+checking that the output is roughly what we expect).
 
 
 ## Why this organization (technical - only for developers)
@@ -31,7 +31,7 @@ does require quite some computational power if we all want to compute them,
 especially if we want to start computation from scratch (to avoid trying to a 
 test that turns out to rely on data that was scrambled).
 
-A few design consideration were taken into account:
+A few design considerations were taken into account:
  - We want a single class with a `tearDownClass`-method to clean up the data 
    after running. If we would have many classes doing this, you would end up 
    producing the same data many times. If you don't have a `tearDownClass` with
@@ -39,7 +39,7 @@ A few design consideration were taken into account:
    lot of frustration  https://github.com/XENONnT/straxen/pull/923.
  - Add a modular approach where new tests can be added (in a for loop). 
    While [subtests](https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests) 
- - should be a nice tool for doing this, it turns out to be not as transparent 
+   should be a nice tool for doing this, it turns out to be not as transparent 
    as it claims. Furthermore, you somehow still need to have the entire class 
    in one file, whereas we'd lile to split these tests into small, targeted 
    files.

--- a/tests/plugins/_core.py
+++ b/tests/plugins/_core.py
@@ -19,6 +19,7 @@ class PluginTestAccumulator:
             raise ValueError('Test failed')
     ```
     """
+
     # See URLConfigs for the original inspiration.
     @classmethod
     def register(cls, test_name, func=None):

--- a/tests/plugins/_core.py
+++ b/tests/plugins/_core.py
@@ -1,4 +1,24 @@
+import strax
+from unittest import TestCase
+
+
 class PluginTestAccumulator:
+    """
+    Accumulator for test functions for unit-testing such that all plugin
+    related unit tests can be run on the same data within a single
+    unit-test.
+
+    Use example:
+    ```python
+        from _core import PluginTestAccumulator
+
+
+        @PluginTestAccumulator.register('test_example')
+        def test_example(self, # You should always accept self as an argument!
+                        ):
+            raise ValueError('Test failed')
+    ```
+    """
     # See URLConfigs for the original inspiration.
     @classmethod
     def register(cls, test_name, func=None):
@@ -13,3 +33,9 @@ class PluginTestAccumulator:
             return func
 
         return wrapper(func) if func is not None else wrapper
+
+
+class PluginTestCase(TestCase):
+    """Class for type hinting of PluginTest"""
+    run_id: str
+    st: strax.Context

--- a/tests/plugins/_core.py
+++ b/tests/plugins/_core.py
@@ -1,0 +1,15 @@
+class PluginTestAccumulator:
+    # See URLConfigs for the original inspiration.
+    @classmethod
+    def register(cls, test_name, func=None):
+        def wrapper(func):
+            if not isinstance(test_name, str):
+                raise ValueError('test_name name must be a string.')
+            if not test_name.startswith('test'):
+                raise ValueError(f'Tests should start with test_.., '
+                                 f'got {test_name} for {func}')
+
+            setattr(cls, test_name, func)
+            return func
+
+        return wrapper(func) if func is not None else wrapper

--- a/tests/plugins/event_building.py
+++ b/tests/plugins/event_building.py
@@ -3,7 +3,7 @@ import numpy as np
 
 
 @PluginTestAccumulator.register('test_exclude_s1_as_triggering_peaks_config')
-def exclude_s1_as_triggering_peaks_config(self: PluginTestCase):
+def exclude_s1_as_triggering_peaks_config(self: PluginTestCase, trigger_min_area=10):
     """
     Test for checking the event building options, specifically the S1 (exclusion)
     """
@@ -11,25 +11,55 @@ def exclude_s1_as_triggering_peaks_config(self: PluginTestCase):
     # decrease the trigger_min_area to allow small s1s to be triggering
     st = self.st.new_context()
     st.set_config(dict(exclude_s1_as_triggering_peaks=0,
-                       trigger_min_area=20,
+                       trigger_min_area=trigger_min_area,
                        ))
-    events = st.get_array(self.run_id, 'event_basics')
+    events = st.get_array(self.run_id, 'event_basics', progress_bar=False)
     new_min_coincidence = int(np.max(events['s1_tight_coincidence']) - 1)
 
     # Create an alternative config, but with less
     st_alt = st.new_context()
     st_alt.set_config(dict(event_s1_min_coincidence=new_min_coincidence))
-    events_alt = st_alt.get_array(self.run_id, 'event_basics')
-
-    # There should be more "alt" events since we don't concatenate as
-    # many peaks into one event
-    self.assertGreaterEqual(len(events_alt), len(events))
+    events_alt = st_alt.get_array(self.run_id, 'event_basics', progress_bar=False)
 
     # The event durations should be smaller, since almost no s1s are
     # considered triggering so the events are extended less in the alt
     # config.
     self.assertLessEqual(
-        np.mean(events_alt['endtime']-events_alt['time']),
-        np.mean(events['endtime']-events['time']),
-
+        np.mean(events_alt['endtime'] - events_alt['time']),
+        np.mean(events['endtime'] - events['time']),
     )
+
+    # Check the triggers of the alternate config
+    event_plugin = st_alt.get_single_plugin(self.run_id, 'events')
+    triggers = get_triggering_peaks(events_alt,
+                                    event_plugin.left_extension,
+                                    event_plugin.right_extension)
+    s1_triggers = triggers[triggers['type'] == 1]
+    self.assertTrue(all(s1_triggers['tight_coincidence'] >= new_min_coincidence))
+    self.assertTrue(all(triggers['area'] >= trigger_min_area))
+
+
+def get_triggering_peaks(events, left_extension, right_extension):
+    """
+    Extract the first and last triggering peaks from an event and return type, area an tight_coincidence
+    """
+    peaks = np.zeros(len(events) * 4,
+                     dtype=[(('type', 'type of peak'), np.int8),
+                            (('tight_coincidence', 'tc level'), np.int16,),
+                            (('area', 'peak area'), np.float32),
+                            ])
+    peaks_seen = 0
+    for event in events:
+        for peak in 's1_ s2_ alt_s1_ alt_s2_'.split():
+            # We know that the event boundaries are set by the first/last
+            # triggering peaks, so just select those peaks that have defined the
+            # boundary (if we can still). This is not a complete list of
+            # triggers, but works well enough for this test
+            is_first_trigger = event[f'{peak}time'] - left_extension == event['time']
+            is_last_trigger = event[f'{peak}endtime'] + right_extension == event['endtime']
+            if is_first_trigger or is_last_trigger:
+                peaks[peaks_seen]['type'] = int(peak[-2])
+                for field in 'area tight_coincidence'.split():
+                    peaks[peaks_seen][field] = event[f'{peak}{field}']
+                peaks_seen += 1
+    return peaks[:peaks_seen]

--- a/tests/plugins/event_building.py
+++ b/tests/plugins/event_building.py
@@ -1,7 +1,9 @@
+from _core import PluginTestAccumulator
 from unittest import TestCase
 
 
-def plugin_test_exclude_s1_as_triggering_peaks_config(self: TestCase):
+@PluginTestAccumulator.register('test_exclude_s1_as_triggering_peaks_config')
+def exclude_s1_as_triggering_peaks_config(self: TestCase):
     st = self.st
 
     # Create an alternative config with almost identical settings

--- a/tests/plugins/event_building.py
+++ b/tests/plugins/event_building.py
@@ -1,18 +1,35 @@
-from _core import PluginTestAccumulator
-from unittest import TestCase
+from _core import PluginTestAccumulator, PluginTestCase
+import numpy as np
 
 
 @PluginTestAccumulator.register('test_exclude_s1_as_triggering_peaks_config')
-def exclude_s1_as_triggering_peaks_config(self: TestCase):
-    st = self.st
-
-    # Create an alternative config with almost identical settings
-    st_alt = st.new_context()
-    st_alt.set_config(dict(exclude_s1_as_triggering_peaks=0,
-                           event_s1_min_coincidence=2,
-                           ),
-                      )
+def exclude_s1_as_triggering_peaks_config(self: PluginTestCase):
+    """
+    Test for checking the event building options, specifically the S1 (exclusion)
+    """
+    # Change the config to allow s1s to be triggering, also drastically
+    # decrease the trigger_min_area to allow small s1s to be triggering
+    st = self.st.new_context()
+    st.set_config(dict(exclude_s1_as_triggering_peaks=0,
+                       trigger_min_area=20,
+                       ))
     events = st.get_array(self.run_id, 'event_basics')
+    new_min_coincidence = int(np.max(events['s1_tight_coincidence']) - 1)
+
+    # Create an alternative config, but with less
+    st_alt = st.new_context()
+    st_alt.set_config(dict(event_s1_min_coincidence=new_min_coincidence))
     events_alt = st_alt.get_array(self.run_id, 'event_basics')
 
-    self.assertAlmostEqual(len(events), len(events_alt))
+    # There should be more "alt" events since we don't concatenate as
+    # many peaks into one event
+    self.assertGreaterEqual(len(events_alt), len(events))
+
+    # The event durations should be smaller, since almost no s1s are
+    # considered triggering so the events are extended less in the alt
+    # config.
+    self.assertLessEqual(
+        np.mean(events_alt['endtime']-events_alt['time']),
+        np.mean(events['endtime']-events['time']),
+
+    )

--- a/tests/plugins/event_building.py
+++ b/tests/plugins/event_building.py
@@ -14,4 +14,3 @@ def plugin_test_exclude_s1_as_triggering_peaks_config(self: TestCase):
     events_alt = st_alt.get_array(self.run_id, 'event_basics')
 
     self.assertAlmostEqual(len(events), len(events_alt))
-

--- a/tests/plugins/event_building.py
+++ b/tests/plugins/event_building.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+
+def plugin_test_exclude_s1_as_triggering_peaks_config(self: TestCase):
+    st = self.st
+
+    # Create an alternative config with almost identical settings
+    st_alt = st.new_context()
+    st_alt.set_config(dict(exclude_s1_as_triggering_peaks=0,
+                           event_s1_min_coincidence=2,
+                           ),
+                      )
+    events = st.get_array(self.run_id, 'event_basics')
+    events_alt = st_alt.get_array(self.run_id, 'event_basics')
+
+    self.assertAlmostEqual(len(events), len(events_alt))
+

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -5,6 +5,7 @@ import os
 import shutil
 from importlib import import_module
 
+# Call all tests starting with this name
 _magic_key = 'plugin_test_'
 
 
@@ -27,6 +28,7 @@ class PluginTest(unittest.TestCase):
 
             setattr(cls, test_name, func)
             return func
+
         return wrapper(func) if func is not None else wrapper
 
     @classmethod
@@ -51,23 +53,23 @@ class PluginTest(unittest.TestCase):
 
 
 # Very important step! We add a test for each of the plugins
-for t in straxen.test_utils.nt_test_context()._plugin_class_registry.keys():
-    if t in PluginTest.exclude_plugins:
+for _target in straxen.test_utils.nt_test_context()._plugin_class_registry.keys():
+    if _target in PluginTest.exclude_plugins:
         continue
 
-    @PluginTest.register(f'test_{t}')
-    def _make(self, target=t):
+    # pylint disable=cell-var-from-loop
+    @PluginTest.register(f'test_{_target}')
+    def _make(self, target=_target):
         self.st.make(self.run_id, target)
-
 
 # There is probably a cleaner step but add all the functions in any .py
 # file in this dir to the tests
-for file in os.listdir(os.path.dirname(os.path.abspath(__file__))):
-    if not file.endswith('.py') and file != str(__file__):
+for _file in os.listdir(os.path.dirname(os.path.abspath(__file__))):
+    if not _file.endswith('.py') and _file != str(__file__):
         continue
 
-    module = import_module(file[:-len('.py')])
+    _module = import_module(_file[:-len('.py')])
 
-    for attr, _object in module.__dict__.items():
+    for attr, _object in _module.__dict__.items():
         if attr.startswith(_magic_key):
             PluginTest.register(f'test_{attr[len(_magic_key):]}', _object)

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -1,3 +1,4 @@
+import strax
 import straxen
 import unittest
 from straxen.test_utils import nt_test_run_id
@@ -35,7 +36,10 @@ class PluginTest(unittest.TestCase, PluginTestAccumulator):
 
 
 # Very important step! We add a test for each of the plugins
-for _target in straxen.test_utils.nt_test_context()._plugin_class_registry.keys():
+for _target in set(straxen.test_utils.nt_test_context()._plugin_class_registry.items()):
+    # Only run one test per plugin (even if it provides multiple targets)
+    _target = strax.to_str_tuple(_target.provides)[0]
+
     if _target in PluginTest.exclude_plugins:
         continue
 

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -12,6 +12,15 @@ import event_building
 # Don't bother with remote tests
 @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
 class PluginTest(PluginTestCase, PluginTestAccumulator):
+    """
+    Class for managing tests that depend on specific plugins and
+    require a bit of data to run the test
+    (provided by straxen.test_utils.nt_test_context).
+
+    Don't add tests directly, but add using the
+    `@PluginTestAccumulator.register`-decorator (see
+    straxen/tests/plugins/README.md)
+    """
     exclude_plugins = 'events_sync_mv', 'events_sync_nv'
 
     @classmethod
@@ -19,7 +28,7 @@ class PluginTest(PluginTestCase, PluginTestAccumulator):
         """
         Common setup for all the tests. We need some data which we
         don't delete but reuse to prevent a lot of computations in this
-        class
+        class. Only after running all the tests, we run the cleanup.
         """
         cls.st = straxen.test_utils.nt_test_context()
         cls.run_id = nt_test_run_id
@@ -43,7 +52,6 @@ for _target in set(straxen.test_utils.nt_test_context()._plugin_class_registry.v
     _target = strax.to_str_tuple(_target.provides)[0]
     if _target in PluginTest.exclude_plugins:
         continue
-
 
     # pylint: disable=cell-var-from-loop
     @PluginTestAccumulator.register(f'test_{_target}')

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -36,14 +36,14 @@ class PluginTest(unittest.TestCase, PluginTestAccumulator):
 
 
 # Very important step! We add a test for each of the plugins
-for _target in set(straxen.test_utils.nt_test_context()._plugin_class_registry.values()):
+for _target in set(straxen.test_utils.nt_test_context()._plugin_class_registry.items()):
     # Only run one test per plugin (even if it provides multiple targets)
     _target = strax.to_str_tuple(_target.provides)[0]
 
     if _target in PluginTest.exclude_plugins:
         continue
 
-    # pylint disable=cell-var-from-loop
+    # pylint: disable=cell-var-from-loop
     @PluginTestAccumulator.register(f'test_{_target}')
     def _make(self, target=_target):
         self.st.make(self.run_id, target)

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -4,7 +4,7 @@ import unittest
 from straxen.test_utils import nt_test_run_id
 import os
 import shutil
-from _core import PluginTestAccumulator
+from _core import PluginTestCase, PluginTestAccumulator
 
 # Need import to attach new tests to the PluginTestAccumulator
 import event_building
@@ -12,7 +12,7 @@ import event_building
 
 # Don't bother with remote tests
 @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
-class PluginTest(unittest.TestCase, PluginTestAccumulator):
+class PluginTest(PluginTestCase, PluginTestAccumulator):
     exclude_plugins = 'events_sync_mv', 'events_sync_nv'
 
     @classmethod
@@ -39,7 +39,6 @@ class PluginTest(unittest.TestCase, PluginTestAccumulator):
 for _target in set(straxen.test_utils.nt_test_context()._plugin_class_registry.values()):
     # Only run one test per plugin (even if it provides multiple targets)
     _target = strax.to_str_tuple(_target.provides)[0]
-
     if _target in PluginTest.exclude_plugins:
         continue
 

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -38,8 +38,6 @@ class PluginTest(unittest.TestCase, PluginTestAccumulator):
 for _target in straxen.test_utils.nt_test_context()._plugin_class_registry.keys():
     if _target in PluginTest.exclude_plugins:
         continue
-    if _target != 'records':
-        continue
 
     # pylint disable=cell-var-from-loop
     @PluginTestAccumulator.register(f'test_{_target}')

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -36,7 +36,7 @@ class PluginTest(unittest.TestCase, PluginTestAccumulator):
 
 
 # Very important step! We add a test for each of the plugins
-for _target in set(straxen.test_utils.nt_test_context()._plugin_class_registry.items()):
+for _target in set(straxen.test_utils.nt_test_context()._plugin_class_registry.values()):
     # Only run one test per plugin (even if it provides multiple targets)
     _target = strax.to_str_tuple(_target.provides)[0]
 

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -1,0 +1,73 @@
+import straxen
+import unittest
+from straxen.test_utils import nt_test_run_id
+import os
+import shutil
+from importlib import import_module
+
+_magic_key = 'plugin_test_'
+
+
+# Somehow the registering cases some issues with importing this main
+# class elsewhere (pytest won't recognize the setUpClass anymore, ideas
+# to fix are welcome)
+@unittest.skipIf(not __file__.endswith('test_plugins.py'),
+                 'Only run from main testing file')
+# Don't bother with remote tests
+@unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
+class PluginTest(unittest.TestCase):
+    exclude_plugins = 'events_sync_mv', 'events_sync_nv'
+
+    @classmethod
+    def register(cls, test_name, func=None):
+        # See URLConfigs for the original insparation.
+        def wrapper(func):
+            if not isinstance(test_name, str):
+                raise ValueError('test_name name must be a string.')
+
+            setattr(cls, test_name, func)
+            return func
+        return wrapper(func) if func is not None else wrapper
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """
+        Common setup for all the tests. We need some data which we
+        don't delete but reuse to prevent a lot of computations in this
+        class
+        """
+        cls.st = straxen.test_utils.nt_test_context()
+        cls.run_id = nt_test_run_id
+        # cls.st.make(cls.run_id, 'records')
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Removes test data after tests are done.
+        """
+        path = os.path.abspath(cls.st.storage[-1].path)
+        for file in os.listdir(path):
+            shutil.rmtree(os.path.join(path, file))
+
+
+# Very important step! We add a test for each of the plugins
+for t in straxen.test_utils.nt_test_context()._plugin_class_registry.keys():
+    if t in PluginTest.exclude_plugins:
+        continue
+
+    @PluginTest.register(f'test_{t}')
+    def _make(self, target=t):
+        self.st.make(self.run_id, target)
+
+
+# There is probably a cleaner step but add all the functions in any .py
+# file in this dir to the tests
+for file in os.listdir(os.path.dirname(os.path.abspath(__file__))):
+    if not file.endswith('.py') and file != str(__file__):
+        continue
+
+    module = import_module(file[:-len('.py')])
+
+    for attr, _object in module.__dict__.items():
+        if attr.startswith(_magic_key):
+            PluginTest.register(f'test_{attr[len(_magic_key):]}', _object)


### PR DESCRIPTION
This PR is a fix #881, it also starts refactoring the plugin tests with a simple example for #881, I will open a separate PR for doing a bit of refactoring to use this PR efficiently.

The documentation follows, [see this file](https://github.com/XENONnT/straxen/blob/excl_tc2_trigg_peaks/tests/plugins/README.md):


-------------

# Test for plugins

In this directory, we accumulate tests for the plugins we are using. 
This makes data-manipulation and plugin configuration tests development easy.

## Writing new tests
Write a new test by adding a `.py` file and write a function that should be run
in the testing suite by adding this decorator:
```python
from _core import PluginTestAccumulator


@PluginTestAccumulator.register('test_example')
def test_example(self, # You should always accept self as an argument!
                ):
    raise ValueError('Test failed')
```

Make sure that the new `.py`-file is imported in the `test_plugins.py` file 
(see explanation below).

## Example
See for example this ![event_building.py](event_building.py)-file. Here we add 
a test that works on event_basics (by changing a few configurations and 
checking that the output is roughly what we expect.


## Why this organization (technical - only for developers)
At the time of writing, there are ~132 different dependencies. Testing them 
does require quite some computational power if we all want to compute them, 
especially if we want to start computation from scratch (to avoid trying to a 
test that turns out to rely on data that was scrambled).

A few design consideration were taken into account:
 - We want a single class with a `tearDownClass`-method to clean up the data 
   after running. If we would have many classes doing this, you would end up 
   producing the same data many times. If you don't have a `tearDownClass` with
   storage cleanup, you could end up working on cached data which can cause a 
   lot of frustration  https://github.com/XENONnT/straxen/pull/923.
 - Add a modular approach where new tests can be added (in a for loop). 
   While [subtests](https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests) 
 - should be a nice tool for doing this, it turns out to be not as transparent 
   as it claims. Furthermore, you somehow still need to have the entire class 
   in one file, whereas we'd lile to split these tests into small, targeted 
   files.
 - In order to accumulate the test functions, we made a dedicated class 
   `PluginTestAccumulator` that just is a dump for the tests that we write in
   various places. We can't very cleanly re-import `unittest.TestCase`-classes,
   it seems to break the `pytest` (not doing proper setup- and teardowns).

With this setup, we can very easily write tests at any level of data without 
doing a lot of re-computes of already stored data while providing a simple 
infrastructure for developers.
