### PR TITLE
Remove unnecessary check in `merged_s2s`

### DIFF
--- a/straxen/plugins/merged_s2s/merged_s2s.py
+++ b/straxen/plugins/merged_s2s/merged_s2s.py
@@ -102,8 +102,6 @@ class MergedS2s(strax.OverlapWindowPlugin):
             max_gap=max_gap,
             max_area=max_area,
         )
-        if (end_merge_at - start_merge_at).min() <= 1:
-            raise ValueError('Found merging only 1 peak')
 
         assert 'data_top' in peaklets.dtype.names
 


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Sometimes `end_merge_at` and `start_merge_at` can be empty arrays. Function `_filter_s1_starts` has already guaranteed that the plugin will not merge a single peak. 

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
