### PR TITLE
Allow long runs

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -15,7 +15,7 @@ How to use
 For more info, see the documentation:
 https://straxen.readthedocs.io/en/latest/bootstrax.html
 """
-__version__ = '1.2.1'
+__version__ = '1.3.0'
 
 import argparse
 from datetime import datetime, timedelta, timezone
@@ -31,7 +31,7 @@ import time
 import traceback
 import numpy as np
 import pymongo
-from psutil import pid_exists, disk_usage
+from psutil import pid_exists, disk_usage, Process
 import pytz
 import strax
 import straxen
@@ -121,13 +121,13 @@ timeouts = {
     'retry_run': 60,
     # Maximum time [s] for strax to complete a processing
     # if exceeded, strax will be killed by bootstrax
-    'max_processing_time': 24*3600,
+    'max_processing_time': 24*36000,
     # Max processing time [s] for bootstrax to finish processing after run ended
     'max_processing_time_after_completion': 6*3600,
     # Every this many [s] we should have at least one new file written to disk
-    'max_no_write_time': 15*60,
+    'max_no_write_time': 30*60,
     # Sleep between checking whether a strax process is alive
-    'check_on_strax': 60,
+    'check_on_strax': 10,
     # Maximum time a run is 'busy' without a further update from
     # its responsible bootstrax. Bootstrax normally updates every
     # check_on_strax seconds, so make sure this is substantially
@@ -460,24 +460,24 @@ def now(plus=0):
     return datetime.now(pytz.utc) + timedelta(seconds=plus)
 
 
-def kill_process(pid, wait_time=None):
-    """Kill process pid, or raise RuntimeError if we cannot
-    :param wait_time: time to wait before escalating signal strength
-    """
-    if wait_time is None:
-        wait_time = timeouts['signal_escalate']
+def kill_process(pid):
+    """Kill process pid"""
+    log.warning(f'Kill PID:{pid}')
     if not pid_exists(pid):
+        log.warning(f'No PID:{pid}')
         return
 
-    for sig in [signal.SIGTERM, signal.SIGKILL, 'die']:
-        time.sleep(wait_time)
-        if not pid_exists(pid):
-            return
-        if signal == 'die':
-            message = f"Could not kill process {pid}"
-            log_warning(message, priority='fatal')
-            raise RuntimeError(message)
-        os.kill(pid, sig)
+    parent = Process(pid)
+    for child in parent.children(recursive=True):
+        child.kill()
+    parent.kill()
+
+    # Just make it extra dead
+    os.kill(pid, signal.SIGKILL)
+
+    if pid_exists(pid):
+        message = f"Could not kill process {pid}?!"
+        log_warning(message, priority='fatal')        
 
 
 def _remove_veto_from_t(targets: ty.Union[str, list, tuple],
@@ -1477,27 +1477,35 @@ def process_run(rd, send_heartbeats=args.production):
                 send_heartbeat(update)
             ec = strax_proc.exitcode
             if ec is None:
+                # fail(bla) raises RunFailed so no need for elifs
                 if t0 < now(-timeouts['max_processing_time']):
-                    fail(f"Processing took longer than {timeouts['max_processing_time']} sec")
                     kill_process(strax_proc.pid)
+                    fail(f"Processing took longer than {timeouts['max_processing_time']} sec")
+                    
 
-                elif (end_time := run_coll.find_one({'_id': rd['_id']},
-                                                   projection={'end': 1}
-                                                   ).get('end', None)
-                                                   ) is not None:
-                    end_time = end_time.replace(tzinfo=pytz.utc)
-                    if end_time < now(-timeouts['max_processing_time_after_completion']):
+                if (
+                (end_time := run_coll.find_one({'_id': rd['_id']},
+                        projection={'end': 1}
+                        ).get('end', None)
+                        ) is not None
+                and t0 < now(-timeouts['max_processing_time_after_completion'])
+                ):
+                        kill_process(strax_proc.pid)
                         fail(f"After the run ended, processing did not succeed in "
                              f"{timeouts['max_processing_time_after_completion']} sec")
-                        kill_process(strax_proc.pid)
-                elif last_write := last_file_write_time(os.path.join(output_folder, f'{run_id}*')) < now(-timeouts['max_no_rr_write_time']):
-                    fail(f"No data written for {timeouts['max_no_write_time']} sec. Last write is from {last_write}")
+                if (
+                    t0 < now(-timeouts['max_no_write_time'])
+                    and
+                    (last_write := last_file_write_time(os.path.join(output_folder, f'{run_id}*'))
+                    ) < now(-timeouts['max_no_write_time'])
+                ):
                     kill_process(strax_proc.pid)
-                elif args.production:
+                    fail(f"No data written for {timeouts['max_no_write_time']} sec. Last write is from {last_write}")
+                    
+                if args.production:
                     set_run_state(rd, 'busy', **info)
-                    time.sleep(timeouts['check_on_strax'])
-
-                log.info(f"Still processing run {run_id}")
+                time.sleep(timeouts['check_on_strax'])
+                log.info(f"Still processing run {run_id}. PID:{strax_proc.pid}")
                 continue
 
             elif ec == 0:

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -18,6 +18,7 @@ https://straxen.readthedocs.io/en/latest/bootstrax.html
 __version__ = '1.3.0'
 
 import argparse
+import typing
 from datetime import datetime, timedelta, timezone
 import logging
 import multiprocessing
@@ -1127,6 +1128,9 @@ def upload_file_metadata(rd):
                  })
 
 
+def get_end_time(rd) -> typing.Optional[datetime]:
+    return run_coll.find_one({'_id': rd['_id']}, projection={'end': 1}).get('end', None)
+
 def set_status_finished(rd):
     """Set the status to ready to upload for datamanager and admix"""
     # Check mongo connection
@@ -1486,7 +1490,7 @@ def process_run(rd, send_heartbeats=args.production):
                     fail(f"Processing took longer than {timeouts['max_processing_time']} sec")
 
                 # Fail because we are taking a very long time to process despite the run having ended
-                if (run_coll.find_one({'_id': rd['_id']}, projection={'end': 1}).get('end', None) is not None
+                if (get_end_time(rd) is not None
                     and t0 < now(-timeouts['max_processing_time_after_completion'])):
                         kill_process(strax_proc.pid)
                         fail(f"After the run ended, processing did not succeed in "
@@ -1536,8 +1540,8 @@ def process_run(rd, send_heartbeats=args.production):
                         fail("Processing succeeded, but no chunks were written!")
 
                     log.info(f"Check that run has ended")
-                    rd = get_run(mongo_id=rd['_id'])
-                    if 'end' not in rd or rd['end'] is None:
+                    end_time=get_end_time(rd)
+                    if end_time is None:
                         fail("Processing succeeded, but run hasn't yet ended!")
 
                     log.info(f"Check the processing time of the run")
@@ -1551,7 +1555,7 @@ def process_run(rd, send_heartbeats=args.production):
                                  min([x.get('first_time', 10e9 * 1e9) for x in
                                       md['chunks']])) / 1e9)
                     log.info(f"Compute runtime")
-                    run_duration = rd['end'] - rd['start']
+                    run_duration = end_time - rd['start']
                     if not (0 < t_covered.seconds < float('inf')):
                         fail(f"Processed data covers {t_covered} sec")
                     if not (timedelta(seconds=-max_timetamp_diff)

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1481,9 +1481,11 @@ def process_run(rd, send_heartbeats=args.production):
                     fail(f"Processing took longer than {timeouts['max_processing_time']} sec")
                     kill_process(strax_proc.pid)
 
-                elif end_time := run_coll.find_one({'_id': rd['_id']},
+                elif (end_time := run_coll.find_one({'_id': rd['_id']},
                                                    projection={'end': 1}
-                                                   ).get('end', None) is not None:
+                                                   ).get('end', None)
+                                                   ) is not None:
+                    end_time = end_time.replace(tzinfo=pytz.utc)
                     if end_time < now(-timeouts['max_processing_time_after_completion']):
                         fail(f"After the run ended, processing did not succeed in "
                              f"{timeouts['max_processing_time_after_completion']} sec")

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -124,8 +124,8 @@ timeouts = {
     'max_processing_time': 24*3600,
     # Max processing time [s] for bootstrax to finish processing after run ended
     'max_processing_time_after_completion': 6*3600,
-    # Every this many [s] we should have at least one new raw-records entry written to disk
-    'max_no_write_time': 5*60,
+    # Every this many [s] we should have at least one new file written to disk
+    'max_no_write_time': 15*60,
     # Sleep between checking whether a strax process is alive
     'check_on_strax': 60,
     # Maximum time a run is 'busy' without a further update from
@@ -1345,21 +1345,24 @@ def run_strax(run_id, input_dir, targets, readout_threads, compressor,
             f.write(exc_info)
         raise
 
-def last_file_write_time(base_location: str) -> datetime:
+def last_file_write_time(match_location: str) -> datetime:
     """
     Get the datetime in UTC of the last file that was written in raw-records*
