### PR TITLE
Fix pymongo warning bootstrax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ custom_data
 test_input_data
 *.zip
 last_bootstrax_exception.txt
+bootstrax_exceptions
 
 # cProfile output
 *.prof

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1648,6 +1648,10 @@ def cleanup_db():
 
 
 if __name__ == '__main__':
+
+    # to avoid warnings pymongo fork
+    multiprocessing.set_start_method('spawn')
+
     if not args.undying:
         main()
     else:


### PR DESCRIPTION
## Fix warnings from pymongo in bootstrax

The following warning was showing up so much that reading the logs of bootstrax was becoming impossible. 

```
/home/xedaq/miniconda/envs/py38/lib/python3.8/site-packages/pymongo/topology.py:164: UserWarning: MongoClient opened before fork. Create MongoClient only after forking. See PyMongo's documentation for details: https://pymongo.readthedocs.io/en/stable/faq.html#is-pymongo-fork-safe
```

Following this [stackoverflow thread ](https://stackoverflow.com/questions/65255779/userwarning-mongoclient-opened-before-fork-create-mongoclient-only-after-forki), and setting the start as spawn, makes the error disappear and the process more safe. 