### PR TITLE
Check chunk n for backends after chunk loading

### DIFF
--- a/straxen/storage/rucio_local.py
+++ b/straxen/storage/rucio_local.py
@@ -158,6 +158,7 @@ class RucioLocalBackend(strax.FileSytemBackend):
         with open(metadata_path, mode='r') as f:
             return json.loads(f.read())
 
+    @strax.check_chunk_n
     def _read_chunk(self, did, chunk_info, dtype, compressor):
         scope, name = did.split(':')
         did = f"{scope}:{chunk_info['filename']}"

--- a/straxen/storage/rucio_remote.py
+++ b/straxen/storage/rucio_remote.py
@@ -138,6 +138,7 @@ class RucioRemoteBackend(strax.FileSytemBackend):
         with open(metadata_path, mode='r') as f:
             return json.loads(f.read())
 
+    @strax.check_chunk_n
     def _read_chunk(self, dset_did, chunk_info, dtype, compressor):
         base_dir = os.path.join(self.staging_dir, did_to_dirname(dset_did))
         chunk_file = chunk_info['filename']


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Apply `check_chunk_n` to rucio local and remote backends.

Depends on https://github.com/AxFoundation/strax/pull/752

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
