### PR TITLE
allow dry eval of URL configs

### DIFF
--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -246,7 +246,7 @@ class URLConfig(strax.Config):
         Utility function to quickly test and evaluate URL configs,
         without the initialization of plugins (so no plugin attributes).
 
-        :example:
+        example::
 
             from straxen import URLConfig
             url_string='cmt://electron_drift_velocity?run_id=027000&version=v3'

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -240,6 +240,40 @@ class URLConfig(strax.Config):
         df = cls.protocol_descr()
         print(df)
 
+    @classmethod
+    def evaluate_dry(cls, url: str, **kwargs):
+        """
+        Utility function to quickly test and evaluate URL configs,
+        without the initialization of plugins (so no plugin attributes).
+
+        Example:
+
+            ```python
+            from straxen import URLConfig
+            url_string='cmt://electron_drift_velocity?run_id=027000&version=v3'
+            URLConfig.evaluate_dry(url_string)
+
+            # or similarly
+            url_string='cmt://electron_drift_velocity?version=v3'
+            URLConfig.evaluate_dry(url_string, run_id='027000')
+            ```
+
+        Please note that this has to be done outside of the plugin, so any
+        attributes of the plugin are not yet note to this dry evaluation
+        of the url-string.
+
+        :param url:
+        :keyword: any additional kwargs are passed to self.dispatch (see example)
+        :return: evaluated value of the URL.
+        """
+        if cls.PLUGIN_ATTR_PREFIX in url:
+            raise ValueError(
+                'You specified at least one parameter that depends on the '
+                'plugin. We cannot fetch this in the dry run. Try replacing '
+                'e.g. plugin.run_id=027000 with run_id=027000 (or pass as an '
+                'extra kwargs)')
+        url_arg, url_kwarg = cls.split_url_kwargs(url)
+        return cls.dispatch(cls, url_arg, **url_kwarg, **kwargs)
 
 @URLConfig.register('cmt')
 def get_correction(name: str,

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -246,9 +246,8 @@ class URLConfig(strax.Config):
         Utility function to quickly test and evaluate URL configs,
         without the initialization of plugins (so no plugin attributes).
 
-        Example:
+        :example:
 
-            ```python
             from straxen import URLConfig
             url_string='cmt://electron_drift_velocity?run_id=027000&version=v3'
             URLConfig.evaluate_dry(url_string)
@@ -256,7 +255,6 @@ class URLConfig(strax.Config):
             # or similarly
             url_string='cmt://electron_drift_velocity?version=v3'
             URLConfig.evaluate_dry(url_string, run_id='027000')
-            ```
 
         Please note that this has to be done outside of the plugin, so any
         attributes of the plugin are not yet note to this dry evaluation

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -262,7 +262,7 @@ class URLConfig(strax.Config):
         attributes of the plugin are not yet note to this dry evaluation
         of the url-string.
 
-        :param url:
+        :param url: URL to evaluate, see above for example.
         :keyword: any additional kwargs are passed to self.dispatch (see example)
         :return: evaluated value of the URL.
         """


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Allow evaluation of URL configs outside of context.

Sometimes, it's very useful to test the output of url-configs outside of a context. Just to sanity check that we are getting the right values. Until this moment, I always first changed the plugin, than checked that the plugin was giving me the correct value I was asking for. However, apart from the .plugin attributes, the URL config can be used in a broader sense than only for plugins. So I wrote a very small class method to do just that.

I had to scratch my head that it was so simple (of course that's @jmosbacher 's work 🎉) but probably still useful to add for it's nice to have since I'm sure people will also be running into the question _"how do I know I've written some URL config that makes sense?"_

## Can you give a minimal working example (or illustrate with a figure)?
Please see the example also written in the docstring/test:
```python
plugin_url = 'cmt://electron_drift_velocity?run_id=plugin.run_id&version=v3'
self.st.set_config({'test_config': plugin_url})
p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
correct_val = p.test_config

# We can also get it from one of these methods
dry_val1 = straxen.URLConfig.evaluate_dry(
    f'cmt://electron_drift_velocity?run_id={nt_test_run_id}&version=v3')
dry_val2 = straxen.URLConfig.evaluate_dry(
    f'cmt://electron_drift_velocity?version=v3', run_id=nt_test_run_id)

# All methods should yield the same
assert correct_val == dry_val1 == dry_val2
```