### PR TITLE
Use formatted float in `dataframe_to_wiki`

### DIFF
--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -32,7 +32,7 @@ export, __all__ = strax.exporter()
 
 @export
 def dataframe_to_wiki(
-    df, float_digits=5, title='Awesome table', force_int=()):
+    df, float_digits=5, title='Awesome table', force_int:ty.Tuple=()):
     """Convert a pandas dataframe to a dokuwiki table 
     (which you can copy-paste onto the XENON wiki)
     :param df: dataframe to convert
@@ -47,8 +47,8 @@ def dataframe_to_wiki(
         if isinstance(x, float):
             return f'{x:.{float_digits}f}'
         return x
-    force_int = np.where(np.in1d(
-        df.columns.values, strax.to_str_tuple(force_int)))[0]
+    force_int = np.where(np.in1d(df.columns.values,
+                                 strax.to_str_tuple(force_int)))[0]
 
     for _, row in df.iterrows():
         table += "| " + ' | '.join([

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -32,7 +32,7 @@ export, __all__ = strax.exporter()
 
 @export
 def dataframe_to_wiki(
-    df, float_digits=5, title='Awesome table', force_int=tuple()):
+    df, float_digits=5, title='Awesome table', force_int=()):
     """Convert a pandas dataframe to a dokuwiki table 
     (which you can copy-paste onto the XENON wiki)
     :param df: dataframe to convert

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -31,27 +31,28 @@ export, __all__ = strax.exporter()
 
 
 @export
-def dataframe_to_wiki(df, float_digits=5, title='Awesome table', 
-                      force_int=tuple()):
+def dataframe_to_wiki(
+    df, float_digits=5, title='Awesome table', force_int=tuple()):
     """Convert a pandas dataframe to a dokuwiki table 
     (which you can copy-paste onto the XENON wiki)
     :param df: dataframe to convert
-    :param float_digits: Round float-ing point values to this number of digits.
+    :param float_digits: format float to this number of digits.
     :param title: title of the table.
+    :param force_int: tuple of column names to force to be integers
     """
     table = '^ %s ' % title + '^' * (len(df.columns) - 1) + '^\n'
     table += '^ ' + ' ^ '.join(df.columns) + ' ^\n'
 
-    def do_round(x):
+    def format_float(x):
         if isinstance(x, float):
-            return round(x, float_digits)
+            return f'{x:.{float_digits}f}'
         return x
-    force_int = np.where(np.in1d(df.columns.values,
-                                 strax.to_str_tuple(force_int)))[0]
+    force_int = np.where(np.in1d(
+        df.columns.values, strax.to_str_tuple(force_int)))[0]
 
     for _, row in df.iterrows():
         table += "| " + ' | '.join([
-            str(int(x) if i in force_int else do_round(x))
+            str(int(x) if i in force_int else format_float(x))
             for i, x in enumerate(row.values.tolist())]) + ' |\n'
     return table
 


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

In the previous implementation, `straxen.dataframe_to_wiki` will give you '0.5' when `float_digits=2`, which gives the output different lengths. 

Previous:
```
import pandas as pd
import straxen

df = pd.DataFrame({'x': [0.51], 'y': [0.50]})
print(straxen.dataframe_to_wiki(df, float_digits=2))
```

gives output:
```
^ Awesome table ^^
^ x ^ y ^
| 0.51 | 0.5 |
```

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

Now the new code gives output:
```
^ Awesome table ^^
^ x ^ y ^
| 0.51 | 0.50 |
```

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
