### PR TITLE
Split event_area_per_channel into two plugins: event_area_per_channel…

### DIFF
--- a/straxen/plugins/events/__init__.py
+++ b/straxen/plugins/events/__init__.py
@@ -13,6 +13,9 @@ from .event_ambience import *
 from . import event_area_per_channel
 from .event_area_per_channel import *
 
+from . import event_waveform
+from .event_waveform import *
+
 from . import event_top_bottom_params
 from .event_top_bottom_params import *
 

--- a/straxen/plugins/events/event_area_per_channel.py
+++ b/straxen/plugins/events/event_area_per_channel.py
@@ -6,14 +6,14 @@ export, __all__ = strax.exporter()
 
 
 @export
-class EventAreaPerChannel(strax.LoopPlugin):
+class EventAreaPerChannel(strax.Plugin):
     """
     Simple plugin that provides area per channel for main and alternative S1/S2 in the event.
     """
     
     depends_on = ('event_basics', 'peaks')
     provides = "event_area_per_channel"
-    __version__ = '0.0.3'
+    __version__ = '0.1.0'
 
     compressor = 'zstd'
     save_when = strax.SaveWhen.EXPLICIT
@@ -44,28 +44,28 @@ class EventAreaPerChannel(strax.LoopPlugin):
                   np.int16),
                  (("Main S1 top count of contributing PMTs", "s1_top_n_channels"),
                   np.int16),
-                 (("Main S1 bottom count of contributing PMTs", "s1_bottom_n_channels"),
-                  np.int16),
                  ]
         dtype += strax.time_fields
         return dtype
 
-    def compute_loop(self, event, peaks):
-        result = {}
-        result['time'] = event['time']
-        result['endtime'] = strax.endtime(event)
+    def compute(self, events, peaks):
+        result = np.zeros(len(events), self.dtype)
+        result['time'] = events['time']
+        result['endtime'] = strax.endtime(events)
 
-        for type_ in ['s1', 's2', 'alt_s1', 'alt_s2']:
-            type_index = event[f'{type_}_index']
-            if type_index != -1:
-                type_area_per_channel = peaks['area_per_channel'][type_index]
-                result[f'{type_}_area_per_channel'] = type_area_per_channel
-                result[f'{type_}_length'] = peaks['length'][type_index]
-                result[f'{type_}_dt'] = peaks['dt'][type_index]
-                if type_ == 's1':
-                    result['s1_n_channels'] = len(type_area_per_channel[type_area_per_channel > 0])
-                    result['s1_top_n_channels'] = len(type_area_per_channel[:self.config['n_top_pmts']][
-                                                          type_area_per_channel[:self.config['n_top_pmts']] > 0])
-                    result['s1_bottom_n_channels'] = len(type_area_per_channel[self.config['n_top_pmts']:][
-                                                             type_area_per_channel[self.config['n_top_pmts']:] > 0])
+        split_peaks = strax.split_by_containment(peaks, events)
+        
+        for event_i, (event, sp) in enumerate(zip(events, split_peaks)):
+            for type_ in ['s1', 's2', 'alt_s1', 'alt_s2']:
+                type_index = event[f'{type_}_index']
+                if type_index != -1:
+                    type_area_per_channel = sp['area_per_channel'][type_index]
+                    result[f'{type_}_area_per_channel'][event_i] = type_area_per_channel
+                    result[f'{type_}_length'][event_i] = sp['length'][type_index]
+                    result[f'{type_}_dt'][event_i] = sp['dt'][type_index]
+                    if type_ == 's1':
+                        result['s1_n_channels'][event_i] = len(type_area_per_channel[type_area_per_channel > 0])
+                        result['s1_top_n_channels'][event_i] = len(type_area_per_channel[:self.config['n_top_pmts']][
+                                                                   type_area_per_channel[:self.config['n_top_pmts']] > 0])
+
         return result

--- a/straxen/plugins/events/event_area_per_channel.py
+++ b/straxen/plugins/events/event_area_per_channel.py
@@ -8,8 +8,9 @@ export, __all__ = strax.exporter()
 @export
 class EventAreaPerChannel(strax.LoopPlugin):
     """
-    Simple plugin that provides area per channel for main and alternative S1/S2 in the event. 
+    Simple plugin that provides area per channel for main and alternative S1/S2 in the event.
     """
+    
     depends_on = ('event_basics', 'peaks')
     provides = "event_area_per_channel"
     __version__ = '0.0.3'
@@ -21,10 +22,10 @@ class EventAreaPerChannel(strax.LoopPlugin):
 
     def infer_dtype(self):
         # setting data type from peak dtype
