### PR TITLE
Event waveform CEvNS

### DIFF
--- a/straxen/plugins/events/__init__.py
+++ b/straxen/plugins/events/__init__.py
@@ -54,3 +54,6 @@ from .event_s2_position_gcn import *
 
 from . import local_minimum_info
 from .local_minimum_info import *
+
+from . import event_waveform
+from .event_waveform import *

--- a/straxen/plugins/events/event_waveform.py
+++ b/straxen/plugins/events/event_waveform.py
@@ -1,0 +1,226 @@
+from straxen.plugins.peak_processing import PeakBasics
+import straxen
+import strax
+import numpy as np
+import numba
+export, __all__ = strax.exporter()
+
+
+@export
+@strax.takes_config(
+    strax.Option('hit_number_peak_waveform_s1', default=10, type=int,
+                 help='Number of hits we stored in peaks'),
+)
+class EventWaveformS1(strax.Plugin):
+    """
+    Trivially fill peak_waveform_s1 into event level
+    """
+    __version__ = '0.0.0'
+    depends_on = ('event_basics', 'peak_basics', 'peak_waveform_s1')
+    provides = 'event_waveform_s1'
+
+    def setup(self):
+        # The fill-in dtype needs to be consistent with self.infer_dtype
+        return
+
+    def infer_dtype(self):
+        self.hits1_dtype = [
+                            # name                dtype       comment
+                            ('hits_max_time',     np.int64,   'Hits max_time'),
+                            ('hits_area',         np.float64, 'Hits area'),
+                            ('hits_channel',      np.int16,   'Hits channel'),
+                            ('hits_height',       np.float64, 'Hits height'),
+                            ]
+        self.hits1_dtype += [
+                            # name                dtype       comment
+                            ('hits_shadow_dt',     np.int64,   'Hits time difference to prehits'),
+                            ('hits_shadow',        np.float64, 'Hits shadow'),
+                            ('hits_prehits_area',  np.float64, 'Hits prehits area'),
+                            ]
+        dtype = strax.time_fields
+        for item in self.hits1_dtype:
+            (_name, _dtype, _comment) = item
+            dtype = dtype + [((f'{_comment} in event level', f's1_{_name}'), _dtype, (self.config['hit_number_peak_waveform_s1']))]
+        return dtype
+
+    def compute(self, events, peaks):
+        result = np.zeros(len(events), self.dtype)
+        result['time'] = events['time']
+        result['endtime'] = strax.endtime(events)
+        split_peaks = strax.split_by_containment(peaks, result)
+
+        for event_i, (event, sp) in enumerate(zip(events, split_peaks)):
+            idx = event['s1_index']
+            if idx >= 0:
+                for dtype in self.hits1_dtype:
+                    result[f's1_{dtype[0]}'][event_i] = sp[f'peak_{dtype[0]}'][idx]
+        return result
+
+
+@export
+@strax.takes_config(
+    strax.Option('hit_number_peak_ambience_s1', default=20, type=int,
+                 help='Number of hits we stored in peaks for ambience'),
+)
+class EventAmbienceS1(strax.Plugin):
+    """
+    Trivially fill peak_ambience_s1 into event level
+    """
+    __version__ = '0.0.0'
+    depends_on = ('event_basics', 'peak_basics', 'peak_ambience_s1')
+    provides = 'event_ambience_s1'
+
+    def infer_dtype(self):
+        dtype = strax.time_fields + [
+            (('Lone hits time in event level', 's1_ambience_lone_hits_time'), np.int64, (self.config['hit_number_peak_ambience_s1'])),
+            (('Lone hits area in event level', 's1_ambience_lone_hits_area'), np.float64, (self.config['hit_number_peak_ambience_s1'])),
+            (('Lone hits channel in event level', 's1_ambience_lone_hits_channel'), np.int16, (self.config['hit_number_peak_ambience_s1']))]
+        return dtype
+
+    def compute(self, events, peaks):
+        result = np.zeros(len(events), self.dtype)
+        result['time'] = events['time']
+        result['endtime'] = strax.endtime(events)
+        split_peaks = strax.split_by_containment(peaks, result)
+
+        for event_i, (event, sp) in enumerate(zip(events, split_peaks)):
+            idx = event['s1_index']
+            if idx >= 0:
+                for dtype in ['time', 'area', 'channel']:
+                    result[f's1_ambience_lone_hits_{dtype}'][event_i] = sp[f'lone_hits_{dtype}'][idx]
+        return result
+
+
+
+@export
+@strax.takes_config(
+    strax.Option('peaklet_number_event_waveform_s2', default=20, type=int,
+                 help='Number of peaklet we store'),
+)
+class EventWaveformS2(strax.OverlapWindowPlugin):
+    """
+    Return timing and area for single peaklets in S2s, in small S2s they are single electrons.
+    """
+    __version__ = "0.0.0"
+    parallel = True
+    depends_on = ('event_info', 'peaklets',)
+    provides = 'event_waveform_s2'
+    save_when = strax.SaveWhen.ALWAYS
+
+    electron_drift_velocity = straxen.URLConfig(
+        default='cmt://'
+                'electron_drift_velocity'
+                '?version=ONLINE&run_id=plugin.run_id',
+        cache=True,
+        help='Vertical electron drift velocity in cm/ns (1e4 m/ms)'
+    )
+
+    def setup(self):
+        self.drift_time_max = int(straxen.tpc_z / self.electron_drift_velocity)
+        return
+
+    def infer_dtype(self):
+        dtype = strax.time_fields + [
+            (('Center time of the peaklets in S2', 's2_peaklet_center_time'), np.int64, (self.config['peaklet_number_event_waveform_s2'])),
+            (('Area of the peaklets in S2', 's2_peaklet_area'), np.float32, (self.config['peaklet_number_event_waveform_s2'])),
+        ]
+        return dtype
+
+    def get_window_size(self):
+        return 10 * self.drift_time_max
+
+    def compute(self, events, peaklets):
+        # Step1: Split peaklets contained in main S2 time and endtime
+        temp_events = np.zeros(len(events), dtype=strax.time_fields)
+        temp_events['time'] = events['s2_time']
+        temp_events['endtime'] = events['s2_endtime']
+        split_peaklets = strax.split_touching_windows(peaklets, temp_events)
+
+        # Step 2: Fetch the first peaklet_number peaklets, and store area and center_time
+        result = np.zeros(len(events), self.dtype)
+        result['time'] = events['time']
+        result['endtime'] = strax.endtime(events)
+        for i in range(len(split_peaklets)):
+            peaklets_head = split_peaklets[i][:self.config['peaklet_number_event_waveform_s2']]
+            result[i]['s2_peaklet_area'] = np.pad(peaklets_head['area'], (0, self.config['peaklet_number_event_waveform_s2'] - len(peaklets_head)))
+            result[i]['s2_peaklet_center_time'] = np.pad(
+                                                peaklets_head['time'] + PeakBasics.compute_center_times(peaklets_head),
+                                                (0, self.config['peaklet_number_event_waveform_s2'] - len(peaklets_head)))
+        return result
+
+
+@export
+@strax.takes_config(
+    strax.Option('peak_number_event_ambience_s2', default=30, type=int,
+                 help='Number of peaks we store near the main S2 ambience'),
+)
+class EventAmbienceS2(strax.OverlapWindowPlugin):
+    """
+    Return the first peak_number peaks' information, sorted according to its time difference to main_S2.
+    """
+    __version__ = "0.0.0"
+    parallel = True
+    depends_on = ('event_basics', 'peak_basics',)
+    provides = 'event_ambience_s2'
+    save_when = strax.SaveWhen.ALWAYS
+
+    electron_drift_velocity = straxen.URLConfig(
+        default='cmt://'
+                'electron_drift_velocity'
+                '?version=ONLINE&run_id=plugin.run_id',
+        cache=True,
+        help='Vertical electron drift velocity in cm/ns (1e4 m/ms)'
+    )
+
+    def setup(self):
+        self.drift_time_max = int(straxen.tpc_z / self.electron_drift_velocity)
+        return
+
+    def infer_dtype(self):
+        peak_number = self.config['peak_number_event_ambience_s2']
+        dtype = strax.time_fields + [
+            (('S2 Ambience Peak range_50p_area in event level', 's2_ambience_peak_range_50p_area'), np.int64, (peak_number)),
+            (('S2 Ambience Peak range_90p_area in event level', 's2_ambience_peak_range_90p_area'), np.float64, (peak_number)),
+            (('S2 Ambience Peak area_fraction_top in event level', 's2_ambience_peak_area_fraction_top'), np.float64, (peak_number)),
+            (('S2 Ambience Peak center_time in event level', 's2_ambience_peak_center_time'), np.float64, (peak_number)),
+            (('S2 Ambience Peak max_pmt_area in event level', 's2_ambience_peak_max_pmt_area'), np.float64, (peak_number)),
+            (('S2 Ambience Peak area in event level', 's2_ambience_peak_area'), np.float64, (peak_number)),
+            (('S2 Ambience Peak type in event level', 's2_ambience_peak_type'), np.int, (peak_number)),
+        ]
+        return dtype
+
+    def get_window_size(self):
+        return 10 * self.drift_time_max
+
+    def fill_result(self, result, split_peaks, events, dtype):
+        for i, (_split_peaks, _events) in enumerate(zip(split_peaks, events)):
+            time_to_main_s2 = np.abs(_events['s2_time'] - _split_peaks['time'])
+            _split_peaks = _split_peaks[np.argsort(time_to_main_s2)]
+            peaks_head = _split_peaks[:self.config['peak_number_event_ambience_s2']]
+            for name in dtype:
+                if name == 'type':
+                    constant_values = -1
+                else:
+                    constant_values = 0
+                result[i][f's2_ambience_peak_{name}'] = np.pad(peaks_head[name],
+                                                               (0, self.config['peak_number_event_ambience_s2'] - len(peaks_head)),
+                                                               constant_values=constant_values)
+        return result
+
+    def compute(self, events, peaks):
+        # Step1: Find peaks contained in the drift_time_max window before and after
+        temp_events = np.zeros(len(events), dtype=strax.time_fields)
+        temp_events['time'] = events['s2_time'] - self.drift_time_max
+        temp_events['endtime'] = events['s2_endtime'] + self.drift_time_max
+        split_peaks = strax.split_by_containment(peaks, temp_events)
+
+        # Step2: Fill the peak level information in
+        result = np.zeros(len(events), self.dtype)
+        result['time'] = events['time']
+        result['endtime'] = strax.endtime(events)
+        dtype = ['range_50p_area', 'range_90p_area', 'center_time',
+                 'area_fraction_top', 'max_pmt_area', 'area', 'type']
+        result = self.fill_result(result, split_peaks, events, dtype)
+        return result
+
+

