### PR TITLE
Replace `z` from `z_naive` to `z_dv_corr`

### DIFF
--- a/straxen/plugins/events/event_positions.py
+++ b/straxen/plugins/events/event_positions.py
@@ -57,21 +57,21 @@ class EventPositions(strax.Plugin):
             comment = f'Main interaction {j}-position, field-distortion corrected (cm)'
             dtype += [(j, np.float32, comment)]
             for s_i in [1, 2]:
-                comment = f'Alternative S{s_i} interaction (rel. main S{int(2 * (1.5 - s_i) + s_i)}) {j}-position, field-distortion corrected (cm)'
+                comment = f'Alternative S{s_i} interaction (rel. main S{3 - s_i}) {j}-position, field-distortion corrected (cm)'
                 field = f'alt_s{s_i}_{j}_fdc'
                 dtype += [(field, np.float32, comment)]
 
         for j in ['z']:
-            comment = 'Interaction z-position corrected to non-uniform drift velocity (cm)'
+            comment = 'Interaction z-position, corrected to non-uniform drift velocity (cm)'
             dtype += [(j, np.float32, comment)]
-            comment = 'Interaction z-position corrected to non-uniform drift velocity (cm)'
+            comment = 'Interaction z-position, corrected to non-uniform drift velocity, duplicated (cm)'
             dtype += [(j + "_dv_corr", np.float32, comment)]
             for s_i in [1, 2]:
-                comment = f'Alternative S{s_i} z-position (rel. main S{int(2 * (1.5 - s_i) + s_i)}) corrected to non-uniform drift velocity (cm)'
+                comment = f'Alternative S{s_i} z-position (rel. main S{3 - s_i}), corrected to non-uniform drift velocity (cm)'
                 field = f'alt_s{s_i}_z'
                 dtype += [(field, np.float32, comment)]
                 # values for corrected Z position
-                comment = f'Alternative S{s_i} z-position (rel. main S{[1 if s_i==2 else 2]}), corrected for non-uniform field (cm)'
+                comment = f'Alternative S{s_i} z-position (rel. main S{3 - s_i}), corrected to non-uniform drift velocity, duplicated (cm)'
                 field = f'alt_s{s_i}_z_dv_corr'
                 dtype += [(field, np.float32, comment)]
 
@@ -89,7 +89,7 @@ class EventPositions(strax.Plugin):
                 naive_pos += [(
                     f'alt_s{s_i}_{j}_naive',
                     np.float32,
-                    f'Alternative S{s_i} interaction (rel. main S{int(2 * (1.5 - s_i) + s_i)}) {j}-position with observed position (cm)')]
+                    f'Alternative S{s_i} interaction (rel. main S{3 - s_i}) {j}-position with observed position (cm)')]
                 fdc_pos += [(f'alt_s{s_i}_{j}_field_distortion_correction',
                              np.float32,
                              f'Correction added to alt_s{s_i}_{j}_naive for field distortion (cm)')]
@@ -97,7 +97,7 @@ class EventPositions(strax.Plugin):
         for s_i in [1, 2]:
             dtype += [(f'alt_s{s_i}_theta',
                        np.float32,
-                       f'Alternative S{s_i} (rel. main S{int(2 * (1.5 - s_i) + s_i)}) interaction angular position (radians)')]
+                       f'Alternative S{s_i} (rel. main S{3 - s_i}) interaction angular position (radians)')]
 
         dtype += [('theta', np.float32, f'Main interaction angular position (radians)')]
         return dtype + strax.time_fields

--- a/straxen/plugins/events/event_positions.py
+++ b/straxen/plugins/events/event_positions.py
@@ -19,7 +19,7 @@ class EventPositions(strax.Plugin):
 
     depends_on = ('event_basics',)
 
-    __version__ = '0.2.0'
+    __version__ = '0.2.1'
 
     default_reconstruction_algorithm = straxen.URLConfig(
         default=DEFAULT_POSREC_ALGO,

--- a/straxen/plugins/events/event_positions.py
+++ b/straxen/plugins/events/event_positions.py
@@ -62,12 +62,12 @@ class EventPositions(strax.Plugin):
                 dtype += [(field, np.float32, comment)]
 
         for j in ['z']:
-            comment = 'Interaction z-position, using mean drift velocity only (cm)'
+            comment = 'Interaction z-position corrected to non-uniform drift velocity (cm)'
             dtype += [(j, np.float32, comment)]
             comment = 'Interaction z-position corrected to non-uniform drift velocity (cm)'
             dtype += [(j + "_dv_corr", np.float32, comment)]
             for s_i in [1, 2]:
-                comment = f'Alternative S{s_i} z-position (rel. main S{int(2 * (1.5 - s_i) + s_i)}), using mean drift velocity only (cm)'
+                comment = f'Alternative S{s_i} z-position (rel. main S{int(2 * (1.5 - s_i) + s_i)}) corrected to non-uniform drift velocity (cm)'
                 field = f'alt_s{s_i}_z'
                 dtype += [(field, np.float32, comment)]
                 # values for corrected Z position
@@ -153,9 +153,9 @@ class EventPositions(strax.Plugin):
                            f'{pre_field}r_field_distortion_correction': delta_r,
                            f'{pre_field}theta': np.arctan2(orig_pos[:, 1], orig_pos[:, 0]),
                            f'{pre_field}z_naive': z_obs,
-                           # using z_obs in agreement with the dtype description
+                           # using z_dv_corr (z_obs - z_dv_delta) in agreement with the dtype description
                            # the FDC for z (z_cor) is found to be not reliable (see #527)
-                           f'{pre_field}z': z_obs,
+                           f'{pre_field}z': z_obs - z_dv_delta,
                            f'{pre_field}z_field_distortion_correction': delta_z,
                            f'{pre_field}z_dv_corr': z_obs - z_dv_delta,
                            })


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

It replaces `z` to `z_dv_corr`, `alt_s1_z` to `alt_s1_z_dv_corr` and `alt_s2_z` to `alt_s2_z_dv_corr`. Because `z_dv_corr` already played a good correction for `z`.

Reference: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:terliuk:drift_field_z_bias_correction

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
