### PR TITLE
Don't test without `strax.processor.SHMExecutor`

### DIFF
--- a/tests/test_1T_plugins.py
+++ b/tests/test_1T_plugins.py
@@ -63,7 +63,7 @@ def _update_context(st, max_workers):
             'allow_multiprocess': True,
             'allow_lazy': False,
             'timeout': 120,  # we don't want to build travis for ever
-            'allow_shm': strax.processor.SHMExecutor is None,
+            'allow_shm': strax.processor.SHMExecutor is not None,
         })
 
 

--- a/tests/test_1T_plugins.py
+++ b/tests/test_1T_plugins.py
@@ -63,7 +63,7 @@ def _update_context(st, max_workers):
             'allow_multiprocess': True,
             'allow_lazy': False,
             'timeout': 120,  # we don't want to build travis for ever
-            'allow_shm': True,
+            'allow_shm': strax.processor.SHMExecutor is None,
         })
 
 


### PR DESCRIPTION
Fix some issue seen in https://github.com/XENONnT/base_environment/pull/1109 when the test fails if a new numpy is installed and `strax.processor.SHMExecutor` is None