### PR TITLE
Make apply_xedocs_configs more flexible

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -97,7 +97,7 @@ xnt_common_opts.update({
 
 
 def xenonnt(cmt_version='global_ONLINE', xedocs_version=None,
-            _from_cutax=False,  **kwargs):
+            _from_cutax=False, **kwargs):
     """XENONnT context"""
     if not _from_cutax and cmt_version != 'global_ONLINE':
         warnings.warn('Don\'t load a context directly from straxen, '
@@ -106,7 +106,7 @@ def xenonnt(cmt_version='global_ONLINE', xedocs_version=None,
     st.apply_cmt_version(cmt_version)
     
     if xedocs_version is not None:
-        st.apply_xedocs_configs(xedocs_version)
+        st.apply_xedocs_configs(version=xedocs_version, **kwargs)
 
     return st
 

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -411,8 +411,8 @@ def apply_xedocs_configs(context: strax.Context,
         db_kwargs = straxen.filter_kwargs(func, kwargs)
         db = func(**db_kwargs)
 
-    filter_kwargs = {k: v for k,v in kwargs.items() 
-                     if k in db.context_configs.schema.__fields__}
+    filter_kwargs = {k: v for k, v in kwargs.items()
+                        if k in db.context_configs.schema.__fields__}
 
     docs = db.context_configs.find_docs(**filter_kwargs)
 
@@ -421,7 +421,8 @@ def apply_xedocs_configs(context: strax.Context,
     if len(global_config):
         context.set_config(global_config)
     else:
-        warnings.warn(f"Could not find any context configs matchin {filter_kwargs}")
+        warnings.warn(f"Could not find any context configs matchin {filter_kwargs}",
+                      RuntimeWarning, stacklevel=2)
 
 
 def replace_url_version(url, version):

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -403,19 +403,25 @@ def apply_cmt_version(context: strax.Context, cmt_global_version: str) -> None:
 
 @strax.Context.add_method
 def apply_xedocs_configs(context: strax.Context, 
-                         version: str, db='straxen_db') -> None:
+                         db='straxen_db', **kwargs) -> None:
     import xedocs
 
-    docs = xedocs.find_docs('context_configs', 
-                            datasource=db, 
-                            version=version)
+    if isinstance(db, str):
+        func = getattr(xedocs.databases, db)
+        db_kwargs = straxen.filter_kwargs(func, kwargs)
+        db = func(**db_kwargs)
+
+    filter_kwargs = {k: v for k,v in kwargs.items() 
+                     if k in db.context_configs.schema.__fields__}
+
+    docs = db.context_configs.find_docs(**filter_kwargs)
 
     global_config = {doc.config_name: doc.value for doc in docs}
     
     if len(global_config):
         context.set_config(global_config)
     else:
-        warnings.warn(f"Could not find any context configs for version {version}")
+        warnings.warn(f"Could not find any context configs matchin {filter_kwargs}")
 
 
 def replace_url_version(url, version):


### PR DESCRIPTION
Modify the `apply_xedocs_configs` function to accept arbitrary db parameters and filters from context functions.
This is useful e.g. for loading configs directly from a PR on the corrections github repo 