-    :param base_location: Location where runs are written to
+    :param match_location: Location where runs are written to
     :return: TZ aware timestamp
     """
-    last_time = datetime.datetime.fromtimestamp(0).replace(tzinfo=pytz.utc)
-    for rr_dir in glob(os.path.join(base_location, 'raw_records*')):
+    last_time = datetime.fromtimestamp(0).replace(tzinfo=pytz.utc)
+    matched_folders = glob(match_location)
+    for folder in matched_folders:
         # check last three files only
-        rr_files = sorted(glob(os.path.join(rr_dir, '*')))[-3:]
-        for rr_chunk in rr_files:
-            chunk_write_time = datetime.fromtimestamp(
-                os.stat(rr_chunk).st_mtime
-            ).replace(tzinfo=pytz.utc)
-            last_time = max(last_time, chunk_write_time)
+        chunk_files = sorted(glob(os.path.join(folder, '*')))[-3:]
+        for chunk in chunk_files:
+            # Check that we did not rename this file since the glob above
+            if os.path.exists(chunk):
+                chunk_write_time = datetime.fromtimestamp(
+                    os.stat(chunk).st_mtime
+                ).replace(tzinfo=pytz.utc)
+                last_time = max(last_time, chunk_write_time)
     return last_time
 
 def process_run(rd, send_heartbeats=args.production):
@@ -1485,8 +1488,8 @@ def process_run(rd, send_heartbeats=args.production):
                         fail(f"After the run ended, processing did not succeed in "
                              f"{timeouts['max_processing_time_after_completion']} sec")
                         kill_process(strax_proc.pid)
-                elif last_file_write_time(os.path.join(output_folder, run_id)) < now(-timeouts['max_no_write_time']):
-                    fail(f"No raw-records written for {timeouts['max_no_write_time']} sec")
+                elif last_write := last_file_write_time(os.path.join(output_folder, f'{run_id}*')) < now(-timeouts['max_no_rr_write_time']):
+                    fail(f"No data written for {timeouts['max_no_write_time']} sec. Last write is from {last_write}")
                     kill_process(strax_proc.pid)
                 elif args.production:
                     set_run_state(rd, 'busy', **info)

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -118,11 +118,13 @@ timeouts = {
     # Escalates exponentially on repeated failures: 1x, 5x, 25x, 125x, 125x, 125x, ...
     # Some jitter is applied: actual delays will randomly be 0.5 - 1.5x as long
     'retry_run': 60,
-    # Maximum time for strax to complete a processing
+    # Maximum time [s] for strax to complete a processing
     # if exceeded, strax will be killed by bootstrax
-    'max_processing_time': 7200,
+    'max_processing_time': 24*3600,
+    # Max processing time [s] for bootstrax to finish processing after run ended
+    'max_processing_time_after_completion': 3600,
     # Sleep between checking whether a strax process is alive
-    'check_on_strax': 10,
+    'check_on_strax': 60,
     # Maximum time a run is 'busy' without a further update from
     # its responsible bootstrax. Bootstrax normally updates every
     # check_on_strax seconds, so make sure this is substantially
@@ -1456,13 +1458,23 @@ def process_run(rd, send_heartbeats=args.production):
                 if t0 < now(-timeouts['max_processing_time']):
                     fail(f"Processing took longer than {timeouts['max_processing_time']} sec")
                     kill_process(strax_proc.pid)
-                # Still working, check in later
-                # TODO: is there a good way to detect hangs, before max_processing_time expires?
+
+                elif end_time := run_coll.find_one({'_id': rd['_id']},
+                                                   projection={'end': 1}
+                                                   ).get('end', None) is not None:
+                    if end_time < now(-timeouts['max_processing_time_after_completion']):
+                        fail(f"After the run ended, processing did not succeed in "
+                             f"{timeouts['max_processing_time_after_completion']} sec")
+                        kill_process(strax_proc.pid)
+
+                elif args.production:
+                    # TODO maybe add a small if statement to check if the last raw-records chunk
+                    #  that was written to disk is less than ~60 s old? That would be a very
+                    #  effective check against hangs 
+                    set_run_state(rd, 'busy', **info)
+                    time.sleep(timeouts['check_on_strax'])
 
                 log.info(f"Still processing run {run_id}")
-                if args.production:
-                    set_run_state(rd, 'busy', **info)
-                time.sleep(timeouts['check_on_strax'])
                 continue
 
             elif ec == 0:

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1477,31 +1477,28 @@ def process_run(rd, send_heartbeats=args.production):
                 send_heartbeat(update)
             ec = strax_proc.exitcode
             if ec is None:
-                # fail(bla) raises RunFailed so no need for elifs
+                # fail(bla) raises RunFailed so no need for elifs. Make sure to
+                # kill main process before raising errors in fail(bla)
+
+                # Fail because we are taking a very long time to process
                 if t0 < now(-timeouts['max_processing_time']):
                     kill_process(strax_proc.pid)
                     fail(f"Processing took longer than {timeouts['max_processing_time']} sec")
-                    
 
-                if (
-                (end_time := run_coll.find_one({'_id': rd['_id']},
-                        projection={'end': 1}
-                        ).get('end', None)
-                        ) is not None
-                and t0 < now(-timeouts['max_processing_time_after_completion'])
-                ):
+                # Fail because we are taking a very long time to process despite the run having ended
+                if (run_coll.find_one({'_id': rd['_id']}, projection={'end': 1}).get('end', None) is not None
+                    and t0 < now(-timeouts['max_processing_time_after_completion'])):
                         kill_process(strax_proc.pid)
                         fail(f"After the run ended, processing did not succeed in "
-                             f"{timeouts['max_processing_time_after_completion']} sec")
-                if (
-                    t0 < now(-timeouts['max_no_write_time'])
-                    and
-                    (last_write := last_file_write_time(os.path.join(output_folder, f'{run_id}*'))
-                    ) < now(-timeouts['max_no_write_time'])
-                ):
+                             f"{timeouts['max_processing_time_after_completion']} sec.")
+
+                # Fail because for some reason, we are not writing any new files to disk.
+                if (t0 < now(-timeouts['max_no_write_time'])
+                    and (last_write := last_file_write_time(os.path.join(output_folder, f'{run_id}*'))
+                        ) < now(-timeouts['max_no_write_time'])):
                     kill_process(strax_proc.pid)
                     fail(f"No data written for {timeouts['max_no_write_time']} sec. Last write is from {last_write}")
-                    
+
                 if args.production:
                     set_run_state(rd, 'busy', **info)
                 time.sleep(timeouts['check_on_strax'])

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -40,6 +40,7 @@ import pandas as pd
 import typing as ty
 import daqnt
 import fnmatch
+from glob import glob
 
 parser = argparse.ArgumentParser(
     description="XENONnT online processing manager")
@@ -122,7 +123,9 @@ timeouts = {
     # if exceeded, strax will be killed by bootstrax
     'max_processing_time': 24*3600,
     # Max processing time [s] for bootstrax to finish processing after run ended
-    'max_processing_time_after_completion': 3600,
+    'max_processing_time_after_completion': 6*3600,
+    # Every this many [s] we should have at least one new raw-records entry written to disk
+    'max_no_write_time': 5*60,
     # Sleep between checking whether a strax process is alive
     'check_on_strax': 60,
     # Maximum time a run is 'busy' without a further update from
@@ -1342,6 +1345,22 @@ def run_strax(run_id, input_dir, targets, readout_threads, compressor,
             f.write(exc_info)
         raise
 
+def last_file_write_time(base_location: str) -> datetime:
+    """
+    Get the datetime in UTC of the last file that was written in raw-records*
+    :param base_location: Location where runs are written to
+    :return: TZ aware timestamp
+    """
+    last_time = datetime.datetime.fromtimestamp(0).replace(tzinfo=pytz.utc)
+    for rr_dir in glob(os.path.join(base_location, 'raw_records*')):
+        # check last three files only
+        rr_files = sorted(glob(os.path.join(rr_dir, '*')))[-3:]
+        for rr_chunk in rr_files:
+            chunk_write_time = datetime.fromtimestamp(
+                os.stat(rr_chunk).st_mtime
+            ).replace(tzinfo=pytz.utc)
+            last_time = max(last_time, chunk_write_time)
+    return last_time
 
 def process_run(rd, send_heartbeats=args.production):
     log.info(f"Starting processing of run {rd['number']}")
@@ -1466,11 +1485,10 @@ def process_run(rd, send_heartbeats=args.production):
                         fail(f"After the run ended, processing did not succeed in "
                              f"{timeouts['max_processing_time_after_completion']} sec")
                         kill_process(strax_proc.pid)
-
+                elif last_file_write_time(os.path.join(output_folder, run_id)) < now(-timeouts['max_no_write_time']):
+                    fail(f"No raw-records written for {timeouts['max_no_write_time']} sec")
+                    kill_process(strax_proc.pid)
                 elif args.production:
-                    # TODO maybe add a small if statement to check if the last raw-records chunk
-                    #  that was written to disk is less than ~60 s old? That would be a very
-                    #  effective check against hangs 
                     set_run_state(rd, 'busy', **info)
                     time.sleep(timeouts['check_on_strax'])
 


### PR DESCRIPTION
if we want to allow > 2h long runs, we should not kill bootstrax before that time. Instead - only kill bootstrax if it is still running for a long time despite the run having ended. Additionally, we can also fail if we did not write any new file for more than 30 minutes which would be a better indicator of hangs than the total processing time.