-        pfields_=self.deps['peaks'].dtype_for('peaks').fields
+        pfields_ = self.deps['peaks'].dtype_for('peaks').fields
         # populating data type
-        infoline = {'s1': 'main S1', 
-                    's2': 'main S2', 
+        infoline = {'s1': 'main S1',
+                    's2': 'main S2',
                     'alt_s1': 'alternative S1',
                     'alt_s2': 'alternative S2',
                    }
@@ -32,11 +33,11 @@ class EventAreaPerChannel(strax.LoopPlugin):
         # populating APC
         ptypes = ['s1', 's2', 'alt_s1', 'alt_s2']
         for type_ in ptypes:
-            dtype +=[((f'Area per channel for {infoline[type_]}', f'{type_}_area_per_channel'),
+            dtype += [((f'Area per channel for {infoline[type_]}', f'{type_}_area_per_channel'),
                      pfields_['area_per_channel'][0])]
-            dtype +=[((f'Length of the interval in samples for {infoline[type_]}', f'{type_}_length'),
+            dtype += [((f'Length of the interval in samples for {infoline[type_]}', f'{type_}_length'),
                      pfields_['length'][0])]
-            dtype +=[((f'Width of one sample for {infoline[type_]} [ns]', f'{type_}_dt'),
+            dtype += [((f'Width of one sample for {infoline[type_]} [ns]', f'{type_}_dt'),
                      pfields_['dt'][0])]
         # populating S1 n channel properties
         dtype += [(("Main S1 count of contributing PMTs", "s1_n_channels"),
@@ -50,7 +51,7 @@ class EventAreaPerChannel(strax.LoopPlugin):
         return dtype
 
     def compute_loop(self, event, peaks):
-        result = dict()
+        result = {}
         result['time'] = event['time']
         result['endtime'] = strax.endtime(event)
 

--- a/straxen/plugins/events/event_area_per_channel.py
+++ b/straxen/plugins/events/event_area_per_channel.py
@@ -44,6 +44,8 @@ class EventAreaPerChannel(strax.Plugin):
                   np.int16),
                  (("Main S1 top count of contributing PMTs", "s1_top_n_channels"),
                   np.int16),
+                 (("Main S1 bottom count of contributing PMTs", "s1_bottom_n_channels"),
+                  np.int16),
                  ]
         dtype += strax.time_fields
         return dtype
@@ -67,4 +69,6 @@ class EventAreaPerChannel(strax.Plugin):
                             type_area_per_channel > 0).sum()
                         result['s1_top_n_channels'][event_i] = (
                             type_area_per_channel[:self.config['n_top_pmts']] > 0).sum()
+                        result['s1_bottom_n_channels'] = (
+                            type_area_per_channel[self.config['n_top_pmts']:] > 0).sum()
         return result

--- a/straxen/plugins/events/event_area_per_channel.py
+++ b/straxen/plugins/events/event_area_per_channel.py
@@ -69,6 +69,6 @@ class EventAreaPerChannel(strax.Plugin):
                             type_area_per_channel > 0).sum()
                         result['s1_top_n_channels'][event_i] = (
                             type_area_per_channel[:self.config['n_top_pmts']] > 0).sum()
-                        result['s1_bottom_n_channels'] = (
+                        result['s1_bottom_n_channels'][event_i] = (
                             type_area_per_channel[self.config['n_top_pmts']:] > 0).sum()
         return result

--- a/straxen/plugins/events/event_area_per_channel.py
+++ b/straxen/plugins/events/event_area_per_channel.py
@@ -54,7 +54,6 @@ class EventAreaPerChannel(strax.Plugin):
         result['endtime'] = strax.endtime(events)
 
         split_peaks = strax.split_by_containment(peaks, events)
-        
         for event_i, (event, sp) in enumerate(zip(events, split_peaks)):
             for type_ in ['s1', 's2', 'alt_s1', 'alt_s2']:
                 type_index = event[f'{type_}_index']
@@ -64,8 +63,8 @@ class EventAreaPerChannel(strax.Plugin):
                     result[f'{type_}_length'][event_i] = sp['length'][type_index]
                     result[f'{type_}_dt'][event_i] = sp['dt'][type_index]
                     if type_ == 's1':
-                        result['s1_n_channels'][event_i] = len(type_area_per_channel[type_area_per_channel > 0])
-                        result['s1_top_n_channels'][event_i] = len(type_area_per_channel[:self.config['n_top_pmts']][
-                                                                   type_area_per_channel[:self.config['n_top_pmts']] > 0])
-
+                        result['s1_n_channels'][event_i] = (
+                            type_area_per_channel > 0).sum()
+                        result['s1_top_n_channels'][event_i] = (
+                            type_area_per_channel[:self.config['n_top_pmts']] > 0).sum()
         return result

--- a/straxen/plugins/events/event_waveform.py
+++ b/straxen/plugins/events/event_waveform.py
@@ -56,18 +56,18 @@ class EventWaveform(strax.Plugin):
         result['endtime'] = strax.endtime(events)
 
         split_peaks = strax.split_by_containment(peaks, events)
-        
         for event_i, (event, sp) in enumerate(zip(events, split_peaks)):
             for type_ in ['s1', 's2', 'alt_s1', 'alt_s2']:
                 type_index = event[f'{type_}_index']
                 if type_index != -1:
                     type_area_per_channel = sp['area_per_channel'][type_index]
                     result[f'{type_}_length'][event_i] = sp['length'][type_index]
-                    result[f'{type_}_data'][event_i] = peaks['data'][type_index]
-                    result[f'{type_}_data_top'][event_i] = peaks['data_top'][type_index]
-                    result[f'{type_}_dt'][event_i] = peaks['dt'][type_index]
+                    result[f'{type_}_data'][event_i] = sp['data'][type_index]
+                    result[f'{type_}_data_top'][event_i] = sp['data_top'][type_index]
+                    result[f'{type_}_dt'][event_i] = sp['dt'][type_index]
                     if type_ == 's1':
-                        result['s1_n_channels'][event_i] = len(type_area_per_channel[type_area_per_channel > 0])
-                        result['s1_top_n_channels'][event_i] = len(type_area_per_channel[:self.config['n_top_pmts']][
-                                                                   type_area_per_channel[:self.config['n_top_pmts']] > 0])
+                        result['s1_n_channels'][event_i] = (
+                            type_area_per_channel > 0).sum()
+                        result['s1_top_n_channels'][event_i] = (
+                            type_area_per_channel[:self.config['n_top_pmts']] > 0).sum()
         return result

--- a/straxen/plugins/events/event_waveform.py
+++ b/straxen/plugins/events/event_waveform.py
@@ -8,7 +8,8 @@ export, __all__ = strax.exporter()
 @export
 class EventWaveform(strax.LoopPlugin):
     """
-    Simple plugin that provides total (data) and top (data_top) waveforms for main and alternative S1/S2 in the event. 
+    Simple plugin that provides total (data) and top (data_top) waveforms for 
+    main and alternative S1/S2 in the event.
     """
     depends_on = ('event_basics', 'peaks')
     provides = "event_waveform"
@@ -21,10 +22,10 @@ class EventWaveform(strax.LoopPlugin):
 
     def infer_dtype(self):
         # setting data type from peak dtype
-        pfields_=self.deps['peaks'].dtype_for('peaks').fields
+        pfields_ = self.deps['peaks'].dtype_for('peaks').fields
         # populating data type
-        infoline = {'s1': 'main S1', 
-                    's2': 'main S2', 
+        infoline = {'s1': 'main S1',
+                    's2': 'main S2',
                     'alt_s1': 'alternative S1',
                     'alt_s2': 'alternative S2',
                    }
@@ -32,13 +33,13 @@ class EventWaveform(strax.LoopPlugin):
         # populating waveform samples
         ptypes = ['s1', 's2', 'alt_s1', 'alt_s2']
         for type_ in ptypes:
-            dtype +=[((f'Waveform for {infoline[type_]} [ PE / sample ]', f'{type_}_data'),
+            dtype += [((f'Waveform for {infoline[type_]} [ PE / sample ]', f'{type_}_data'),
                      pfields_['data'][0])]
-            dtype +=[((f'Top waveform for {infoline[type_]} [ PE / sample ]', f'{type_}_data_top'),
+            dtype += [((f'Top waveform for {infoline[type_]} [ PE / sample ]', f'{type_}_data_top'),
                      pfields_['data_top'][0])]
-            dtype +=[((f'Length of the interval in samples for {infoline[type_]}', f'{type_}_length'),
+            dtype += [((f'Length of the interval in samples for {infoline[type_]}', f'{type_}_length'),
                      pfields_['length'][0])]
-            dtype +=[((f'Width of one sample for {infoline[type_]} [ns]', f'{type_}_dt'),
+            dtype += [((f'Width of one sample for {infoline[type_]} [ns]', f'{type_}_dt'),
                      pfields_['dt'][0])]
         # populating S1 n channel properties
         dtype += [(("Main S1 count of contributing PMTs", "s1_n_channels"),
@@ -52,7 +53,7 @@ class EventWaveform(strax.LoopPlugin):
         return dtype
 
     def compute_loop(self, event, peaks):
-        result = dict()
+        result = {}
         result['time'] = event['time']
         result['endtime'] = strax.endtime(event)
 

--- a/straxen/plugins/events/event_waveform.py
+++ b/straxen/plugins/events/event_waveform.py
@@ -46,8 +46,6 @@ class EventWaveform(strax.LoopPlugin):
                   np.int16),
                  (("Main S1 top count of contributing PMTs", "s1_top_n_channels"),
                   np.int16),
-                 (("Main S1 bottom count of contributing PMTs", "s1_bottom_n_channels"),
-                  np.int16),
                  ]
         dtype += strax.time_fields
         return dtype
@@ -69,6 +67,4 @@ class EventWaveform(strax.LoopPlugin):
                     result['s1_n_channels'] = len(type_area_per_channel[type_area_per_channel > 0])
                     result['s1_top_n_channels'] = len(type_area_per_channel[:self.config['n_top_pmts']][
                                                           type_area_per_channel[:self.config['n_top_pmts']] > 0])
-                    result['s1_bottom_n_channels'] = len(type_area_per_channel[self.config['n_top_pmts']:][
-                                                             type_area_per_channel[self.config['n_top_pmts']:] > 0])
         return result

--- a/straxen/plugins/events/event_waveform.py
+++ b/straxen/plugins/events/event_waveform.py
@@ -6,13 +6,13 @@ export, __all__ = strax.exporter()
 
 
 @export
-class EventAreaPerChannel(strax.LoopPlugin):
+class EventWaveform(strax.LoopPlugin):
     """
-    Simple plugin that provides area per channel for main and alternative S1/S2 in the event. 
+    Simple plugin that provides total (data) and top (data_top) waveforms for main and alternative S1/S2 in the event. 
     """
     depends_on = ('event_basics', 'peaks')
-    provides = "event_area_per_channel"
-    __version__ = '0.0.3'
+    provides = "event_waveform"
+    __version__ = '0.0.1'
 
     compressor = 'zstd'
     save_when = strax.SaveWhen.EXPLICIT
@@ -29,11 +29,13 @@ class EventAreaPerChannel(strax.LoopPlugin):
                     'alt_s2': 'alternative S2',
                    }
         dtype = []
-        # populating APC
+        # populating waveform samples
         ptypes = ['s1', 's2', 'alt_s1', 'alt_s2']
         for type_ in ptypes:
-            dtype +=[((f'Area per channel for {infoline[type_]}', f'{type_}_area_per_channel'),
-                     pfields_['area_per_channel'][0])]
+            dtype +=[((f'Waveform for {infoline[type_]} [ PE / sample ]', f'{type_}_data'),
+                     pfields_['data'][0])]
+            dtype +=[((f'Top waveform for {infoline[type_]} [ PE / sample ]', f'{type_}_data_top'),
+                     pfields_['data_top'][0])]
             dtype +=[((f'Length of the interval in samples for {infoline[type_]}', f'{type_}_length'),
                      pfields_['length'][0])]
             dtype +=[((f'Width of one sample for {infoline[type_]} [ns]', f'{type_}_dt'),
@@ -58,8 +60,9 @@ class EventAreaPerChannel(strax.LoopPlugin):
             type_index = event[f'{type_}_index']
             if type_index != -1:
                 type_area_per_channel = peaks['area_per_channel'][type_index]
-                result[f'{type_}_area_per_channel'] = type_area_per_channel
                 result[f'{type_}_length'] = peaks['length'][type_index]
+                result[f'{type_}_data'] = peaks['data'][type_index]
+                result[f'{type_}_data_top'] = peaks['data_top'][type_index]
                 result[f'{type_}_dt'] = peaks['dt'][type_index]
                 if type_ == 's1':
                     result['s1_n_channels'] = len(type_area_per_channel[type_area_per_channel > 0])


### PR DESCRIPTION
In this PR, the **event_area_per_channel** plugin is splitted into two independent plugins: **event_area_per_channel** and **event_waveform**, to reduce the redundancy for reprocessing

The original **event_area_per_channel** contains both the hit pattern for S1/alt_S1/S2/alt_S2 and their waveforms (data), therefore has large outputs. In this PR, the **event_area_per_channel** plugin is reduced to only keep the hit pattern information while the waveforms (data) are saved with the new plugin **event_waveform**.

No need to register the event_waveform plugin as it also belongs to events.

