### PR TITLE
No need to get map shape for 0D placeholder map

### DIFF
--- a/straxen/itp_map.py
+++ b/straxen/itp_map.py
@@ -156,10 +156,12 @@ class InterpolatingMap:
         for map_name in self.map_names:
             # Specify dtype float to set Nones to nan
             map_data = np.array(self.data[map_name], dtype=np.float64)
-            if len(self.coordinate_system) == len(map_data):
-                array_valued = len(map_data.shape) == 2
-            else:
-                array_valued = len(map_data.shape) == self.dimensions + 1
+
+            if self.dimensions != 0:
+                if len(self.coordinate_system) == len(map_data):
+                    array_valued = len(map_data.shape) == 2
+                else:
+                    array_valued = len(map_data.shape) == self.dimensions + 1
 
             if self.dimensions == 0:
                 # 0 D -- placeholder maps which take no arguments


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

When using placeholder maps, usually they are single values, so we can not use `len` on `map_data`.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_
