### PR TITLE
Add 'electron_diffusion_cte' variable from CMT

### DIFF
--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -21,7 +21,7 @@ corrections_w_file = ['mlp_model', 'cnn_model', 'gcn_model',
 single_value_corrections = ['elife_xenon1t', 'elife', 'baseline_samples_nv',
                             'electron_drift_velocity', 'electron_drift_time_gate',
                             'se_gain', 'rel_extraction_eff', 'relative_light_yield',
-                            'avg_se_gain']
+                            'avg_se_gain', 'electron_diffusion_cte']
 
 arrays_corrections = ['hit_thresholds_tpc', 'hit_thresholds_he',
                       'hit_thresholds_nv', 'hit_thresholds_mv']


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
The longitudinal diffusion constant value was added to the CMT but not to the `single_value_corrections` list. Without it, `straxen.get_correction_from_cmt(run_id', ('electron_diffusion_cte', version, detector))` leads to an error.
Issue in code found by @l-althueser.

This PR adds support for `straxen.get_correction_from_cmt` to fetch the diffusion constant from CMT.

## Can you briefly describe how it works?
Main code stays unaltered, `'electron_diffusion_cte'` added to the  `single_value_corrections` list.

## Can you give a minimal working example (or illustrate with a figure)?

`straxen.get_correction_from_cmt('17895', ('electron_diffusion_cte', 'ONLINE', 'nT'))`