--- a/straxen/plugins/peaks/__init__.py
+++ b/straxen/plugins/peaks/__init__.py
@@ -27,3 +27,6 @@ from .peak_shadow import *
 
 from . import peaks
 from .peaks import *
+
+from . import peak_waveform
+from .peak_waveform import *

--- a/straxen/plugins/peaks/peak_waveform.py
+++ b/straxen/plugins/peaks/peak_waveform.py
@@ -1,0 +1,318 @@
+from straxen.plugins.peak_processing import PeakBasics
+import straxen
+import strax
+import numpy as np
+import numba
+from straxen.plugins.peaklet_processing import hit_max_sample
+from straxen.plugins.pulse_processing import HITFINDER_OPTIONS, HITFINDER_OPTIONS_he, HE_PREAMBLE
+export, __all__ = strax.exporter()
+
+
+
+
+@export
+@strax.takes_config(
+    strax.Option('gain_model', infer_type=False,
+                 help='PMT gain model. Specify as '
+                      '(str(model_config), str(version), nT-->boolean'),
+    strax.Option('peak_waveform_max_s1_area', default=100, infer_type=False,
+                 help='Maximum area of S1 we do hit analysis'),
+    *HITFINDER_OPTIONS,
+)
+class HitsS1(strax.OverlapWindowPlugin):
+    """
+    Return timing and area for single hits in S1s.
+    Reconstruct hits for S1s with area smaller than 100PE
+    """
+    __version__ = "0.0.0"
+    parallel = True
+    depends_on = ('peak_basics', 'records',)
+    provides = 'hits_s1'
+    data_kind = 'hits'
+    save_when = strax.SaveWhen.ALWAYS
+
+    electron_drift_velocity = straxen.URLConfig(
+        default='cmt://'
+                'electron_drift_velocity'
+                '?version=ONLINE&run_id=plugin.run_id',
+        cache=True,
+        help='Vertical electron drift velocity in cm/ns (1e4 m/ms)'
+    )
+
+
+    def setup(self):
+        self.drift_time_max = int(straxen.tpc_z / self.electron_drift_velocity)
+        self.to_pe = straxen.get_correction_from_cmt(self.run_id,
+                                                     self.config['gain_model'])
+        self.hit_thresholds = straxen.get_correction_from_cmt(self.run_id,
+                                                              self.config['hit_min_amplitude'])
+
+        return
+
+    def infer_dtype(self):
+        self.hits1_dtype = [
+                            # name                dtype       comment
+                            ('hits_max_time',     np.int64,   'Hits max_time'),
+                            ('hits_area',         np.float64, 'Hits area'),
+                            ('hits_channel',      np.int16,   'Hits channel'),
+                            ('hits_height',       np.float64, 'Hits height'),
+                            ]
+        dtype = strax.time_fields + self.hits1_dtype
+        return dtype
+
+    def get_window_size(self):
+        # return 1000  # ns
+        return self.drift_time_max
+
+    def reconstruct_hits_from_records(self, r):
+        # See straxen.plugins.peaklet_processing for reference
+        # We trick the lone_hit integration to get the area of hits
+        hits = strax.find_hits(r, min_amplitude=self.hit_thresholds)
+        hits = hits[self.to_pe[hits['channel']] != 0]
+        hits = strax.sort_by_time(hits)
+        strax.integrate_lone_hits(lone_hits=hits, records=r,
+                                  peaks=np.zeros(0, dtype=strax.time_fields),
+                                  save_outside_hits=(30, 200),
+                                  n_channels=len(self.to_pe))
+        hitlet_time_shift = (hits['left'] - hits['left_integration']) * hits['dt']
+        hits['time'] = hits['time'] - hitlet_time_shift
+        hits['length'] = (hits['right_integration'] - hits['left_integration'])
+        hits = strax.sort_by_time(hits)
+        hit_max_times = np.sort(
+            hits['time']
+            + hits['dt'] * hit_max_sample(r, hits)
+            + hitlet_time_shift
+        )
+        hitlets = np.zeros(len(hits), dtype=self.dtype)
+        hitlets['hits_channel'] = np.zeros(len(hits)) * (-1)
+        for dtype in ['channel', 'area', 'height']:
+            hitlets[f'hits_{dtype}'] = hits[dtype]
+        hitlets['hits_max_time'] = hit_max_times
+        hitlets['time'] = hits['time']
+        hitlets['endtime'] = strax.endtime(hits)
+        return hitlets
+
+    def compute(self, peaks, records):
+        # Perform waveform analysis only on records contained in small S1s
+        mask = (peaks['type'] == 1) & (peaks['area'] <= self.config['peak_waveform_max_s1_area'])
+        records_in_s1 = strax.split_touching_windows(records, peaks[mask])
+        if records_in_s1:
+            # if there is any records contained in S1
+            records_in_s1 = np.concatenate(records_in_s1)
+            hitlets = self.reconstruct_hits_from_records(records_in_s1)
+            return hitlets
+
+
+
+
+@export
+@strax.takes_config(
+    strax.Option('gain_model', infer_type=False,
+                 help='PMT gain model. Specify as '
+                      '(str(model_config), str(version), nT-->boolean'),
+    strax.Option('peak_waveform_max_s1_area', default=100, infer_type=False,
+                 help='Maximum area of S1 we do hit analysis'),
+    strax.Option('hit_number_peak_waveform_s1', default=10, type=int,
+                 help='Number of hits we stored in peaks'),
+    strax.Option('hit_shadow_casting_pmt_pe_threshold', default=2, infer_type=False,
+                 help='Minimum PMT areas we consider a shadow casting PMT'),
+    strax.Option('hit_shadow_casting_time_backward', default=1000e6, infer_type=False,
+                 help='Maximum of searching time for a casting shadow hit'),
+    *HITFINDER_OPTIONS,
+)
+class PeakWaveformS1(strax.OverlapWindowPlugin):
+    """
+    Return timing and area for single hits in S1s.
+    Reconstruct hits for S1s with area smaller than 100PE
+    Put hit shadow parameter for hits
+    """
+    __version__ = "0.0.0"
+    parallel = True
+    depends_on = ('peak_basics', 'peaks', 'hits_s1',)
+    provides = 'peak_waveform_s1'
+    data_kind = 'peaks'
+    save_when = strax.SaveWhen.ALWAYS
+
+    electron_drift_velocity = straxen.URLConfig(
+        default='cmt://'
+                'electron_drift_velocity'
+                '?version=ONLINE&run_id=plugin.run_id',
+        cache=True,
+        help='Vertical electron drift velocity in cm/ns (1e4 m/ms)'
+    )
+
+    def infer_dtype(self):
+        self.hits1_dtype_hit = [
+                            # name                dtype       comment
+                            ('hits_max_time',     np.int64,   'Hits max_time'),
+                            ('hits_area',         np.float64, 'Hits area'),
+                            ('hits_channel',      np.int16,   'Hits channel'),
+                            ('hits_height',       np.float64, 'Hits height'),
+                            ]
+        self.hits1_dtype_shadow = [
+                            # name                dtype       comment
+                            ('hits_shadow_dt',     np.int64,   'Hits time difference to prehits'),
+                            ('hits_shadow',        np.float64, 'Hits shadow'),
+                            ('hits_prehits_area',  np.float64, 'Hits prehits area'),
+                            ]
+        self.hits1_dtype = self.hits1_dtype_shadow + self.hits1_dtype_hit
+        dtype = strax.time_fields
+        for item in self.hits1_dtype:
+            (_name, _dtype, _comment) = item
+            dtype = dtype + [((f'{_comment} in peak level', f'peak_{_name}'), _dtype, (self.config['hit_number_peak_waveform_s1']))]
+        return dtype
+
+    def setup(self):
+        self.drift_time_max = int(straxen.tpc_z / self.electron_drift_velocity)
+        return
+
+    def get_window_size(self):
+        return self.config['hit_shadow_casting_time_backward']
+
+    @staticmethod
+    @numba.njit
+    def hit_shadow(hits, pre_peaks,
+                   touching_windows,
+                   exponent,
+                   pmt_area_threshold):
+        '''
+        Calculate hit shadow casted from a previous peak which has the largest
+        area_in_pmt/dt
+        '''
+        # Loop hits
+        for p_i, suspicious_hit in enumerate(hits):
+            indices = touching_windows[p_i]
+            # Loop peaks before certain hit
+            for idx in range(indices[0], indices[1]):
+                casting_peak = pre_peaks[idx]
+                dt = suspicious_hit['hits_max_time'] - casting_peak['center_time']
+                if dt<=0:
+                    continue
+                # We only need the specific channel area for hit shadow
+                casting_pmt_pe = casting_peak['area_per_channel'][suspicious_hit['hits_channel']]
+                if casting_pmt_pe >= pmt_area_threshold:
+                    new_shadow = casting_pmt_pe / dt
+                    if new_shadow > hits['hits_shadow'][p_i]:
+                        hits['hits_shadow'][p_i] = new_shadow
+                        hits['hits_shadow_dt'][p_i] = dt
+                        hits['hits_prehits_area'][p_i] = casting_pmt_pe
+
+
+    def compute(self, peaks, hits):
+        result = np.zeros(len(peaks), self.dtype)
+        result['time'] = peaks['time']
+        result['endtime'] = peaks['endtime']
+        result['peak_hits_channel'] = -1
+
+        hitlet = np.zeros(len(hits), dtype=[(elem[0], elem[1]) for elem in self.hits1_dtype+strax.time_fields])
+        for dtype in self.hits1_dtype_hit:
+            hitlet[dtype[0]] = hits[dtype[0]]
+
+        # Searching window is from hit_shadow_casting_time_backward to hits_max_time
+        roi_shadow = np.zeros(len(hitlet), dtype=strax.time_fields)
+        roi_shadow['time'] = hitlet['hits_max_time'] - self.config['hit_shadow_casting_time_backward']
+        roi_shadow['endtime'] = hitlet['hits_max_time']
+        # Use temp_peaks endtime as time to search, to avoid the hits' own peak to join the shadow
+        temp_peaks = np.zeros(len(peaks), dtype=strax.time_fields)
+        temp_peaks['time'] = temp_peaks['endtime'] = peaks['endtime']
+        split_shadow_window = strax.touching_windows(temp_peaks, roi_shadow)
+        self.hit_shadow(hits=hitlet,
+                        pre_peaks=peaks,
+                        touching_windows=split_shadow_window,
+                        exponent=int(-1),
+                        pmt_area_threshold=self.config['hit_shadow_casting_pmt_pe_threshold'])
+
+        # Perform waveform analysis only on records contained in small S1s
+        mask = (peaks['type'] == 1) & (peaks['area'] <= self.config['peak_waveform_max_s1_area'])
+        # Search for hit-s1 matching with maxtime
+        temp = np.zeros(len(hitlet), dtype=strax.time_fields)
+        temp['time'] = temp['endtime'] = hitlet['hits_max_time']
+        split_hits_window = strax.touching_windows(temp, peaks[mask])
+        for i, index in zip(range(mask.sum()),
+                            np.arange(len(mask))[mask]):
+            left_i, right_i = split_hits_window[i]
+            hitlet_head = hitlet[left_i:right_i][:self.config['hit_number_peak_waveform_s1']]
+            for name in [elem[0] for elem in self.hits1_dtype]:
+                if 'channel' in name:
+                    constant_values = -1
+                else:
+                    constant_values = 0
+                result[index][f'peak_{name}'] = np.pad(hitlet_head[name],
+                                                       (0, self.config['hit_number_peak_waveform_s1'] - len(hitlet_head)),
+                                                       constant_values=constant_values)
+        return result
+
+
+@export
+@strax.takes_config(
+    strax.Option('hit_number_peak_ambience_s1', default=20, type=int,
+                 help='Number of hits we stored in peaks for ambience'),
+)
+class PeakAmbienceS1(strax.OverlapWindowPlugin):
+    """
+    Return the first peak_number lone_hits information in a window near S1
+    """
+    __version__ = "0.0.0"
+    parallel = True
+    depends_on = ('peak_basics', 'lone_hits',)
+    provides = 'peak_ambience_s1'
+    data_kind = 'peaks'
+    save_when = strax.SaveWhen.ALWAYS
+
+    electron_drift_velocity = straxen.URLConfig(
+        default='cmt://'
+                'electron_drift_velocity'
+                '?version=ONLINE&run_id=plugin.run_id',
+        cache=True,
+        help='Vertical electron drift velocity in cm/ns (1e4 m/ms)'
+    )
+    def infer_dtype(self):
+        dtype = strax.time_fields + [
+            (('Lone hits time in peak level', 'lone_hits_time'), np.int64, (self.config['hit_number_peak_ambience_s1'])),
+            (('Lone hits area in peak level', 'lone_hits_area'), np.float64, (self.config['hit_number_peak_ambience_s1'])),
+            (('Lone hits channel in peak level', 'lone_hits_channel'), np.int16, (self.config['hit_number_peak_ambience_s1']))]
+        return dtype
+
+    def setup(self):
+        self.drift_time_max = int(straxen.tpc_z / self.electron_drift_velocity)
+        self.s1_ambience_time_window = 5 * self.drift_time_max
+        return
+
+    def get_window_size(self):
+        return 10 * self.drift_time_max
+
+    @staticmethod
+    @numba.njit
+    def fill_result(result, _dtype, windows, container, things_time_only,
+                    things_dtype_only, peak_number):
+        for i, _container in enumerate(container):
+            left_i, right_i = windows[i]
+            _split_things_time = things_time_only[left_i:right_i]
+            _split_things_dtype = things_dtype_only[left_i:right_i]
+            time_to_container = np.abs(_container['time'] - _split_things_time)
+            _split_things_dtype = _split_things_dtype[np.argsort(time_to_container)][:peak_number]
+            if 'channel' in _dtype:
+                fill_in = np.ones(peak_number) * (-1)
+            else:
+                fill_in = np.zeros(peak_number)
+            length = np.int8(len(_split_things_dtype))
+            fill_in[:length] = _split_things_dtype
+            result[i] = fill_in
+
+    def compute(self, peaks, lone_hits):
+        windows = strax.touching_windows(lone_hits, peaks,
+                                         window=self.s1_ambience_time_window)
+        result = np.zeros(len(peaks), self.dtype)
+        result['time'] = peaks['time']
+        result['endtime'] = peaks['endtime']
+        dtype = ['time', 'area', 'channel']
+        for _dtype in dtype:
+            self.fill_result(result=result[f'lone_hits_{_dtype}'],
+                             _dtype=_dtype,
+                             windows=windows,
+                             container=peaks,
+                             things_time_only=lone_hits['time'],
+                             things_dtype_only=lone_hits[_dtype],
+                             peak_number=self.config['hit_number_peak_ambience_s1'])
+        return result
+


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

