### PR TITLE
Check if processed data already exists in --production mode

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -347,7 +347,10 @@ def main():
         number = args.process
 
         # Check whether the run is already processed
-        bootstrax_state = run_col.find_one({'number': number}, projection={'bootstrax': True}).get('bootstrax', {}).get{'state', 'no-state')
+        bootstrax_state = run_coll.find_one(
+            {'number': number},
+            projection={'bootstrax': True}).get('bootstrax', {}
+                                                ).get('state', 'no-state')
         if args.production and bootstrax_state in ['done','processing','considering']:
             message = f"It looks like run {number} is already processed."
             log_warning(message, priority='fatal')

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -345,22 +345,26 @@ def main():
     elif args.process:
         t_start = now()
         number = args.process
+
+        # Check whether the run is already processed
+        bootstrax_state = run_col.find_one({'number': number}, projection={'bootstrax': True}).get('bootstrax', {}).get{'state', 'no-state')
+        if args.production and bootstrax_state in ['done','processing','considering']:
+            message = f"It looks like run {number} is already processed."
+            log_warning(message, priority='fatal')
+            raise ValueError(message)
+            
         rd = consider_run({'number': number})
         if rd is None:
             message = f"Trying to process single run but no run numbered {number} exists"
             log_warning(message, priority='fatal')
             raise ValueError(message)
-        if args.production:
-            if not rd['data'][0].get('type','no_type') == 'live':
-                message = f"Live data does not exist. Maybe run {number} is already processed?"
-                log_warning(message, priority='fatal')
-                raise ValueError(message)
-            else:
-                set_state('busy')
-                process_run(rd)
-                log.info(
-                    f'bootstrax ({hostname}) finished run {number} in {(now() - t_start).seconds} seconds')
-                wait_on_delete_thread()
+
+        else:
+            set_state('busy')
+            process_run(rd)
+            log.info(
+                f'bootstrax ({hostname}) finished run {number} in {(now() - t_start).seconds} seconds')
+            wait_on_delete_thread()
 
     else:
         # Start processing

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -359,12 +359,11 @@ def main():
             log_warning(message, priority='fatal')
             raise ValueError(message)
 
-        else:
-            set_state('busy')
-            process_run(rd)
-            log.info(
-                f'bootstrax ({hostname}) finished run {number} in {(now() - t_start).seconds} seconds')
-            wait_on_delete_thread()
+        set_state('busy')
+        process_run(rd)
+        log.info(
+            f'bootstrax ({hostname}) finished run {number} in {(now() - t_start).seconds} seconds')
+        wait_on_delete_thread()
 
     else:
         # Start processing

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -351,7 +351,7 @@ def main():
             {'number': number},
             projection={'bootstrax': True}).get('bootstrax', {}
                                                 ).get('state', 'no-state')
-        if args.production and bootstrax_state in ['done','processing','considering']:
+        if args.production and bootstrax_state in ['done', 'busy', 'considering']:
             message = f"It looks like run {number} is already processed."
             log_warning(message, priority='fatal')
             raise ValueError(message)

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -350,11 +350,17 @@ def main():
             message = f"Trying to process single run but no run numbered {number} exists"
             log_warning(message, priority='fatal')
             raise ValueError(message)
-        set_state('busy')
-        process_run(rd)
-        log.info(
-            f'bootstrax ({hostname}) finished run {number} in {(now() - t_start).seconds} seconds')
-        wait_on_delete_thread()
+        if args.production:
+            if not rd['data'][0].get('type','no_type') == 'live':
+                message = f"Live data does not exist. Maybe run {number} is already processed?"
+                log_warning(message, priority='fatal')
+                raise ValueError(message)
+            else:
+                set_state('busy')
+                process_run(rd)
+                log.info(
+                    f'bootstrax ({hostname}) finished run {number} in {(now() - t_start).seconds} seconds')
+                wait_on_delete_thread()
 
     else:
         # Start processing


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
The code checks in the runs database if the run that is being tried to process, has already been processed  (i.e. `bootstrax_status in ['done', 'processing', 'considering']`). This avoids that the processing results in `'failed'` (because there is no `live_data` available anymore).

## Can you briefly describe how it works?
See above.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [x] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._
