### PR TITLE
Add entry points

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@
 omit =
         ./straxen/storage/rucio_remote.py
         ./straxen/legacy/plugins_1t/pax_interface.py
+        ./straxen/entry_points.py
 
 # Regexes for lines to exclude from consideration
 exclude_lines =

--- a/docs/source/extending_straxen.rst
+++ b/docs/source/extending_straxen.rst
@@ -1,0 +1,33 @@
+Extending Straxen using Entry Points
+====================================
+Straxen has multiple methods for runtime extension of it functionality 
+such as adding context methods, new plugins, URLConfig protocols and mini-analyes.
+These extensions can be registered at runtime by the user when needed.
+Sometimes its useful to place extra features/functionality in a separate package and have the functionality
+registered automatically when straxen is imported. For this python has a mechanism called entry points.
+Entry points are a way to extend the functionality of a package without having to modify the package itself.
+This is done by adding a section to the package's setup.py file. This section is called entry_points and
+is a dictionary where the keys are the entry point group and the values are a list of strings with the
+entry point name and the object reference. For example in you setup.py:
+
+
+.. code-block::
+
+    entry_points={
+        'straxen': [
+            '_ = my_package.my_module:register_my_plugin',
+        ],
+    }
+
+
+or if you have a pyproject.toml file:
+
+.. code-block:: 
+
+    [tool.poetry.plugins."straxen"]
+    "_" = "my_package.my_module:register_my_plugin"
+
+
+The right hand side of the entry point is a reference to the object that should be registered.
+It can be a module or a callable. If it is a callable, 
+straxen will call it on import, otherwise the module will simply be imported.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,6 +41,7 @@ Straxen is the analysis framework for XENONnT, built on top of the generic `stra
     url_configs
     scada_interface
     tutorials/ScadaInterfaceExample.ipynb
+    extending_straxen.rst
 
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,7 +41,7 @@ Straxen is the analysis framework for XENONnT, built on top of the generic `stra
     url_configs
     scada_interface
     tutorials/ScadaInterfaceExample.ipynb
-    extending_straxen.rst
+    extending_straxen
 
 
 .. toctree::

--- a/straxen/__init__.py
+++ b/straxen/__init__.py
@@ -38,3 +38,8 @@ try:
     from .holoviews_utils import *
 except ModuleNotFoundError:
     pass
+
+from .entry_points import load_entry_points
+
+load_entry_points()
+del load_entry_points

--- a/straxen/entry_points.py
+++ b/straxen/entry_points.py
@@ -1,0 +1,55 @@
+
+# Entrypoint loading logic
+# Can be used to register context methods, mini-analyses, 
+# URLConfig protocols etc by other packeges when straxen is
+# imported.
+# The nice optimization of the different import attempts
+# was copied from the hypothesis package
+# https://github.com/HypothesisWorks/hypothesis/blob/master/hypothesis-python/src/hypothesis/entry_points.py
+
+
+try:
+    # We prefer to use importlib.metadata, or the backport on Python <= 3.7,
+    # because it's much faster than pkg_resources (200ms import time speedup).
+    try:
+        from importlib import metadata as importlib_metadata
+    except ImportError:
+        import importlib_metadata  # type: ignore  # mypy thinks this is a redefinition
+
+    def get_entry_points():
+        try:
+            eps = importlib_metadata.entry_points(group="straxen")
+        except TypeError:
+            # Load-time selection requires Python >= 3.10 or importlib_metadata >= 3.6,
+            # so we'll retain this fallback logic for some time to come.  See also
+            # https://importlib-metadata.readthedocs.io/en/latest/using.html
+            eps = importlib_metadata.entry_points().get("straxen", [])
+        yield from eps
+
+except ImportError:
+    # But if we're not on Python >= 3.8 and the importlib_metadata backport
+    # is not installed, we fall back to pkg_resources anyway.
+    try:
+        import pkg_resources
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "Under Python <= 3.7, straxen requires either the importlib_metadata "
+            "or setuptools package in order to load plugins via entrypoints.",
+        )
+
+        def get_entry_points():
+            yield from ()
+
+    else:
+
+        def get_entry_points():
+            yield from pkg_resources.iter_entry_points("straxen")
+
+
+def load_entry_points():
+    for entry in get_entry_points():  # pragma: no cover
+        hook = entry.load()
+        if callable(hook):
+            hook()


### PR DESCRIPTION
Adds entry point loading. This can be used to register context methods, mini-analyses, URLConfig protocols etc by other packages when straxen is imported.

Defines an entry point called `straxen` that packages can register modules or functions to which will be imported/ called on import of straxen.