### PR TITLE
Fix URLConfig.evaluate_dry

### DIFF
--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -523,9 +523,8 @@ class URLConfig(strax.Config):
         :keyword: any additional kwargs are passed to self.dispatch (see example)
         :return: evaluated value of the URL.
         """
-        protocol, url_arg, url_kwarg = cls.url_to_ast(url)
-
-        combined_kwargs = dict(url_kwarg, **kwargs)
+        url = cls.format_url_kwargs(url, **kwargs)
+        _, combined_kwargs = cls.split_url_kwargs(url)
 
         for k, v in combined_kwargs.items():
             if isinstance(v, str) and cls.PLUGIN_ATTR_PREFIX in v:
@@ -536,8 +535,8 @@ class URLConfig(strax.Config):
                     f"Try passing {k} as a keyword argument."
                     f"e.g.: `URLConfig.evaluate_dry({url}, {k}=SOME_VALUE)`"
                 )
-
-        return cls.eval(protocol, url_arg, combined_kwargs)
+        
+        return cls.eval(url)
 
 
 @URLConfig.register("cmt")


### PR DESCRIPTION
`URLConfig.evaluate_dry` was using the `url_to_ast` method which returns a nested abstract syntax tree so only the top level kwargs were replaced. This causes errors when trying to replace kwargs used by nested protocols.
The PR uses the `URLConfig.format_url_kwargs` which replaces kwargs globally in the URL. 

Minimal example:
```python
URL = "list-to-array://xedocs://pmt_area_to_pes?as_list=True&sort=pmt&detector=tpc&run_id=plugin.run_id&version=v9&attr=value"
straxen.URLConfig.evaluate_dry(URL, run_id='047600')
```