It contains the plugins used for the hit/SE level waveform-based AC suppression:

* HitsS1: Perform hit finding for S1s smaller than 100PE, and calculate the hit_max_time; a new data type, as it's uneconomical to store all hit information, while only small S1's are useful.
* PeakWaveformS1: Pile hit level information into the Peak level, and calculate per PMT hit shadow.
* PeakAmbienceS1: Pile ambient lone-hit information into Peak level.
* EventWaveformS1: Pass peak to event
* EventAmbienceS1: Pass peak to event
* EventWaveformS2: Calculate the per single electron time and area in small S2s
* EventAmbienceS2: Pile the ambient single electrons near S2

## Can you briefly describe how it works?
They serve as extractors from low-level information to peak/event-level data. The data is compiled into NumPy arrays like event_area_per_channel for peak and event-level information.

## Note that:
* Since the HitS1 plugin is computationally expensive, it would be great if it can catch the next reprocessing.
* The code styles need refactoring to reflect the change of URL config and the newest straxen data-structure, please help :)

## Relevant notes:
* https://xe1t-wiki.lngs.infn.it/doku.php?id=shenyang:xenonnt_sr0:electron_statistics
* https://xe1t-wiki.lngs.infn.it/doku.php?id=shenyang:xenonnt_sr0:hit_statistics