### PR TITLE
Lower the titles in the same notebook

### DIFF
--- a/notebooks/tutorials/EventDisplayInteractive.ipynb
+++ b/notebooks/tutorials/EventDisplayInteractive.ipynb
@@ -260,7 +260,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Manipulating the display appearance\n",
+    "## Manipulating the display appearance\n",
     "\n",
     "For talks or a thesis it might be necessary to modify some of the fonts styles or size. Further, it may be needed to reduce the amount of shown information. For this purpose I added some additional options: \n",
     "\n",

--- a/notebooks/tutorials/EventDisplayInteractive.ipynb
+++ b/notebooks/tutorials/EventDisplayInteractive.ipynb
@@ -433,7 +433,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Record matrix\n",
+    "## Record matrix\n",
     "\n",
     "The regular event display can be extended by an additional record matrix which is helpful especially for peak building and splitting analyses. To plot the record matrix you have to simply set ` plot_record_matrix=True`. The event display will then automatically check if the specified raw_data is available. The record matrix is build on records, in case only `raw_records` are available the event display will warn you and build the required `records` on the fly.    "
    ]
@@ -507,7 +507,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Event selection\n",
+    "## Event selection\n",
     "\n",
     "(**Currently this function only works in jupyter notebook but not lab**) Beside an interactive event display we also have now an interactive cut selection tool. To use the tool we have to first import get some data:"
    ]


### PR DESCRIPTION
It is a little bit weird that [readthedocs](https://readthedocs.org/projects/straxen/builds/20724168/) do not delete their cache so this small issue is not noticed in https://github.com/XENONnT/straxen/pull/1077. 

The only issue here is that the markdown headers are considered to be another section in docs if it is only started with `#`. 

![image](https://github.com/XENONnT/straxen/assets/40532474/f55e0a0f-2cea-4d53-b38f-b732170c3db0)

Here `Interactive event display`, `Record matrix`, and `Event selection` are from the same notebook. 