### PR TITLE
Give `RunDB` an option to find files in storage

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -158,6 +158,7 @@ def xenonnt_online(output_folder: str = './strax_data',
                    _auto_append_rucio_local: bool = True,
                    _rucio_path: str = '/dali/lgrandi/rucio/',
                    _rucio_local_path: ty.Optional[str] = None,
+                   _find_in_storage: bool = False,
                    _raw_paths: ty.Optional[str] = ['/dali/lgrandi/xenonnt/raw'],
                    _processed_paths: ty.Optional[ty.List[str]] = ['/dali/lgrandi/xenonnt/processed',
                                                                   '/project2/lgrandi/xenonnt/processed',
@@ -224,6 +225,7 @@ def xenonnt_online(output_folder: str = './strax_data',
             runid_field='number',
             new_data_path=output_folder,
             rucio_path=_rucio_path,
+            find_in_storage=_find_in_storage,
         )] if _database_init else []
     if not we_are_the_daq:
         for _raw_path in _raw_paths:

--- a/straxen/storage/rundb.py
+++ b/straxen/storage/rundb.py
@@ -42,6 +42,7 @@ class RunDB(strax.StorageFrontend):
                  new_data_path=None,
                  reader_ini_name_is_mode=False,
                  rucio_path=None,
+                 find_in_storage=False,
                  mongo_url=None,
                  mongo_user=None,
                  mongo_password=None,
@@ -81,6 +82,7 @@ class RunDB(strax.StorageFrontend):
         if self.new_data_path is None:
             self.readonly = True
         self.runid_field = runid_field
+        self.find_in_storage = find_in_storage
 
         if self.runid_field not in ['name', 'number']:
             raise ValueError("Unrecognized runid_field option %s" % self.runid_field)
@@ -230,6 +232,13 @@ class RunDB(strax.StorageFrontend):
         return datum['protocol'], datum['location']
 
     def find_several(self, keys: typing.List[strax.DataKey], **kwargs):
+        """Find several keys at once.
+        If find_in_storage is True, will only check the storage backend,
+        because sometimes the RunDB docs indicate more docs than the available servers.
+        """
+        if self.find_in_storage:
+            return super().find_several(keys, **kwargs)
+
         if kwargs.get('fuzzy_for', False) or kwargs.get('fuzzy_for_options', False):
             warnings.warn("Can't do fuzzy with RunDB yet. Only returning exact matches")
         if not keys:


### PR DESCRIPTION
Give RunDB an option to find files in storage but not in database in find_several function.

## What does the code in this PR do / what does it improve?

Historically, the `RunDB` knows where are all the available files located on servers and assumes they are all available. But if we have multiple partitions, then RunDB will provide runs in the database but not available.

This happens a lot when running `strax.Context.select_runs`, in the `strax.StorageFrontend.find_several` function. So this PR gives RunDB an option to run `strax.StorageFrontend.find_several` directly.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
