### PR TITLE
Fix argsort inside numba.jit using kind='mergesort'

### DIFF
--- a/straxen/plugins/merged_s2s/merged_s2s.py
+++ b/straxen/plugins/merged_s2s/merged_s2s.py
@@ -15,7 +15,7 @@ class MergedS2s(strax.OverlapWindowPlugin):
     Merge together peaklets if peak finding favours that they would
     form a single peak instead.
     """
-    __version__ = '1.0.0'
+    __version__ = '1.0.1'
 
     depends_on = ('peaklets', 'peaklet_classification', 'lone_hits')
     data_kind = 'merged_s2s'

--- a/straxen/plugins/merged_s2s/merged_s2s.py
+++ b/straxen/plugins/merged_s2s/merged_s2s.py
@@ -133,7 +133,8 @@ class MergedS2s(strax.OverlapWindowPlugin):
     @numba.njit(cache=True, nogil=True)
     def get_merge_instructions(
             peaklet_starts, peaklet_ends, areas, types,
-            gap_thresholds, max_duration, max_gap, max_area):
+            gap_thresholds, max_duration, max_gap, max_area,
+            sort_kind='mergesort'):
         """
         Finding the group of peaklets to merge. To do this start with the
         smallest gaps and keep merging until the new, merged S2 has such a
@@ -149,7 +150,7 @@ class MergedS2s(strax.OverlapWindowPlugin):
         peaklet_start_index = np.arange(len(peaklet_starts))
         peaklet_end_index = np.arange(len(peaklet_starts))
 
-        for gap_i in np.argsort(peaklet_gaps, kind='mergesort'):
+        for gap_i in np.argsort(peaklet_gaps, kind=sort_kind):
             start_idx = peaklet_start_index[gap_i]
             inclusive_end_idx = peaklet_end_index[gap_i + 1]
             sum_area = np.sum(areas[start_idx:inclusive_end_idx + 1])

--- a/straxen/plugins/merged_s2s/merged_s2s.py
+++ b/straxen/plugins/merged_s2s/merged_s2s.py
@@ -149,7 +149,7 @@ class MergedS2s(strax.OverlapWindowPlugin):
         peaklet_start_index = np.arange(len(peaklet_starts))
         peaklet_end_index = np.arange(len(peaklet_starts))
 
-        for gap_i in np.argsort(peaklet_gaps):
+        for gap_i in np.argsort(peaklet_gaps, kind='mergesort'):
             start_idx = peaklet_start_index[gap_i]
             inclusive_end_idx = peaklet_end_index[gap_i + 1]
             sum_area = np.sum(areas[start_idx:inclusive_end_idx + 1])


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
As the title described. 

The issue is reported in https://github.com/numba/numba/issues/8938. 

## Can you briefly describe how it works?

This PR is trying to solve https://github.com/XENONnT/straxen/issues/1175. 

When using `mergesort`, the output of the given sample array in the issue is

```bash
[ 1 11 29 34 45 52 59 66 71 73 68  5 46 38 69 14 53 67  2 98 12 79 30 13
 35 80 47 92 93 62 20 74 99 24 95 94 21 15  3 31 63 16 32 75 76 40 17 56
 91  8 37 33 88 23 72 83 22 61 60 87 25 10 48 41 81 78 70 43 44 86  4 77
 65 54 26 18 36 50 97 85 39 51  6 28 55  0 84  7 57 89 42 49 27 90 82  9
 64 58 19 96]
[ 1 11 29 34 45 52 59 66 71 73 68  5 46 38 69 14 53 67  2 98 12 79 30 13
 35 80 47 92 93 62 20 74 99 24 95 94 21 15  3 31 63 16 32 75 76 40 17 56
 91  8 37 33 88 23 72 83 22 61 60 87 25 10 48 41 81 78 70 43 44 86  4 77
 65 54 26 18 36 50 97 85 39 51  6 28 55  0 84  7 57 89 42 49 27 90 82  9
 64 58 19 96]
```

, which are the same. 

See https://numba.readthedocs.io/en/stable/reference/numpysupported.html#other-methods, `numba` supports `kind='mergesort'` in `argsort` function. And because `mergesort` is stable, see https://numpy.org/doc/1.22/reference/generated/numpy.sort.html, the result should be the same whatever package or platform we use. 

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [x] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
