### PR TITLE
Fix detector sync

### DIFF
--- a/straxen/plugins/acqmon_processing.py
+++ b/straxen/plugins/acqmon_processing.py
@@ -488,7 +488,7 @@ class DetectorSynchronization(strax.Plugin):
     )
     # This value is only valid for SR0:
     epsilon_offset = straxen.URLConfig(
-        default=116,
+        default=76,
         type=int,
         track=True,
         help='Measured missing offset for nveto in [ns]'

--- a/straxen/plugins/veto_events.py
+++ b/straxen/plugins/veto_events.py
@@ -499,7 +499,7 @@ class nVETOEventsSync(strax.OverlapWindowPlugin):
 
     provides = 'events_sync_nv'
     save_when = strax.SaveWhen.EXPLICIT
-    __version__ = '0.0.2'
+    __version__ = '0.0.3'
 
     def infer_dtype(self):
         dtype = []
@@ -520,6 +520,7 @@ class nVETOEventsSync(strax.OverlapWindowPlugin):
     def compute(self, events_nv, detector_time_offsets):
         delay = detector_time_offsets[self.delay_field_name]
         delay = np.median(delay[delay > 0])
+        delay = delay.astype(np.int64)
         # Check if delay is >= 0 otherwise something went wrong with 
         # the sync signal.
         assert delay >= 0, f'Missing the GPS sync signal for run {self.run_id}.' 


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
PR which fixes the time synchronization between TPC and neutron-veto.
* Fixes a float64 to int64 conversion bug
* Changes different delay settings for the detector offset plugin.

See the following [note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:wenz:nveto:comissioning:nveto_straxen:ambecalibration:detector_synchronization#nveto) for more information.