### PR TITLE
Manually check event overlapping

### DIFF
--- a/straxen/plugins/events/events.py
+++ b/straxen/plugins/events/events.py
@@ -89,6 +89,10 @@ class Events(strax.OverlapWindowPlugin):
         default=2, type=int,
         help="Minimum tight coincidence necessary to make an S1")
 
+    diagnose_overlapping = straxen.URLConfig(
+        track=False, default=True, infer_type=False,
+        help="Enable runtime checks for disjointness")
+
     def setup(self):
         if self.s1_min_coincidence > self.event_s1_min_coincidence:
             raise ValueError('Peak s1 coincidence requirement should be smaller '
@@ -138,6 +142,11 @@ class Events(strax.OverlapWindowPlugin):
 
         if not result.size > 0:
             print("Found chunk without events?!")
+
+        if self.diagnose_overlapping and len(result):
+            # Check if the event windows overlap
+            _event_window_do_not_overlap = (strax.endtime(result)[:-1] - result['time'][1:]) <= 0
+            assert np.all(_event_window_do_not_overlap), "Events not disjoint"
 
         self.events_seen += len(result)
 

--- a/straxen/plugins/events/veto_proximity.py
+++ b/straxen/plugins/events/veto_proximity.py
@@ -99,6 +99,10 @@ class VetoProximity(strax.OverlapWindowPlugin):
         res = self.get_overlapping_window_time(vetos_during_event, selected_intervals, event_window, result_buffer)
         result_buffer[f'veto_{veto_name}_overlap'] = res
         
+        # Check if the event windows overlap
+        _event_window_do_not_overlap = (strax.endtime(event_window)[:-1] - event_window['time'][1:]) <= 0
+        assert np.all(_event_window_do_not_overlap), 'event_window overlap!'
+
         # Find the next and previous veto's
         times_to_prev, times_to_next = strax.abs_time_to_prev_next_interval(event_window, selected_intervals)
         mask_prev = times_to_prev > 0

--- a/straxen/plugins/events/veto_proximity.py
+++ b/straxen/plugins/events/veto_proximity.py
@@ -40,6 +40,10 @@ class VetoProximity(strax.OverlapWindowPlugin):
              'such that one will never cut events that are < YY ns.'
     )
 
+    diagnose_overlapping = straxen.URLConfig(
+        track=False, default=True, infer_type=False,
+        help="Enable runtime checks for disjointness")
+
     veto_names = ['busy', 'busy_he', 'hev', 'straxen_deadtime']
 
     def infer_dtype(self):
@@ -98,10 +102,11 @@ class VetoProximity(strax.OverlapWindowPlugin):
         # Figure out the vetos *during* an event
         res = self.get_overlapping_window_time(vetos_during_event, selected_intervals, event_window, result_buffer)
         result_buffer[f'veto_{veto_name}_overlap'] = res
-        
-        # Check if the event windows overlap
-        _event_window_do_not_overlap = (strax.endtime(event_window)[:-1] - event_window['time'][1:]) <= 0
-        assert np.all(_event_window_do_not_overlap), 'event_window overlap!'
+
+        if self.diagnose_overlapping:
+            # Check if the event windows overlap
+            _event_window_do_not_overlap = (strax.endtime(event_window)[:-1] - event_window['time'][1:]) <= 0
+            assert np.all(_event_window_do_not_overlap), "event_window not disjoint"
 
         # Find the next and previous veto's
         times_to_prev, times_to_next = strax.abs_time_to_prev_next_interval(event_window, selected_intervals)

--- a/straxen/plugins/events/veto_proximity.py
+++ b/straxen/plugins/events/veto_proximity.py
@@ -40,10 +40,6 @@ class VetoProximity(strax.OverlapWindowPlugin):
              'such that one will never cut events that are < YY ns.'
     )
 
-    diagnose_overlapping = straxen.URLConfig(
-        track=False, default=True, infer_type=False,
-        help="Enable runtime checks for disjointness")
-
     veto_names = ['busy', 'busy_he', 'hev', 'straxen_deadtime']
 
     def infer_dtype(self):
@@ -103,11 +99,6 @@ class VetoProximity(strax.OverlapWindowPlugin):
         res = self.get_overlapping_window_time(vetos_during_event, selected_intervals, event_window, result_buffer)
         result_buffer[f'veto_{veto_name}_overlap'] = res
 
-        if self.diagnose_overlapping:
-            # Check if the event windows overlap
-            _event_window_do_not_overlap = (strax.endtime(event_window)[:-1] - event_window['time'][1:]) <= 0
-            assert np.all(_event_window_do_not_overlap), "event_window not disjoint"
-
         # Find the next and previous veto's
         times_to_prev, times_to_next = strax.abs_time_to_prev_next_interval(event_window, selected_intervals)
         mask_prev = times_to_prev > 0
@@ -115,7 +106,7 @@ class VetoProximity(strax.OverlapWindowPlugin):
 
         max_next = times_to_next > 0
         result_buffer[f'time_to_next_{veto_name}'][max_next] = times_to_next[max_next]
-      
+
     @staticmethod
     @numba.njit
     def get_overlapping_window_time(vetos_during_event, selected_intervals, event_window, result_buffer):

--- a/straxen/plugins/hitlets_nv/hitlets_nv.py
+++ b/straxen/plugins/hitlets_nv/hitlets_nv.py
@@ -133,7 +133,7 @@ class nVETOHitlets(strax.Plugin):
         # Remove data field:
         hitlets = np.zeros(len(temp_hitlets), dtype=strax.hitlet_dtype())
         strax.copy_to_buffer(temp_hitlets, hitlets, '_copy_hitlets')
-        return hitlets
+        return strax.sort_by_time(hitlets)
 
 
 def remove_switched_off_channels(hits, to_pe):

--- a/straxen/test_utils.py
+++ b/straxen/test_utils.py
@@ -94,7 +94,8 @@ def nt_test_context(target_context='xenonnt_online',
         kwargs.setdefault('_database_init', False)
 
     st = getattr(straxen.contexts, target_context)(**kwargs)
-    st.set_config({'diagnose_sorting': True, 'store_per_channel': True})
+    st.set_config({
+        'diagnose_sorting': True, 'diagnose_overlapping': True, 'store_per_channel': True})
     st.register(_get_fake_daq_reader())
     download_test_data('https://raw.githubusercontent.com/XENONnT/'
                        'strax_auxiliary_files/'


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Manually check event overlapping, since we are skipping such assertion in the updated `strax.abs_time_to_prev_next_interval`. 

## Can you briefly describe how it works?
Did what `strax.abs_time_to_prev_next_interval` did before modification:
```
_things_do_not_overlap = (strax.endtime(things)[:-1] - things['time'][1:]) <= 0
assert np.all(_things_do_not_overlap), 'Things overlap!'
```

## Can you give a minimal working example (or illustrate with a figure)?

