### PR TITLE
reforming _raw_path and _processed_path

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -122,10 +122,10 @@ def xenonnt_online(output_folder: str = './strax_data',
                    download_heavy: bool = False,
                    _rucio_path: str = '/dali/lgrandi/rucio/',
                    _rucio_local_path: ty.Optional[str] = None,
-                   _raw_paths: ty.Optional[str] = ['/dali/lgrandi/xenonnt/raw',],
-                   _processed_paths: ty.Optional[ty.List[str]] = ['/dali/lgrandi/xenonnt/processed', 
+                   _raw_paths: ty.Optional[str] = ['/dali/lgrandi/xenonnt/raw'],
+                   _processed_paths: ty.Optional[ty.List[str]] = ['/dali/lgrandi/xenonnt/processed',
                                                                   '/project2/lgrandi/xenonnt/processed',
-                                                                  '/project/lgrandi/xenonnt/processed',],
+                                                                  '/project/lgrandi/xenonnt/processed'],
 
                    # Testing options
                    _context_config_overwrite: ty.Optional[dict] = None,
@@ -189,11 +189,11 @@ def xenonnt_online(output_folder: str = './strax_data',
                 strax.DataDirectory(
                     _raw_path,
                     readonly=True,
-                    take_only=straxen.DAQReader.provides),]
+                    take_only=straxen.DAQReader.provides)]
         for _processed_path in _processed_paths:
             st.storage += [strax.DataDirectory(
                 _processed_path,
-                readonly=True),]
+                readonly=True)]
             
         if output_folder:
             st.storage += [strax.DataDirectory(output_folder,

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -122,8 +122,10 @@ def xenonnt_online(output_folder: str = './strax_data',
                    download_heavy: bool = False,
                    _rucio_path: str = '/dali/lgrandi/rucio/',
                    _rucio_local_path: ty.Optional[str] = None,
-                   _raw_path: ty.Optional[str] = '/dali/lgrandi/xenonnt/raw',
-                   _processed_path: ty.Optional[str] = '/dali/lgrandi/xenonnt/processed',
+                   _raw_paths: ty.Optional[str] = ['/dali/lgrandi/xenonnt/raw',],
+                   _processed_paths: ty.Optional[ty.List[str]] = ['/dali/lgrandi/xenonnt/processed', 
+                                                                  '/project2/lgrandi/xenonnt/processed',
+                                                                  '/project/lgrandi/xenonnt/processed',],
 
                    # Testing options
                    _context_config_overwrite: ty.Optional[dict] = None,
@@ -152,8 +154,8 @@ def xenonnt_online(output_folder: str = './strax_data',
     :param _rucio_path: str, path of rucio
     :param _rucio_local_path: str, path of local RSE of rucio. Only use
         for testing!
-    :param _raw_path: str, common path of the raw-data
-    :param _processed_path: str. common path of output data
+    :param _raw_paths: list[str], common path of the raw-data
+    :param _processed_paths: list[str]. common paths of output data
     :param _context_config_overwrite: dict, overwrite config
     :param _database_init: bool, start the database (for testing)
     :param _forbid_creation_of: str/tuple, of datatypes to prevent form
@@ -182,15 +184,17 @@ def xenonnt_online(output_folder: str = './strax_data',
             rucio_path=_rucio_path,
         )] if _database_init else []
     if not we_are_the_daq:
-        st.storage += [
-            strax.DataDirectory(
-                _raw_path,
-                readonly=True,
-                take_only=straxen.DAQReader.provides),
-            strax.DataDirectory(
+        for _raw_path in _raw_paths:
+            st.storage += [
+                strax.DataDirectory(
+                    _raw_path,
+                    readonly=True,
+                    take_only=straxen.DAQReader.provides),]
+        for _processed_path in _processed_paths:
+            st.storage += [strax.DataDirectory(
                 _processed_path,
-                readonly=True,
-            )]
+                readonly=True),]
+            
         if output_folder:
             st.storage += [strax.DataDirectory(output_folder,
                                                provide_run_metadata=True,

--- a/tests/storage/test_rucio_remote.py
+++ b/tests/storage/test_rucio_remote.py
@@ -21,9 +21,9 @@ class TestRucioRemote(unittest.TestCase):
             include_rucio_remote=True,
             download_heavy=download_heavy,
             _rucio_path=self.staging_dir,
-            _raw_path=os.path.join(self.staging_dir, 'raw'),
+            _raw_paths=[os.path.join(self.staging_dir, 'raw')],
             _database_init=False,
-            _processed_path=os.path.join(self.staging_dir, 'processed'),
+            _processed_paths=[os.path.join(self.staging_dir, 'processed')],
         )
         return context
 


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
To handle the directories where we put processed data automatically, when not being able to access `/dali` storage.

## Can you briefly describe how it works?
Refactored `_raw_path` and `_processed_path` to lists, so that we can have multiple sites. 
## Can you give a minimal working example (or illustrate with a figure)?
On midway2 compute nodes, the following was impossible, because you didn't direct straxen to `/project2/lgrandi/xenonnt/processed`. Lanqing can be pinged less then.

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_

