### PR TITLE
Adding correction of Z position due to non-uniform drift velocity

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -63,6 +63,11 @@ xnt_common_config = dict(
             '&run_id=plugin.run_id'
             '&fmt=binary'
             '&scale_coordinates=plugin.coordinate_scales',
+    z_bias_map='itp_map://'
+               'resource://'
+               'XnT_z_bias_map_chargeup_20230329.json.gz?'
+               'fmt=json.gz'
+               '&method=RegularGridInterpolator',
 )
 # these are placeholders to avoid calling cmt with non integer run_ids. Better solution pending.
 # s1,s2 and fd corrections are still problematic

--- a/straxen/legacy/xenon1t_url_configs.py
+++ b/straxen/legacy/xenon1t_url_configs.py
@@ -86,3 +86,12 @@ def get_legacy_fdc(name, run_id=None):
         raise ValueError(f'No legacy fdc for run {run_id}')
 
     return InterpolatingMap(get_resource(url, fmt='binary'))
+
+
+@URLConfig.register('legacy-z_bias')
+def get_z_bias():
+    """Return a lambda function return zeros as placeholder"""
+    def fake_z_bias(rz, **kwargs):
+        return np.zeros(len(rz))
+
+    return fake_z_bias

--- a/straxen/legacy/xenon1t_url_configs.py
+++ b/straxen/legacy/xenon1t_url_configs.py
@@ -89,9 +89,9 @@ def get_legacy_fdc(name, run_id=None):
 
 
 @URLConfig.register('legacy-z_bias')
-def get_z_bias():
-    """Return a lambda function return zeros as placeholder"""
+def get_z_bias(offset: str):
+    """Return a lambda function return offset as placeholder"""
     def fake_z_bias(rz, **kwargs):
-        return np.zeros(len(rz))
+        return np.zeros(len(rz)) * int(offset)
 
     return fake_z_bias

--- a/straxen/plugins/events/event_positions.py
+++ b/straxen/plugins/events/event_positions.py
@@ -49,7 +49,7 @@ class EventPositions(strax.Plugin):
     z_bias_map = straxen.URLConfig(
         infer_type=False,
         help='Map of Z bias due to non uniform drift velocity/field',
-        default='legacy-z_bias')
+        default='legacy-z_bias://0')
 
     def infer_dtype(self):
         dtype = []

--- a/straxen/plugins/events/event_positions.py
+++ b/straxen/plugins/events/event_positions.py
@@ -50,7 +50,7 @@ class EventPositions(strax.Plugin):
         infer_type=False,
         help='Map of Z bias due to non uniform drift velocity/field',
         default='itp_map://resource://XnT_z_bias_map_chargeup_20230329.json.gz?'
-                 'fmt=json.gz&method=RegularGridInterpolator')
+                'fmt=json.gz&method=RegularGridInterpolator')
     def infer_dtype(self):
         dtype = []
         for j in 'x y r'.split():
@@ -142,7 +142,7 @@ class EventPositions(strax.Plugin):
             z_cor[invalid] = z_obs[invalid]
             delta_z = z_cor - z_obs
             # correction of z bias due to non-uniform field
-            z_dv_delta = self.z_bias_map(np.array([r_obs, z_obs]).T,map_name='z_bias_map')
+            z_dv_delta = self.z_bias_map(np.array([r_obs, z_obs]).T, map_name='z_bias_map')
 
             pre_field = '' if s_i == 0 else f'alt_s{s_i}_'
             post_field = '' if s_i == 0 else '_fdc'
@@ -157,6 +157,6 @@ class EventPositions(strax.Plugin):
                            # the FDC for z (z_cor) is found to be not reliable (see #527)
                            f'{pre_field}z': z_obs,
                            f'{pre_field}z_field_distortion_correction': delta_z,
-                           f'{pre_field}z_dv_corr': z_obs - z_dv_delta
+                           f'{pre_field}z_dv_corr': z_obs - z_dv_delta,
                            })
         return result

--- a/straxen/plugins/events/event_positions.py
+++ b/straxen/plugins/events/event_positions.py
@@ -49,8 +49,8 @@ class EventPositions(strax.Plugin):
     z_bias_map = straxen.URLConfig(
         infer_type=False,
         help='Map of Z bias due to non uniform drift velocity/field',
-        default='itp_map://resource://XnT_z_bias_map_chargeup_20230329.json.gz?'
-                'fmt=json.gz&method=RegularGridInterpolator')
+        default='legacy-z_bias')
+
     def infer_dtype(self):
         dtype = []
         for j in 'x y r'.split():

