### PR TITLE
tweaks to #1027 - single more general protocol

### DIFF
--- a/straxen/plugins/event_processing.py
+++ b/straxen/plugins/event_processing.py
@@ -785,10 +785,12 @@ class CorrectedAreas(strax.Plugin):
             # corrected s2 with s2 xy map only, i.e. no elife correction
             # this is for s2-only events which don't have drift time info
             
-            cs2_top_xycorr = (events[f'{peak_type}s2_area'] * events[f'{peak_type}s2_area_fraction_top'] / self.s2_xy_map(s2_positions, map_name=s2_top_map_name))
-            cs2_bottom_xycorr = (events[f'{peak_type}s2_area'] *
-                                       (1 - events[f'{peak_type}s2_area_fraction_top']) /
-                                       self.s2_xy_map(s2_positions, map_name=s2_bottom_map_name))
+            cs2_top_xycorr = (events[f'{peak_type}s2_area']
+                              * events[f'{peak_type}s2_area_fraction_top']
+                              / self.s2_xy_map(s2_positions, map_name=s2_top_map_name))
+            cs2_bottom_xycorr = (events[f'{peak_type}s2_area']
+                                 * (1 - events[f'{peak_type}s2_area_fraction_top'])
+                                 / self.s2_xy_map(s2_positions, map_name=s2_bottom_map_name))
             
             # For electron lifetime corrections to the S2s,
             # use drift time computed using the main S1.

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -345,7 +345,7 @@ def get_itp_dict(loaded_json,
     Interpolate the dictionary at the start time that is queried from
     a run-id.
 
-    The loaded JSON (dictionary), should have at least one collum `times`
+    The loaded JSON (dictionary), should have at least one collum `time`
     and has other columns given by `itp_dict_keys`.
 
     :param loaded_json: a dictionary with a time-series
@@ -358,7 +358,7 @@ def get_itp_dict(loaded_json,
         (multiple itp_dict_keys)
     """
     keys = strax.to_str_tuple(itp_dict_keys.split(','))
-    times = loaded_json['times']
+    times = loaded_json['time']
     if not all(k in loaded_json for k in keys):
         raise ValueError(f'One or more of {itp_dict_keys} are not in {loaded_json.keys()}')
 

--- a/tests/plugins/event_building.py
+++ b/tests/plugins/event_building.py
@@ -42,6 +42,7 @@ def exclude_s1_as_triggering_peaks_config(self: PluginTestCase, trigger_min_area
     self.assertTrue(all(s1_triggers['tight_coincidence'] >= new_min_coincidence))
     self.assertTrue(all(triggers['area'] >= trigger_min_area))
 
+
 @PluginTestAccumulator.register('test_partitioned_tpc_corrected_areas')
 def test_corrected_areas(self: PluginTestCase, ab_value=20, cd_value=21):
     """

--- a/tests/plugins/event_building.py
+++ b/tests/plugins/event_building.py
@@ -1,5 +1,9 @@
+import os
+import tempfile
 from _core import PluginTestAccumulator, PluginTestCase
 import numpy as np
+import pandas as pd
+from datetime import datetime
 
 
 @PluginTestAccumulator.register('test_exclude_s1_as_triggering_peaks_config')
@@ -37,6 +41,33 @@ def exclude_s1_as_triggering_peaks_config(self: PluginTestCase, trigger_min_area
     s1_triggers = triggers[triggers['type'] == 1]
     self.assertTrue(all(s1_triggers['tight_coincidence'] >= new_min_coincidence))
     self.assertTrue(all(triggers['area'] >= trigger_min_area))
+
+@PluginTestAccumulator.register('test_partitioned_tpc_corrected_areas')
+def test_corrected_areas(self: PluginTestCase, ab_value=20, cd_value=21):
+    """
+    Run the test in ../test_url_config.TestURLConfig.test_seg_file_json
+    on corrected_areas
+    """
+    fake_file = {'time': [datetime(2000, 1, 1).timestamp() * 1e9,
+                          datetime(2021, 1, 1).timestamp() * 1e9,
+                          datetime(2040, 1, 1).timestamp() * 1e9],
+                 'ab': [10, ab_value, 30],
+                 'cd': [11, cd_value, 31]
+                 }
+    # This example also works well with dataframes!
+    temp_dir = tempfile.TemporaryDirectory()
+    fake_file_name = os.path.join(temp_dir.name, 'test_seg.csv')
+    pd.DataFrame(fake_file).to_csv(fake_file_name)
+
+    self.st.set_config({'test_config':f'itp_dict://'
+                                      f'resource://'
+                                      f'{fake_file_name}'
+                                      f'?run_id=plugin.run_id'
+                                      f'&fmt=csv'
+                                      f'&itp_dict_keys=ab,cd'})
+    # Try loading some new data with the interpolated dictionary
+    _ = self.st.get_array(self.run_id, 'corrected_areas')
+    temp_dir.cleanup()
 
 
 def get_triggering_peaks(events, left_extension, right_extension):

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -148,11 +148,12 @@ class TestURLConfig(unittest.TestCase):
                                           f'{fake_file_name}'
                                           f'?run_id=plugin.run_id'
                                           f'&fmt={dump_as}'
-                                          f'&itp_dict_keys=ab,cd'})
+                                          f'&itp_keys=ab,cd'})
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        print(p.test_config)
         self.assertIsInstance(p.test_config, dict)
