### PR TITLE
Fix timing of peaks when ordering in `center_time`

### DIFF
--- a/straxen/plugins/peaks/peak_shadow.py
+++ b/straxen/plugins/peaks/peak_shadow.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numba
 from scipy.stats import halfcauchy
-from .peak_ambience import distance_in_xy
+from .peak_ambience import distance_in_xy, _quick_assign
 import strax
 import straxen
 
@@ -18,7 +18,7 @@ class PeakShadow(strax.OverlapWindowPlugin):
         * v0.1.5 reference: xenon:xenonnt:ac:prediction:shadow_ambience
     """
 
-    __version__ = '0.1.5'
+    __version__ = '0.1.6'
 
     depends_on = ('peak_basics', 'peak_positions')
     provides = 'peak_shadow'
@@ -98,7 +98,11 @@ class PeakShadow(strax.OverlapWindowPlugin):
         return dtype
 
     def compute(self, peaks):
-        return self.compute_shadow(peaks, peaks)
+        argsort = np.argsort(peaks['center_time'], kind='mergesort')
+        _peaks = np.sort(peaks, order='center_time')
+        result = np.zeros(len(peaks), self.dtype)
+        _quick_assign(argsort, result, self.compute_shadow(peaks, _peaks))
+        return result
 
     def compute_shadow(self, peaks, current_peak):
         # 1. Define time window for each peak, we will find previous peaks within these time windows


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

`strax.touching_windows` requires that the `time` of `things` and `containers` are all sorted. 

When the `time` and `endtime` are defined based on `center_time` in some plugins like `PeakShadow` and `PeakAmbience`, the `touching_windows` will show an error, because the `center_time` is not sorted. 

Reference: https://github.com/AxFoundation/strax/pull/725

## Can you briefly describe how it works?

First, order the peaks by `center_time`, after the features are calculated, recover the original order. 

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
