### PR TITLE
Use zstd as compressor of peaks

### DIFF
--- a/straxen/plugins/peaks/peaks.py
+++ b/straxen/plugins/peaks/peaks.py
@@ -20,6 +20,7 @@ class Peaks(strax.Plugin):
     data_kind = 'peaks'
     provides = 'peaks'
     parallel = True
+    compressor = 'zstd'
     save_when = strax.SaveWhen.EXPLICIT
 
     diagnose_sorting = straxen.URLConfig(


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Because sometimes peaks chunk is very large. And if so we will see error which was implemented in https://github.com/AxFoundation/strax/pull/714. 

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
