### PR TITLE
Use same files names for peak and event level pos-rec

### DIFF
--- a/straxen/plugins/events/event_s1_position_cnn.py
+++ b/straxen/plugins/events/event_s1_position_cnn.py
@@ -13,7 +13,7 @@ class EventS1PositionCNN(EventS1PositionBase):
     """
     algorithm = "s1_cnn"
     provides = "event_s1_position_cnn"
-    # tf_event_model_s1_cnn = straxen.URLConfig.evaluate_dry(f'tf:///project2/lgrandi/guidam/CNN_S1_XYZ_SAVED_MODELS/xnt_s1_posrec_cnn_datadriven_00_080921.tar.gz')
+
     tf_event_model_s1_cnn = straxen.URLConfig(
         default=f'tf://'
                 f'resource://'
@@ -26,4 +26,4 @@ class EventS1PositionCNN(EventS1PositionBase):
         help='s1 position 3d reconstruction cnn model. Should be opened using the "tf" descriptor. '
              'Set to "None" to skip computation',
         cache=3,
-)
+    )

--- a/straxen/plugins/peaks/peak_positions_cnn.py
+++ b/straxen/plugins/peaks/peak_positions_cnn.py
@@ -1,6 +1,5 @@
 import strax
 import straxen
-
 from straxen.plugins.peaks._peak_positions_base import PeakPositionsBaseNT
 
 

--- a/straxen/plugins/peaks/peak_s1_position_cnn.py
+++ b/straxen/plugins/peaks/peak_s1_position_cnn.py
@@ -15,7 +15,6 @@ class PeakS1PositionCNN(PeakS1PositionBase):
     algorithm = "s1_cnn"
     __version__ = '0.0.1'
 
-    # tf_peak_model_s1_cnn = straxen.URLConfig.evaluate_dry(f'tf:///project2/lgrandi/guidam/CNN_S1_XYZ_SAVED_MODELS/xnt_s1_posrec_cnn_datadriven_00_080921.tar.gz')
     tf_peak_model_s1_cnn = straxen.URLConfig(
         default=f'tf://'
                 f'resource://'
@@ -28,4 +27,4 @@ class PeakS1PositionCNN(PeakS1PositionBase):
         help='s1 position 3d reconstruction cnn model. Should be opened using the "tf" descriptor. '
              'Set to "None" to skip computation',
         cache=3,
-)
+    )


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Simply change the file name to follow the `peak_positons` and `event_positions` styles. 

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
