### PR TITLE
Fix urllib3 version to 1.26.15 

### DIFF
--- a/extra_requirements/requirements-docs.txt
+++ b/extra_requirements/requirements-docs.txt
@@ -8,3 +8,4 @@ recommonmark==0.7.1
 sphinx==6.2.1
 sphinx_rtd_theme==1.2.0
 Jinja2==3.0.3
+urllib3==1.26.15


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Because from `2.0.0` urllib3 does not support OpenSSL versions older than 1.1.1. So triggered this failure: https://readthedocs.org/projects/straxen/builds/20440356/. Reference: https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#what-are-the-important-changes. 

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
