### PR TITLE
AmBe skip heavy computation

### DIFF
--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -1449,7 +1449,7 @@ def process_run(rd, send_heartbeats=args.production):
                     if not len(md['chunks']):
                         fail("Processing succeeded, but no chunks were written!")
 
-                    if any((chunk['n'] and not chunk['filesize'])
+                    if any((chunk['n'] and 'filesize' in chunk and not chunk['filesize'])
                            for chunk in md['chunks']):
                         # E.g. you tried compressing >2 GB chunk using blosc
                         fail("At least one chunk failed writing!")

--- a/bin/bootstrax
+++ b/bin/bootstrax
@@ -555,6 +555,12 @@ def infer_target(rd: dict) -> dict:
         # also use source field, outcome is the same)
         if 'event_info' in targets or 'event_info' in post_process:
             targets = list(targets) + ['event_info_double']
+    elif 'ambe' in mode:
+        # rates are very high, to ensure smooth operation let's just do this
+        # based on calibrations of Apr 2023 this is the only safe working solution
+        log.debug('ambe-mode')
+        targets = 'raw_records'
+        post_process = 'veto_intervals'
 
     targets = strax.to_str_tuple(targets)
     post_process = strax.to_str_tuple(post_process)

--- a/bin/restrax
+++ b/bin/restrax
@@ -131,7 +131,10 @@ class ReStrax(daq_core.DataBases):
 
     exclude_modes: ty.Iterable = (
         'pmtgain', 'pmtap', 'exttrig', 'noise', 'nVeto_LASER_calibration',
-        'mv_diffuserballs', 'mv_fibres', 'mv_darkrate')
+        'mv_diffuserballs', 'mv_fibres', 'mv_darkrate',
+        # rates are very high, better to skip restrax to avoid memory issues 
+        # anyway, restrax loses a bit its meaning with high rates
+        'ambe_linked', 'ambe_linked_hev')
 
     # If a dataset is larger than this many bytes, only compare a single field (time)
     large_data_compare_threshold: ty.Union[int, float] = int(5e9)

--- a/bin/restrax
+++ b/bin/restrax
@@ -558,7 +558,7 @@ class ReStrax(daq_core.DataBases):
             md_in = storage_backend.get_metadata(dir_in)
             md_out = storage_backend.get_metadata(dir_out)
 
-            if any((chunk['n'] and not chunk['filesize'])
+            if any((chunk.get('n', 0) and not chunk.get('filesize', 0))
                    for chunk in md_out['chunks']):
                 # E.g. you tried compressing >2 GB chunk using blosc
                 errors.append(f'For {dir_out}, at least one doc failed to write')

--- a/bin/restrax
+++ b/bin/restrax
@@ -558,7 +558,8 @@ class ReStrax(daq_core.DataBases):
             md_in = storage_backend.get_metadata(dir_in)
             md_out = storage_backend.get_metadata(dir_out)
 
-            if any((chunk.get('n', 0) and not chunk.get('filesize', 0))
+            # Filesize is "bonus" metadata so it may not always be there. Hence the .get(filesize, True)
+            if any((chunk.get('n', 0) and not chunk.get('filesize', True))
                    for chunk in md_out['chunks']):
                 # E.g. you tried compressing >2 GB chunk using blosc
                 errors.append(f'For {dir_out}, at least one doc failed to write')

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -215,7 +215,7 @@ def xenonnt_online(output_folder: str = './strax_data',
     if _database_init and (include_online_monitor or we_are_the_daq):
         st.storage += [straxen.OnlineMonitor(
             readonly=not we_are_the_daq,
-            take_only=('veto_intervals',
+            take_only=(#'veto_intervals',
                        'online_peak_monitor',
                        'event_basics',
                        'online_monitor_nv',


### PR DESCRIPTION
This is the straxen that is currently running on the EBs. This is just meant to be a pull request for reference. 

It's a mixtures of small operations done on the DAQ. 
It includes:

- bug fix from @JoranAngevaare for getting filesize from rundoc
- temporary patch from @mflierm due to failures in uploading veto_intervals to the MongoDB when too many vetos are fired (happened during ambe_hev) -> it needs to be fixed in some other permanent way, so that we don't completely loose one of our nice online monitor panels
- only process raw_records and veto_intervals by default for ambe modes, added by myself 
- bypass restrax operations by default for ambe modes, added by myself


