### PR TITLE
Bump the versions of peaklets and quality check runs-on

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   qa:
     name: Quality check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Change __all__ exports for pyflake

--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -37,7 +37,7 @@ class Peaklets(strax.Plugin):
     parallel = 'process'
     compressor = 'zstd'
 
-    __version__ = '1.0.0'
+    __version__ = '1.0.1'
 
     peaklet_gap_threshold = straxen.URLConfig(
         default=700, infer_type=False,

--- a/straxen/plugins/peaks/peaks.py
+++ b/straxen/plugins/peaks/peaks.py
@@ -14,7 +14,7 @@ class Peaks(strax.Plugin):
     (replacing all peaklets that were later re-merged as S2s). As this
     step is computationally trivial, never save this plugin.
     """
-    __version__ = '0.1.2'
+    __version__ = '0.1.3'
 
     depends_on = ('peaklets', 'peaklet_classification', 'merged_s2s')
     data_kind = 'peaks'

--- a/straxen/plugins/peaks/peaks.py
+++ b/straxen/plugins/peaks/peaks.py
@@ -14,7 +14,7 @@ class Peaks(strax.Plugin):
     (replacing all peaklets that were later re-merged as S2s). As this
     step is computationally trivial, never save this plugin.
     """
-    __version__ = '0.1.3'
+    __version__ = '0.1.2'
 
     depends_on = ('peaklets', 'peaklet_classification', 'merged_s2s')
     data_kind = 'peaks'


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Because the debugging in https://github.com/AxFoundation/strax/pull/708 will change the `max_gap` in the peaks level. So we should bump the version of `peaklets`. 

Also, try to bump the version of quality check's `runs-on`. 

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
