### PR TITLE
Fix hanging straxer

### DIFF
--- a/bin/straxer
+++ b/bin/straxer
@@ -334,7 +334,8 @@ def start_alive_thread(log, print_timeout):
     from threading import Thread
     thread = Thread(name='Ping alive',
                     target=print_is_alive,
-                    args=(log, print_timeout))
+                    args=(log, print_timeout),
+                    daemon=True)
     log.info(f'Starting thread to ping that we are still running')
     thread.start()
 


### PR DESCRIPTION
status thread is keeping straxer from exiting when the work is done. This PR is a trivial fix, just adding `daemon=True` when creating the thread so it exits when the main thread exits.