### PR TITLE
Sort `hitlets` in `nVETOHitlets`

### DIFF
--- a/straxen/plugins/hitlets_nv/hitlets_nv.py
+++ b/straxen/plugins/hitlets_nv/hitlets_nv.py
@@ -133,7 +133,7 @@ class nVETOHitlets(strax.Plugin):
         # Remove data field:
         hitlets = np.zeros(len(temp_hitlets), dtype=strax.hitlet_dtype())
         strax.copy_to_buffer(temp_hitlets, hitlets, '_copy_hitlets')
-        return hitlets
+        return strax.sort_by_time(hitlets)
 
 
 def remove_switched_off_channels(hits, to_pe):


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

In some very rare cases, the `hitlets` is not sorted. But then in `nVETOEvents` plugin, `strax.touching_windows` will raise error. 

## Can you briefly describe how it works?

Return the sorted `hitlets`. 

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
