### PR TITLE
No longer test `st.runs` in `test_extract_latest_comment_lone_hits`

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -57,10 +57,10 @@ class TestBasics(unittest.TestCase):
         st.extract_latest_comment()
         assert st.runs is not None, "No registry build?"
         assert 'comments' in st.runs.keys()
-        st.select_runs(available=test_for_target)
+        runs = st.select_runs(available=test_for_target)
         if context == 'demo':
             assert len(st.runs)
-        assert f'{test_for_target}_available' in st.runs.keys()
+        assert f'{test_for_target}_available' in runs.keys()
 
     def test_extract_latest_comment_nt(self, **opt):
         """Run the test for nt (but only 2000 runs"""


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Fix straxen test according to strax's PR: https://github.com/AxFoundation/strax/pull/727

## Can you briefly describe how it works?

In https://github.com/AxFoundation/strax/pull/727, after running `st.scan_runs`, there the returned dataframe `dsets` contains additional `available` (besides default and always stored `peak_basics` and `raw_records`). But `st.runs` are not updated following the returned dataframe `dsets`, for faster performance. 

So in the test `test_extract_latest_comment_lone_hits`, we should refer to `dsets` but not `st.runs`, to see if `available` really works. 

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
