### PR TITLE
scale coordinate properly

### DIFF
--- a/straxen/plugins/events/event_positions.py
+++ b/straxen/plugins/events/event_positions.py
@@ -19,7 +19,7 @@ class EventPositions(strax.Plugin):
 
     depends_on = ('event_basics',)
 
-    __version__ = '0.2.0'
+    __version__ = '0.2.1'
 
     default_reconstruction_algorithm = straxen.URLConfig(
         default=DEFAULT_POSREC_ALGO,
@@ -103,8 +103,8 @@ class EventPositions(strax.Plugin):
         return dtype + strax.time_fields
 
     def setup(self):
-        self.coordinate_scales = [1., 1., - self.electron_drift_velocity]
         self.map = self.fdc_map
+        self.map.scale_coordinates([1., 1., - self.electron_drift_velocity])
 
     def compute(self, events):
 


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

The FDC map is made based on (x, y, drift time), it has to be scaled by drift velocity before applying corrections based on (x, y, z). However, the current implementation of coordinate scaling is wrong.

## Can you briefly describe how it works?

Use 
```
self.map.scale_coordinates([1., 1., - self.electron_drift_velocity])
```
to properly scale the coordinate.

## Can you give a minimal working example (or illustrate with a figure)?

The illustration can be found [here](https://xenonnt.slack.com/archives/C016UJZ090B/p1689371326763939).

