### PR TITLE
Fix bug in hitlets time ordering

### DIFF
--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -37,7 +37,7 @@ class Peaklets(strax.Plugin):
     parallel = 'process'
     compressor = 'zstd'
 
-    __version__ = '1.0.1'
+    __version__ = '1.1.0'
 
     peaklet_gap_threshold = straxen.URLConfig(
         default=700, infer_type=False,

--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -37,7 +37,7 @@ class Peaklets(strax.Plugin):
     parallel = 'process'
     compressor = 'zstd'
 
-    __version__ = '1.1.0'
+    __version__ = '1.0.2'
 
     peaklet_gap_threshold = straxen.URLConfig(
         default=700, infer_type=False,

--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -284,12 +284,14 @@ class Peaklets(strax.Plugin):
         # (b) increase strax memory usage / max_messages,
         #     possibly due to its currently primitive scheduling.
         hit_max_times_argsort = np.argsort(hit_max_times)
+        sorted_hit_max_times = hit_max_times[hit_max_times_argsort]
+        sorted_hit_channels = hitlets['channel'][hit_max_times_argsort]
         peaklet_max_times = (
             peaklets['time']
             + np.argmax(peaklets['data'], axis=1) * peaklets['dt'])
         tight_coincidence_channel = get_tight_coin(
-            hit_max_times[hit_max_times_argsort],
-            hitlets['channel'][hit_max_times_argsort],
+            sorted_hit_max_times,
+            sorted_hit_channels,
             peaklet_max_times,
             self.tight_coincidence_window_left,
             self.tight_coincidence_window_right,

--- a/tests/plugins/peak_building.py
+++ b/tests/plugins/peak_building.py
@@ -59,10 +59,13 @@ def test_saturation_correction(self: PluginTestCase):
 @PluginTestAccumulator.register('test_tight_coincidence')
 def test_tight_coincidence(self: PluginTestCase):
     """Test whether tight_coincidence is correctly reconstructed"""
+    if str(self.st.key_for(self.run_id, 'raw_records')) != '012882-raw_records-z7q2d2ye2t':
+        print('skip checking because complexity')
+        return
     peaklets = self.st.get_array(self.run_id, 'peaklets', progress_bar=False)
     message = 'There might be some issue in tight_coincidence.'
     sum_tight_coincidence = np.sum(peaklets['tight_coincidence'])
-    assert sum_tight_coincidence == 1992, message + f' {sum_tight_coincidence}'
+    assert sum_tight_coincidence == 1992, message
 
 
 if __name__ == '__main__':

--- a/tests/plugins/peak_building.py
+++ b/tests/plugins/peak_building.py
@@ -56,5 +56,13 @@ def test_saturation_correction(self: PluginTestCase):
     # TODO add more tests to see if results make sense
 
 
+@PluginTestAccumulator.register('test_tight_coincidence')
+def test_tight_coincidence(self: PluginTestCase):
+    """Test whether tight_coincidence is correctly reconstructed"""
+    peaklets = self.st.get_array(self.run_id, 'peaklets', progress_bar=False)
+    message = 'There might be some issue in tight_coincidence.'
+    assert np.sum(peaklets['tight_coincidence']) == 1992, message
+
+
 if __name__ == '__main__':
     run_pytest_from_main()

--- a/tests/plugins/peak_building.py
+++ b/tests/plugins/peak_building.py
@@ -61,7 +61,8 @@ def test_tight_coincidence(self: PluginTestCase):
     """Test whether tight_coincidence is correctly reconstructed"""
     peaklets = self.st.get_array(self.run_id, 'peaklets', progress_bar=False)
     message = 'There might be some issue in tight_coincidence.'
-    assert np.sum(peaklets['tight_coincidence']) == 1992, message
+    sum_tight_coincidence = np.sum(peaklets['tight_coincidence'])
+    assert sum_tight_coincidence == 1992, message + str(sum_tight_coincidence)
 
 
 if __name__ == '__main__':

--- a/tests/plugins/peak_building.py
+++ b/tests/plugins/peak_building.py
@@ -62,7 +62,7 @@ def test_tight_coincidence(self: PluginTestCase):
     peaklets = self.st.get_array(self.run_id, 'peaklets', progress_bar=False)
     message = 'There might be some issue in tight_coincidence.'
     sum_tight_coincidence = np.sum(peaklets['tight_coincidence'])
-    assert sum_tight_coincidence == 1992, message + str(sum_tight_coincidence)
+    assert sum_tight_coincidence == 1992, message + f' {sum_tight_coincidence}'
 
 
 if __name__ == '__main__':

--- a/tests/test_peaklet_processing.py
+++ b/tests/test_peaklet_processing.py
@@ -51,7 +51,7 @@ def test_n_hits():
 @given(fake_hits,
        strat.lists(elements=strat.integers(0, 9), min_size=20))
 @settings(deadline=None)
-def test_tight_coincidence(hits, channel):
+def test_get_tight_coin(hits, channel):
     hits['area'] = 1
     hits['channel'] = channel[:len(hits)]  # In case there are less channel then hits (unlikely)
     gap_threshold = 10
@@ -68,11 +68,10 @@ def test_tight_coincidence(hits, channel):
     left = 5
     right = 5
     tight_coin_channel = get_tight_coin(hits_max_time,
-                                                    hits['channel'],
-                                                    peaks_max_time,
-                                                    left,
-                                                    right,
-                                                    )
+                                        hits['channel'],
+                                        peaks_max_time,
+                                        left,
+                                        right)
     for ind, p_max_t in enumerate(peaks_max_time):
         m_hits_in_peak = (hits_max_time >= (p_max_t - left))
         m_hits_in_peak &= (hits_max_time <= (p_max_t + right))


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

In https://github.com/XENONnT/straxen/blob/b1a0884a84a9ec8cb4f3b0ad6a6ea27ec02991ec/straxen/plugins/peaklets/peaklets.py#L232-L234 `hitlet_time_shift` is calculated but in https://github.com/XENONnT/straxen/blob/b1a0884a84a9ec8cb4f3b0ad6a6ea27ec02991ec/straxen/plugins/peaklets/peaklets.py#L235 `hitlets` is sorted, so https://github.com/XENONnT/straxen/blob/b1a0884a84a9ec8cb4f3b0ad6a6ea27ec02991ec/straxen/plugins/peaklets/peaklets.py#L283-L287 will mix `hitlets` with different order in time into `hit_max_times`. 

Additionally, https://github.com/XENONnT/straxen/blob/b1a0884a84a9ec8cb4f3b0ad6a6ea27ec02991ec/straxen/plugins/peaklets/peaklets.py#L291-L297 `hit_max_times` and `hitlets['channel']` might not have the same time order. 

## Can you briefly describe how it works?

The new codes will not set the variable used in `get_tight_coin` in `hitlets['time']` order. 

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
