### PR TITLE
Use mongodb v4.4.1 when testing to match real version used in production

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.8.0
         with:
-          mongodb-version: 4.2
+          mongodb-version: 4.4.1
 
       - name: patch utilix file
         # Secrets and required files


### PR DESCRIPTION
Current mongodb version being used is 4.4.1 so we should also use this version when testing.