### PR TITLE
Fix ipython version

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -5,3 +5,4 @@ wfsim==1.0.2
 nbmake
 pytest-xdist
 xedocs==0.2.16
+ipython==8.12.1


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

From `ipython==8.13.0`, it stops supporting `python==3.8` or lower versions. 

https://github.com/ipython/ipython/blob/02bab11e7a2cd15670c17f6c8587f0609eb61961/IPython/__init__.py#L29

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
