### PR TITLE
Add function to save itp_map InterpolatingMap related dictionary into pickle

### DIFF
--- a/straxen/itp_map.py
+++ b/straxen/itp_map.py
@@ -278,7 +278,7 @@ def save_interpolating_map(
     ):
     """
     Make a straxen-style InterpolatingMap.
-    To fit the large XENONnT per-PMT MC maps into strax_auxiliary files,
+    To fit the large XENONnT per-PMT maps into strax_auxiliary files,
     quantized them to values of 1e-5,
     and store the maps as 16-bit integer multiples of 1e-5, instead of 64-bit floats.
     :param itp_map: numpy itp_map or list of floats,

--- a/straxen/itp_map.py
+++ b/straxen/itp_map.py
@@ -266,7 +266,7 @@ class InterpolatingMap:
 
 
 @export
-def save_interpolating_map(
+def save_interpolation_formatted_map(
         itp_map,
         coordinate_system: List,
         filename: str,

--- a/straxen/itp_map.py
+++ b/straxen/itp_map.py
@@ -1,13 +1,22 @@
-import logging
+import os
+import re
 import gzip
 import json
-import re
+import time
+import pickle
+import logging
+import warnings
+from typing import List, Literal
+from textwrap import dedent
 
 import numpy as np
 from scipy.spatial import cKDTree
 from scipy.interpolate import RectBivariateSpline, RegularGridInterpolator
+from multihist import Histdd
+
 import straxen
 import strax
+
 export, __all__ = strax.exporter()
 
 
@@ -50,8 +59,8 @@ class InterpolateAndExtrapolate:
         if self.array_valued:
             weights = np.repeat(weights, self.n_dim).reshape(values.shape)
 
-        result[valid] = np.average(values, weights=weights,
-                                   axis=-2 if self.array_valued else -1)
+        result[valid] = np.average(
+            values, weights=weights, axis=-2 if self.array_valued else -1)
         return result
 
 
@@ -133,15 +142,16 @@ class InterpolatingMap:
 
         self.coordinate_system = csys
         self.interpolators = {}
-        self.map_names = sorted([k for k in self.data.keys()
-                                 if k not in self.metadata_field_names])
+        self.map_names = sorted([
+            k for k in self.data.keys()
+            if k not in self.metadata_field_names])
 
         log = logging.getLogger('InterpolatingMap')
-        log.debug('Map name: %s' % self.data.get('name',
-                                                 "NO NAME?!"))
-        log.debug('Map description:\n    ' +
-                  re.sub(r'\n', r'\n    ', self.data.get('description',
-                                                         "NO DESCRIPTION?!")))
+        log.debug(
+            'Map name: %s' % self.data.get('name', "NO NAME?!"))
+        log.debug(
+            'Map description:\n    ' +
+            re.sub(r'\n', r'\n    ', self.data.get('description', "NO DESCRIPTION?!")))
         log.debug("Map names found: %s" % self.map_names)
 
         for map_name in self.map_names:
@@ -249,7 +259,71 @@ class InterpolatingMap:
             array_valued = len(map_data.shape) == self.dimensions + 1
         if array_valued:
             map_data = map_data.reshape((-1, map_data.shape[-1]))
-        itp_fun = InterpolateAndExtrapolate(points=np.array(alt_csys),
-                                            values=np.array(map_data),
-                                            array_valued=array_valued)
+        itp_fun = InterpolateAndExtrapolate(
+            points=np.array(alt_csys),
+            values=np.array(map_data),
+            array_valued=array_valued)
         self.interpolators[map_name] = itp_fun
+
+
+@export
+def save_interpolating_map(
+    histogram,
+    coordinate_system: List,
+    filename: str,
+    map_name: str = None,
+    quantum=0.00001,
+    map_description: str = '',
+    compressor: Literal['bz2', 'zstd', 'blosc', 'lz4'] = 'zstd'):
+    """
+    Make a straxen-style InterpolatingMap.
+    To fit the large XENONnT per-PMT MC maps into strax_auxiliary files,
+    quantized them to values of 1e-5,
+    and store the maps as 16-bit integer multiples of 1e-5, instead of 64-bit floats.
+    :param histogram: numpy histogram
+    :param coordinate_system: coordinate system of the histogram,
+    list of [['x', [x_min, x_max, n_x]], [['y', [y_min, y_max, n_y], ...] for each dimension,
+    or [[x1, y1], [x2, y2], [x3, y3], [x4, y4], ...]
+    :param filename: filename with '.pkl' extension
+    :param map_name: name of map
+    :param quantum: quantum of the map if quantized
+    :param map_description: map's description
+    :param compressor: key of compressor in strax.io.COMPRESSORS
+    """
+    if isinstance(coordinate_system[0][0], str):
+        histogram_shape = list(histogram.shape)
+        coordinate_shape = [c[1][2] for c in coordinate_system]
+        mask = (len(histogram_shape) == len(coordinate_shape))
+        mask &= all([hs == cs for hs, cs in zip(histogram_shape, coordinate_shape)])
+    else:
+        histogram_shape = len(histogram)
+        coordinate_shape = len(coordinate_system)
+        mask = (histogram_shape == coordinate_shape)
+    if not mask:
+        raise ValueError(
+            f"The shape of histogram: {histogram_shape} and "
+            f"coordinate system: {coordinate_shape} do not match")
+
+    dtype = np.int16
+    encode_until = np.iinfo(dtype).max * quantum
+    if histogram.max() > encode_until:
+        raise ValueError(
+            f"Map maximum value is {histogram.max():.4f},"
+            " can encode values until {encode_until:.4f}")
+
+    output = dict(
+        coordinate_system=coordinate_system,
+        map=strax.io.COMPRESSORS[compressor]['compress'](np.round(histogram / quantum).astype(dtype)),
+        quantized=quantum,
+        description=dedent(map_description),
+        timestamp=time.time(),
+        compressed=(compressor, dtype, histogram.shape),
+    )
+    if map_name is not None:
+        output['name'] = map_name
+
+    if os.path.splitext(filename)[-1] != '.pkl':
+        warnings.warn("Better use .pkl extension for map files")
+    with open(filename, mode='wb') as f:
+        pickle.dump(output, f)
+    print(f"Wrote new map file {filename}, {os.path.getsize(filename) / 1e6:.2f} MB")

--- a/straxen/itp_map.py
+++ b/straxen/itp_map.py
@@ -339,8 +339,13 @@ def save_interpolating_map(
     if map_name is not None:
         output['name'] = map_name
 
-    if os.path.splitext(filename)[-1] != '.pkl':
-        warnings.warn("Better use .pkl extension for map files")
-    with open(filename, mode='wb') as f:
+    if 'pkl' not in filename:
+        warnings.warn("Better use .pkl or .pkl.gz extension for map files")
+    splitext = os.path.splitext(filename)
+    if splitext[-1] == '.gz':
+        opener = gzip.open
+    else:
+        opener = open
+    with opener(filename, mode='wb') as f:
         pickle.dump(output, f)
     print(f"Wrote new map file {filename}, {os.path.getsize(filename) / 1e6:.2f} MB")

--- a/tests/test_itp_map.py
+++ b/tests/test_itp_map.py
@@ -51,6 +51,13 @@ class TestItpMaps(TestCase):
             filename=filename_quantized,
             quantum=0.001,
         )
+        filename_quantized_gzip = 'test_array_valued_quantized.pkl.gz'
+        save_interpolating_map(
+            self._map['map'],
+            self._map['coordinate_system'],
+            filename=filename_quantized_gzip,
+            quantum=0.001,
+        )
 
         # Let's do something easy, check if one fixed point yields the
         # same result if not, our interpolation map depends on the
@@ -58,7 +65,8 @@ class TestItpMaps(TestCase):
         itp_maps = [
             InterpolatingMap(self._map),
             InterpolatingMap(get_resource(filename, fmt='pkl')),
-            InterpolatingMap(get_resource(filename_quantized, fmt='pkl'))
+            InterpolatingMap(get_resource(filename_quantized, fmt='pkl')),
+            InterpolatingMap(get_resource(filename_quantized_gzip, fmt='pkl.gz')),
         ]
         for itp_map in itp_maps:
             map_at_random_point = itp_map([[0, 0, 0], [0, 0, -140]])

--- a/tests/test_itp_map.py
+++ b/tests/test_itp_map.py
@@ -43,7 +43,13 @@ class TestItpMaps(TestCase):
             self._map['map'],
             self._map['coordinate_system'],
             filename=filename,
-            quantum=0.1,
+        )
+        filename_quantized = 'test_array_valued_quantized.pkl'
+        save_interpolating_map(
+            self._map['map'],
+            self._map['coordinate_system'],
+            filename=filename_quantized,
+            quantum=0.001,
         )
 
         # Let's do something easy, check if one fixed point yields the
@@ -51,11 +57,14 @@ class TestItpMaps(TestCase):
         # straxen version?! That's bad!
         itp_maps = [
             InterpolatingMap(self._map),
-            InterpolatingMap(get_resource(filename, fmt='.pkl'))]
+            InterpolatingMap(get_resource(filename, fmt='pkl')),
+            InterpolatingMap(get_resource(filename_quantized, fmt='pkl'))
+        ]
         for itp_map in itp_maps:
             map_at_random_point = itp_map([[0, 0, 0], [0, 0, -140]])
-            self.assertAlmostEqual(map_at_random_point[0][0], 2.80609655)
-            self.assertAlmostEqual(map_at_random_point[0][1], 7.37967879)
+            places = 5
+            self.assertAlmostEqual(map_at_random_point[0][0], 2.80609655, places=places)
+            self.assertAlmostEqual(map_at_random_point[0][1], 7.37967879, places=places)
 
-            self.assertAlmostEqual(map_at_random_point[1][0], 2.17815179)
-            self.assertAlmostEqual(map_at_random_point[1][1], 9.47282782)
+            self.assertAlmostEqual(map_at_random_point[1][0], 2.17815179, places=places)
+            self.assertAlmostEqual(map_at_random_point[1][1], 9.47282782, places=places)

--- a/tests/test_itp_map.py
+++ b/tests/test_itp_map.py
@@ -4,25 +4,6 @@ from straxen import InterpolatingMap, save_interpolating_map
 
 
 class TestItpMaps(TestCase):
-    @property
-    def _map(self):
-        """See https://github.com/XENONnT/straxen/pull/757"""
-        _map = {'coordinate_system': [[-18.3, -31.7, -111.5],
-                                      [36.6, -0.0, -111.5],
-                                      [-18.3, 31.7, -111.5],
-                                      [-18.3, -31.7, -37.5],
-                                      [36.6, -0.0, -37.5],
-                                      [-18.3, 31.7, -37.5]],
-                'description': 'Array_valued dummy map with lists',
-                'name': 'Dummy map',
-                'map': [[1.7, 11.1],
-                        [1.7, 11.1],
-                        [1.7, 11.0],
-                        [3.3, 5.7],
-                        [3.3, 5.8],
-                        [3.3, 5.7]]}
-        return _map
-
     def open_map(self, map_name, fmt, method='WeightedNearestNeighbors'):
         map_data = get_resource(map_name, fmt=fmt)
         m = InterpolatingMap(map_data, method=method)
@@ -31,6 +12,30 @@ class TestItpMaps(TestCase):
     @skipIf(not utilix_is_configured(), 'Cannot download maps without db access')
     def test_lce_map(self):
         self.open_map('XENONnT_s1_xyz_LCE_corrected_qes_MCva43fa9b_wires.json.gz', fmt='json.gz')
+
+    @property
+    def _map(self):
+        """See https://github.com/XENONnT/straxen/pull/757"""
+        map = {
+            'coordinate_system': [
+                [-18.3, -31.7, -111.5],
+                [36.6, -0.0, -111.5],
+                [-18.3, 31.7, -111.5],
+                [-18.3, -31.7, -37.5],
+                [36.6, -0.0, -37.5],
+                [-18.3, 31.7, -37.5]],
+            'description': 'Array_valued dummy map with lists',
+            'name': 'Dummy map',
+            'map': [
+                [1.7, 11.1],
+                [1.7, 11.1],
+                [1.7, 11.0],
+                [3.3, 5.7],
+                [3.3, 5.8],
+                [3.3, 5.7],
+            ],
+        }
+        return map
 
     def test_array_valued(self):
         filename = 'test_array_valued.pkl'
@@ -41,13 +46,13 @@ class TestItpMaps(TestCase):
             quantum=0.1,
         )
 
-        for itp_map in [
+        # Let's do something easy, check if one fixed point yields the
+        # same result if not, our interpolation map depends on the
+        # straxen version?! That's bad!
+        itp_maps = [
             InterpolatingMap(self._map),
-            InterpolatingMap(get_resource(filename, fmt='.pkl'))]:
-
-            # Let's do something easy, check if one fixed point yields the
-            # same result if not, our interpolation map depends on the
-            # straxen version?! That's bad!
+            InterpolatingMap(get_resource(filename, fmt='.pkl'))]
+        for itp_map in itp_maps:
             map_at_random_point = itp_map([[0, 0, 0], [0, 0, -140]])
             self.assertAlmostEqual(map_at_random_point[0][0], 2.80609655)
             self.assertAlmostEqual(map_at_random_point[0][1], 7.37967879)

--- a/tests/test_itp_map.py
+++ b/tests/test_itp_map.py
@@ -1,18 +1,11 @@
 from unittest import TestCase, skipIf
-from straxen import InterpolatingMap, utilix_is_configured, get_resource
+from straxen import utilix_is_configured, get_resource
+from straxen import InterpolatingMap, save_interpolating_map
 
 
 class TestItpMaps(TestCase):
-    def open_map(self, map_name, fmt, method='WeightedNearestNeighbors'):
-        map_data = get_resource(map_name, fmt=fmt)
-        m = InterpolatingMap(map_data, method=method)
-        self.assertTrue(m is not None)
-
-    @skipIf(not utilix_is_configured(), 'Cannot download maps without db access')
-    def test_lce_map(self):
-        self.open_map('XENONnT_s1_xyz_LCE_corrected_qes_MCva43fa9b_wires.json.gz', fmt='json.gz')
-
-    def test_array_valued(self):
+    @property
+    def _map(self):
         """See https://github.com/XENONnT/straxen/pull/757"""
         _map = {'coordinate_system': [[-18.3, -31.7, -111.5],
                                       [36.6, -0.0, -111.5],
@@ -28,14 +21,36 @@ class TestItpMaps(TestCase):
                         [3.3, 5.7],
                         [3.3, 5.8],
                         [3.3, 5.7]]}
-        itp_map = InterpolatingMap(_map)
+        return _map
 
-        # Let's do something easy, check if one fixed point yields the
-        # same result if not, our interpolation map depends on the
-        # straxen version?! That's bad!
-        map_at_random_point = itp_map([[0, 0, 0], [0, 0, -140]])
-        self.assertAlmostEqual(map_at_random_point[0][0], 2.80609655)
-        self.assertAlmostEqual(map_at_random_point[0][1], 7.37967879)
+    def open_map(self, map_name, fmt, method='WeightedNearestNeighbors'):
+        map_data = get_resource(map_name, fmt=fmt)
+        m = InterpolatingMap(map_data, method=method)
+        self.assertTrue(m is not None)
 
-        self.assertAlmostEqual(map_at_random_point[1][0], 2.17815179)
-        self.assertAlmostEqual(map_at_random_point[1][1], 9.47282782)
+    @skipIf(not utilix_is_configured(), 'Cannot download maps without db access')
+    def test_lce_map(self):
+        self.open_map('XENONnT_s1_xyz_LCE_corrected_qes_MCva43fa9b_wires.json.gz', fmt='json.gz')
+
+    def test_array_valued(self):
+        filename = 'test_array_valued.pkl'
+        save_interpolating_map(
+            self._map['map'],
+            self._map['coordinate_system'],
+            filename=filename,
+            quantum=0.1,
+        )
+
+        for itp_map in [
+            InterpolatingMap(self._map),
+            InterpolatingMap(get_resource(filename, fmt='.pkl'))]:
+
+            # Let's do something easy, check if one fixed point yields the
+            # same result if not, our interpolation map depends on the
+            # straxen version?! That's bad!
+            map_at_random_point = itp_map([[0, 0, 0], [0, 0, -140]])
+            self.assertAlmostEqual(map_at_random_point[0][0], 2.80609655)
+            self.assertAlmostEqual(map_at_random_point[0][1], 7.37967879)
+
+            self.assertAlmostEqual(map_at_random_point[1][0], 2.17815179)
+            self.assertAlmostEqual(map_at_random_point[1][1], 9.47282782)

--- a/tests/test_itp_map.py
+++ b/tests/test_itp_map.py
@@ -1,6 +1,6 @@
 from unittest import TestCase, skipIf
 from straxen import utilix_is_configured, get_resource
-from straxen import InterpolatingMap, save_interpolating_map
+from straxen import InterpolatingMap, save_interpolation_formatted_map
 
 
 class TestItpMaps(TestCase):
@@ -39,20 +39,20 @@ class TestItpMaps(TestCase):
 
     def test_array_valued(self):
         filename = 'test_array_valued.pkl'
-        save_interpolating_map(
+        save_interpolation_formatted_map(
             self._map['map'],
             self._map['coordinate_system'],
             filename=filename,
         )
         filename_quantized = 'test_array_valued_quantized.pkl'
-        save_interpolating_map(
+        save_interpolation_formatted_map(
             self._map['map'],
             self._map['coordinate_system'],
             filename=filename_quantized,
             quantum=0.001,
         )
         filename_quantized_gzip = 'test_array_valued_quantized.pkl.gz'
-        save_interpolating_map(
+        save_interpolation_formatted_map(
             self._map['map'],
             self._map['coordinate_system'],
             filename=filename_quantized_gzip,


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Add a function to generate pickle format `InterpolatingMap`. Codes are mainly copied from https://github.com/XENONnT/nton/blob/dcd7193061778a9a155bfdcb703ef6c19f0b7d60/nton/sim/optical_patterns/optical_simulations/maps.py#L420-L475. 

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
