### PR TITLE
Enforce endtime at readout level

### DIFF
--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -98,6 +98,7 @@ class DAQReader(strax.Plugin):
     )
     compressor = 'lz4'
     __version__ = '0.0.0'
+    _endtime = None
     input_timeout = 300
     
     def infer_dtype(self):
@@ -185,6 +186,7 @@ class DAQReader(strax.Plugin):
                 (pre and post
                  or chunk_i == 0 and post
                  or ended and (pre and not next_ahead)))):
+            self.endtime = utilix.rundb.xent_collection().find_one({'number': int(self.run_id)}', projection={'end': 1})
             return True
         return False
 
@@ -324,6 +326,9 @@ class DAQReader(strax.Plugin):
             records,
             np.asarray(list(self.config['channel_map'].values())))
         del records
+        
+        if self.endtime is not None:
+            result_arrays = [r[strax.endtime(r)<self.endtime] for r in result_arrays]
 
         # Convert to strax chunks
         result = dict()

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -175,6 +175,7 @@ class DAQReader(strax.Plugin):
         end_dir = self.config["daq_input_dir"] + '/THE_END'
         if not os.path.exists(end_dir):
             return False
+        # TODO 'end' doesn't reflect the timestamps in the live data, should have GPS times or something better
         self._endtime = utilix.rundb.xent_collection().find_one({'number': int(self.run_id)}, projection={'end': 1})
         self._endtime = self._endtime['end'].timestamp() * int(1e9) if self._endtime is not None else None
         return self._count_files_per_chunk(end_dir) >= self.n_readout_threads

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -186,7 +186,8 @@ class DAQReader(strax.Plugin):
                 (pre and post
                  or chunk_i == 0 and post
                  or ended and (pre and not next_ahead)))):
-            self.endtime = utilix.rundb.xent_collection().find_one({'number': int(self.run_id)}', projection={'end': 1})
+            self.endtime = utilix.rundb.xent_collection().find_one({'number': int(self.run_id)}, projection={'end': 1})
+            self.endtime = self.endtime['end'].timestamp()*int(1e9) if self.endtime is not None else None
             return True
         return False
 
@@ -329,7 +330,9 @@ class DAQReader(strax.Plugin):
         
         if self.endtime is not None:
             result_arrays = [r[strax.endtime(r)<self.endtime] for r in result_arrays]
-
+            # Maybe clip the boundary of the chunk as well? TODO
+            break_post = self.endtime - self.t0 
+        
         # Convert to strax chunks
         result = dict()
         for i, subd in enumerate(self.config['channel_map']):

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -5,7 +5,7 @@ from collections import Counter
 from immutabledict import immutabledict
 import numpy as np
 import numba
-
+import utilix
 import strax
 
 export, __all__ = strax.exporter()
@@ -186,8 +186,8 @@ class DAQReader(strax.Plugin):
                 (pre and post
                  or chunk_i == 0 and post
                  or ended and (pre and not next_ahead)))):
-            self.endtime = utilix.rundb.xent_collection().find_one({'number': int(self.run_id)}, projection={'end': 1})
-            self.endtime = self.endtime['end'].timestamp()*int(1e9) if self.endtime is not None else None
+            self._endtime = utilix.rundb.xent_collection().find_one({'number': int(self.run_id)}, projection={'end': 1})
+            self._endtime = self._endtime['end'].timestamp() * int(1e9) if self._endtime is not None else None
             return True
         return False
 
@@ -328,10 +328,11 @@ class DAQReader(strax.Plugin):
             np.asarray(list(self.config['channel_map'].values())))
         del records
         
-        if self.endtime is not None:
-            result_arrays = [r[strax.endtime(r)<self.endtime] for r in result_arrays]
-            # Maybe clip the boundary of the chunk as well? TODO
-            break_post = self.endtime - self.t0 
+        if self._endtime is not None:
+            # TODO this is too slow probably (no need to do endtime for all the data in the chunk) but just illustrates the example
+            result_arrays = [r[strax.endtime(r) < self._endtime] for r in result_arrays]
+            # TODO Maybe clip the boundary of the chunk as well?
+            #  break_post = self._endtime - self.t0
         
         # Convert to strax chunks
         result = dict()

--- a/straxen/plugins/daqreader.py
+++ b/straxen/plugins/daqreader.py
@@ -175,8 +175,9 @@ class DAQReader(strax.Plugin):
         end_dir = self.config["daq_input_dir"] + '/THE_END'
         if not os.path.exists(end_dir):
             return False
-        else:
-            return self._count_files_per_chunk(end_dir) >= self.n_readout_threads
+        self._endtime = utilix.rundb.xent_collection().find_one({'number': int(self.run_id)}, projection={'end': 1})
+        self._endtime = self._endtime['end'].timestamp() * int(1e9) if self._endtime is not None else None
+        return self._count_files_per_chunk(end_dir) >= self.n_readout_threads
 
     def is_ready(self, chunk_i):
         ended = self.source_finished()
@@ -186,8 +187,6 @@ class DAQReader(strax.Plugin):
                 (pre and post
                  or chunk_i == 0 and post
                  or ended and (pre and not next_ahead)))):
-            self._endtime = utilix.rundb.xent_collection().find_one({'number': int(self.run_id)}, projection={'end': 1})
-            self._endtime = self._endtime['end'].timestamp() * int(1e9) if self._endtime is not None else None
             return True
         return False
 


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Simple example of how to trim all the endtime to the endtime in the rundoc


## Can you briefly describe how it works?
Read an endtime from the rundoc when the run has ended, clip al the raw-records to be within that time interval
