### PR TITLE
Never change raw_records

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -75,3 +75,8 @@ class TestBasics(unittest.TestCase):
     def test_extract_latest_comment_lone_hits(self):
         """Run the test for some target that is not in the default availability check"""
         self.test_extract_latest_comment_nt(test_for_target='lone_hits')
+
+    def test_raw_records_lineage(self):
+        """The raw records lineage may NEVER change, if you ever do, doom ensures"""
+        st = straxen.contexts.xenonnt_online()
+        self.assertTrue(st.key_for('0', 'raw_records').lineage_hash == 'rfzvpzj4mf')

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -75,7 +75,8 @@ class TestBasics(unittest.TestCase):
     def test_extract_latest_comment_lone_hits(self):
         """Run the test for some target that is not in the default availability check"""
         self.test_extract_latest_comment_nt(test_for_target='lone_hits')
-
+    
+    @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
     def test_raw_records_lineage(self):
         """The raw records lineage may NEVER change, if you ever do, doom ensures"""
         st = straxen.contexts.xenonnt_online()


### PR DESCRIPTION
Very small test to assure that we never are allowed to change the nT lineage for raw-records