### PR TITLE
Move `get_window_size` factor of merged_s2s as untracked configuration

### DIFF
--- a/straxen/plugins/merged_s2s/merged_s2s.py
+++ b/straxen/plugins/merged_s2s/merged_s2s.py
@@ -60,6 +60,13 @@ class MergedS2s(strax.OverlapWindowPlugin):
         help='Digitize the sum waveform of the top array separately'
     )
 
+    merged_s2s_get_window_size_factor = straxen.URLConfig(
+        default=5,
+        type=int,
+        track=False,
+        help='Factor of the window size for the merged_s2s plugin'
+    )
+
     def setup(self):
         self.to_pe = self.gain_model
 
@@ -67,8 +74,8 @@ class MergedS2s(strax.OverlapWindowPlugin):
         return strax.unpack_dtype(self.deps['peaklets'].dtype_for('peaklets'))
 
     def get_window_size(self):
-        return 5 * (int(self.s2_merge_gap_thresholds[0][1])
-                    + self.s2_merge_max_duration)
+        return self.merged_s2s_get_window_size_factor * (
+            int(self.s2_merge_gap_thresholds[0][1]) + self.s2_merge_max_duration)
 
     def compute(self, peaklets, lone_hits):
         if self.merge_without_s1:


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

The original factor is 5. This PR moves it to an untracked context configuration, because in reprocessing we might want to change it, but better without changing the source code. 

It is trying to resolve: https://github.com/AxFoundation/strax/issues/490

This PR will not change the result of `MergedS2s`. It will not change the lineage either. 

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