-        assert np.isclose(p.test_config['ab'], ab_value)
-        assert np.isclose(p.test_config['cd'], cd_value)
+        assert np.isclose(p.test_config['ab'], ab_value, rtol=1e-3)
+        assert np.isclose(p.test_config['cd'], cd_value, rtol=1e-3)
         os.remove(fake_file_name)
 
     def test_seg_file_csv(self):
@@ -162,8 +163,8 @@ class TestURLConfig(unittest.TestCase):
     def test_ee_file(self):
         """Same logic as test_seg_file, just keeping this example for bookkeeping since it's nice"""
         fake_file = {'time': [datetime(2000, 1, 1).timestamp() * 1e9,
-                              datetime(2020, 1, 1).timestamp() * 1e9,
-                              datetime(2040, 1, 1).timestamp() * 1e9],
+                                    datetime(2020, 1, 1).timestamp() * 1e9,
+                                    datetime(2040, 1, 1).timestamp() * 1e9],
                      'ee_ab': [0.1, 0.2, 0.3],
                      'ee_cd': [0.4, 0.5, 0.6]
                      }
@@ -178,10 +179,25 @@ class TestURLConfig(unittest.TestCase):
                                 f'{fake_file_name}'
                                 f'?run_id=plugin.run_id'
                                 f'&fmt=json'
-                                f'&itp_dict_keys=ee_ab,ee_cd'})
+                                f'&itp_keys=ee_ab,ee_cd'
+                            })
         p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
         self.assertIsInstance(p.test_config, dict)
         os.remove(fake_file_name)
+
+    def test_rekey(self):
+        original_dict = {'a': 1, 'b': 2, 'c': 3}
+        check_dict = {'anew': 1, 'bnew': 2, 'cnew': 3}
+        test_file = 'test_dict.json'
+        with open(test_file, 'w') as f:
+            json.dump(original_dict, f)
+
+        self.st.set_config({'test_config': f'rekey_dict://resource://{test_file}?'
+                                           f'fmt=json&replace_keys=a,b,c'
+                                           f'&with_keys=anew,bnew,cnew'})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(p.test_config, check_dict)
+
 
     def test_print_protocol_desc(self):
         straxen.URLConfig.print_protocols()

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -125,9 +125,9 @@ class TestURLConfig(unittest.TestCase):
             {'number': int(nt_test_run_id)},
             projection={'start': 1}
         ).get('start', 'QUERY FAILED!')
-        fake_file = {'times': [datetime(2000, 1, 1).timestamp() * 1e9,
-                               central_datetime.timestamp() * 1e9,
-                               datetime(2040, 1, 1).timestamp() * 1e9],
+        fake_file = {'time': [datetime(2000, 1, 1).timestamp() * 1e9,
+                              central_datetime.timestamp() * 1e9,
+                              datetime(2040, 1, 1).timestamp() * 1e9],
                      'ab': [10, ab_value, 30],
                      'cd': [11, cd_value, 31]
                          }
@@ -160,10 +160,10 @@ class TestURLConfig(unittest.TestCase):
 
     @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test CMT.")
     def test_ee_file(self):
-        """Same logic as test_seg_file, just keeping this example for bookkeeping"""
-        fake_file = {'times': [datetime(2000, 1, 1).timestamp() * 1e9,
-                               datetime(2020, 1, 1).timestamp() * 1e9,
-                               datetime(2040, 1, 1).timestamp() * 1e9],
+        """Same logic as test_seg_file, just keeping this example for bookkeeping since it's nice"""
+        fake_file = {'time': [datetime(2000, 1, 1).timestamp() * 1e9,
+                              datetime(2020, 1, 1).timestamp() * 1e9,
+                              datetime(2040, 1, 1).timestamp() * 1e9],
                      'ee_ab': [0.1, 0.2, 0.3],
                      'ee_cd': [0.4, 0.5, 0.6]
                      }


### PR DESCRIPTION
This PR just tweaks the protocols in #1027 to make it a bit more general. Core idea is still @ershockley 's 

## Differences
 - Only difference is that now the protocol would return the keys as they are requested from the json`'gain_ab'` instead of `'ab'` - depending on what the columns are in the file.
 - Call the time column `'time'` instead of `'times'` or `'timestamps'`

## Updates
- I've also added a few words of documentation and also expanded the test to work on CSV files 
- testing code on the CorrectedAreas-plugin

## Further generalization options
 - Not sure if the comma separation `keys = strax.to_str_tuple(itp_dict_keys.split(','))` could be handled by the URLConfig
