### PR TITLE
Add max_gap into peak and event level

### DIFF
--- a/straxen/plugins/events/event_basics.py
+++ b/straxen/plugins/events/event_basics.py
@@ -19,7 +19,7 @@ class EventBasics(strax.Plugin):
     alternative S2 is selected as the largest S2 other than main S2
     in the time window [main S1 time, main S1 time + max drift time].
     """
-    __version__ = '1.3.1'
+    __version__ = '1.3.2'
 
     depends_on = ('events',
                   'peak_basics',
@@ -75,6 +75,13 @@ class EventBasics(strax.Plugin):
                   ]
 
         dtype += self._get_si_dtypes(self.peak_properties)
+
+        dtype += [
+            (f's1_max_gap', np.int32,
+             f'Main S1 largest gap between hits [ns]'),
+            (f'alt_s1_max_gap', np.int32,
+             f'Alternate S1 largest gap between hits [ns]')
+        ]
 
         dtype += [
             (f's2_x', np.float32,
@@ -253,7 +260,9 @@ class EventBasics(strax.Plugin):
             # Largest index 0 -> main sx, 1 -> alt sx
             for largest_index, main_or_alt in enumerate(['s', 'alt_s']):
                 peak_properties_to_save = [name for name, _, _ in self.peak_properties]
-                if s_i == 2:
+                if s_i == 1:
+                    peak_properties_to_save += ['max_gap']
+                elif s_i == 2:
                     peak_properties_to_save += ['x', 'y']
                     peak_properties_to_save += self.posrec_save
                 field_names = [f'{main_or_alt}{s_i}_{name}' for name in peak_properties_to_save]

--- a/straxen/plugins/peaks/peak_basics.py
+++ b/straxen/plugins/peaks/peak_basics.py
@@ -14,7 +14,7 @@ class PeakBasics(strax.Plugin):
     arrays.
     NB: This plugin can therefore be loaded as a pandas DataFrame.
     """
-    __version__ = "0.1.3"
+    __version__ = "0.1.4"
     parallel = True
     depends_on = ('peaks',)
     provides = 'peak_basics'
@@ -53,7 +53,9 @@ class PeakBasics(strax.Plugin):
         (('Number of PMTs with hits within tight range of mean',
           'tight_coincidence'), np.int16),
         (('Classification of the peak(let)',
-          'type'), np.int8)
+          'type'), np.int8),
+        (('Largest gap between hits inside peak [ns]',
+          'max_gap'), np.int32)
     ]
 
     n_top_pmts = straxen.URLConfig(default=straxen.n_top_pmts, infer_type=False,
@@ -68,7 +70,7 @@ class PeakBasics(strax.Plugin):
     def compute(self, peaks):
         p = peaks
         r = np.zeros(len(p), self.dtype)
-        for q in 'time length dt area type'.split():
+        for q in 'time length dt area type max_gap'.split():
             r[q] = p[q]
         r['endtime'] = p['time'] + p['dt'] * p['length']
         r['n_channels'] = (p['area_per_channel'] > 0).sum(axis=1)


### PR DESCRIPTION
Add max_gap(largest gap between hits inside peak) into peak and event _basics

## What does the code in this PR do / what does it improve?

Save `max_gap` to peak and event level, in `peak_basics` and `event_basics`

## Can you briefly describe how it works?

Just add some data fields. 

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_
