### PR TITLE
Allow constant tuple options

### DIFF
--- a/straxen/get_corrections.py
+++ b/straxen/get_corrections.py
@@ -85,7 +85,7 @@ def get_correction_from_cmt(run_id, conf):
 
         # special case constant single value or list of values.
         elif 'constant' in model_conf:
-            if not isinstance(cte_value, (float, int, str, list)):
+            if not isinstance(cte_value, (float, int, str, list, tuple)):
                 raise ValueError(f"User specify a model type {model_conf} "
                                  "and should provide a number or list of numbers. Got: "
                                  f"{type(cte_value)}")


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
While trying to run with some tuple for the PMT gains in WFSim I encountered some issues with https://github.com/XENONnT/WFSim/blob/master/wfsim/strax_interface.py#L511, I tried inputting a list of values, but writing and loading this from json gave me some issues (because that's automatically decoded to tuples).

## Can you briefly describe how it works?
Also allow tuples, not only lists.

## Example:
```python
# Works
some_gains = [ 1, 2, 3, ..]
st.set_config(dict(gain_model_mc=('constant', some_gains),))

# Does not work, but I think it should
some_gains = (1, 2, 3, ..)
st.set_config(dict(gain_model_mc=('constant', some_gains),))
```