--- a/straxen/plugins/events/event_positions.py
+++ b/straxen/plugins/events/event_positions.py
@@ -49,7 +49,7 @@ class EventPositions(strax.Plugin):
     z_bias_map = straxen.URLConfig(
         infer_type=False,
         help='Map of Z bias due to non uniform drift velocity/field',
-        default='itp_map://resource://z_bias_map_comsol_chargeup_20230329.json.gz?'
+        default='itp_map://resource://XnT_z_bias_map_chargeup_20230329.json.gz?'
                  'fmt=json.gz&method=RegularGridInterpolator')
     def infer_dtype(self):
         dtype = []

--- a/straxen/plugins/events/event_positions.py
+++ b/straxen/plugins/events/event_positions.py
@@ -19,7 +19,7 @@ class EventPositions(strax.Plugin):
 
     depends_on = ('event_basics',)
 
-    __version__ = '0.1.5'
+    __version__ = '0.2.0'
 
     default_reconstruction_algorithm = straxen.URLConfig(
         default=DEFAULT_POSREC_ALGO,
@@ -46,6 +46,11 @@ class EventPositions(strax.Plugin):
         help='3D field distortion correction map path',
         default='legacy-fdc://xenon1t_sr0_sr1?run_id=plugin.run_id')
 
+    z_bias_map = straxen.URLConfig(
+        infer_type=False,
+        help='Map of Z bias due to non uniform drift velocity/field',
+        default='itp_map://resource://z_bias_map_comsol_chargeup_20230329.json.gz?'
+                 'fmt=json.gz&method=RegularGridInterpolator')
     def infer_dtype(self):
         dtype = []
         for j in 'x y r'.split():
@@ -59,10 +64,17 @@ class EventPositions(strax.Plugin):
         for j in ['z']:
             comment = 'Interaction z-position, using mean drift velocity only (cm)'
             dtype += [(j, np.float32, comment)]
+            comment = 'Interaction z-position corrected to non-uniform drift velocity [ cm ]'
+            dtype += [(j + "_dv_corr", np.float32, comment)]
             for s_i in [1, 2]:
                 comment = f'Alternative S{s_i} z-position (rel. main S{int(2 * (1.5 - s_i) + s_i)}), using mean drift velocity only (cm)'
                 field = f'alt_s{s_i}_z'
                 dtype += [(field, np.float32, comment)]
+                # values for corrected Z position
+                comment = f'Alternative S{s_i} z-position (rel. main S{[1 if s_i==2 else 2]}), corrected for non-uniform field (cm)'
+                field = f'alt_s{s_i}_z_dv_corr'
+                dtype += [(field, np.float32, comment)]
+
 
         naive_pos = []
         fdc_pos = []
@@ -129,6 +141,8 @@ class EventPositions(strax.Plugin):
                 invalid |= z_obs >= 0
             z_cor[invalid] = z_obs[invalid]
             delta_z = z_cor - z_obs
+            # correction of z bias due to non-uniform field
+            z_dv_delta = self.z_bias_map(np.array([r_obs, z_obs]).T,map_name='z_bias_map')
 
             pre_field = '' if s_i == 0 else f'alt_s{s_i}_'
             post_field = '' if s_i == 0 else '_fdc'
@@ -142,7 +156,7 @@ class EventPositions(strax.Plugin):
                            # using z_obs in agreement with the dtype description
                            # the FDC for z (z_cor) is found to be not reliable (see #527)
                            f'{pre_field}z': z_obs,
-                           f'{pre_field}z_field_distortion_correction': delta_z
+                           f'{pre_field}z_field_distortion_correction': delta_z,
+                           f'{pre_field}z_dv_corr': z_obs - z_dv_delta
                            })
-
         return result


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Adds correction of Z position bias due to non-uniform field and, correspondingly, drift velocity. 

## Can you briefly describe how it works?
It loads a map produced from COMSOL field simulation. The map gets r_naive, z_naive and returns expected bias value that is then subtracted from z_naive. 

Map is uploaded to database in this PR https://github.com/XENONnT/private_nt_aux_files/pull/251

## Can you give a minimal working example (or illustrate with a figure)?
```
st.get_array(runid, ["event_positions"])
```
the new corrected position is in field `z_dv_corr` 