### PR TITLE
Lower the default config value of online_max_bytes

### DIFF
--- a/straxen/plugins/individual_peak_monitor/individual_peak_monitor.py
+++ b/straxen/plugins/individual_peak_monitor/individual_peak_monitor.py
@@ -23,7 +23,7 @@ class IndividualPeakMonitor(strax.Plugin):
     """
 
     online_max_bytes = straxen.URLConfig(
-        default=10e6,
+        default=6e6,
         track=True,
         help='Maximum amount of bytes of data for MongoDB document'
     )


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Since we were running into the error of a too large document size multiple times, we decided to lower the max_bytes that the data array can have. We have the strong suspicion that the error must come from conversion from our np.float32 to standard python float64, which doubles the datasize. However, it remains unclear that this 'suddenly' happens, with normal data rates and chunk lengths.
