### PR TITLE
Rename `tf_peak_model_s1_cnn` to `tf_model_s1_cnn`

### DIFF
--- a/straxen/plugins/peaks/_peak_s1_positions_base.py
+++ b/straxen/plugins/peaks/_peak_s1_positions_base.py
@@ -48,10 +48,10 @@ class PeakS1PositionBase(strax.Plugin):
     
     def get_tf_model(self):
         """
-        Simple wrapper to have several tf_peak_model_s1_cnn, ..
+        Simple wrapper to have several tf_model_s1_cnn, ..
         point to this same function in the compute method
         """
-        model = getattr(self, f'tf_peak_model_{self.algorithm}', None)
+        model = getattr(self, f'tf_model_{self.algorithm}', None)
         if model is None:
             warn(f'Setting model to None for {self.__class__.__name__} will '
                  f'set only nans as output for {self.algorithm}')

--- a/straxen/plugins/peaks/peak_s1_positions_cnn.py
+++ b/straxen/plugins/peaks/peak_s1_positions_cnn.py
@@ -15,7 +15,7 @@ class PeakS1PositionCNN(PeakS1PositionBase):
     algorithm = "s1_cnn"
     __version__ = '0.0.1'
 
-    tf_peak_model_s1_cnn = straxen.URLConfig(
+    tf_model_s1_cnn = straxen.URLConfig(
         default=f'tf://'
                 f'resource://'
                 f'xedocs://posrec_models'

--- a/straxen/url_config.py
+++ b/straxen/url_config.py
@@ -529,11 +529,11 @@ class URLConfig(strax.Config):
         for k, v in combined_kwargs.items():
             if isinstance(v, str) and cls.PLUGIN_ATTR_PREFIX in v:
                 raise ValueError(
-                    f"The URL parameter {k} depends on the plugin"
-                    "You must specify the value for this parameter"
-                    "for this URL to be evaluated correctly."
-                    f"Try passing {k} as a keyword argument."
-                    f"e.g.: `URLConfig.evaluate_dry({url}, {k}=SOME_VALUE)`"
+                    f"The URL parameter {k} depends on the plugin. "
+                    "You must specify the value for this parameter "
+                    "for this URL to be evaluated correctly. "
+                    f"Try passing {k} as a keyword argument. "
+                    f"e.g.: `URLConfig.evaluate_dry({url}, {k}=SOME_VALUE)`."
                 )
         
         return cls.eval(url)


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

This name is following https://github.com/XENONnT/straxen/blob/b3e776f632f224808d823fe924dbde05f1fcdf28/straxen/plugins/peaks/peak_positions_cnn.py#L16-L26

We do not need to update the plugin version because it is lineage depends on plugin configs. 

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
