### PR TITLE
Photon ionization correction on S2

### DIFF
--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -81,7 +81,7 @@ class CorrectedAreas(strax.Plugin):
 
     # Photon ionization intensity and cS2 AFT correction
     photon_ionization_intensity = straxen.URLConfig(
-        default='cmt://photon_ionization_intensity?version=ONLINE&run_id=plugin.run_id',
+        default='cmt://photoionization_strengths?version=ONLINE&run_id=plugin.run_id',
         help='Photon ionization intensity'
     )
 

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -21,7 +21,7 @@ class CorrectedAreas(strax.Plugin):
         cs2_top and cs2_bottom are corrected by the corresponding maps,
         and cs2 is the sum of the two.
     """
-    __version__ = '0.3.0'
+    __version__ = '0.3.1'
 
     depends_on = ['event_basics', 'event_positions']
 

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -80,7 +80,7 @@ class CorrectedAreas(strax.Plugin):
     )
 
     # cS2 AFT correction due to photon ionization
-    bottom_top_ratio_correction = straxen.URLConfig(
+    cs2_bottom_top_ratio_correction = straxen.URLConfig(
         default=1,
         help='Scaling factor for cS2 AFT correction due to photon ionization'
     )
@@ -216,7 +216,7 @@ class CorrectedAreas(strax.Plugin):
 
             # Bottom top ratios
             bt = cs2_bottom / cs2_top
-            bt_corrected = bt * self.bottom_top_ratio_correction
+            bt_corrected = bt * self.cs2_bottom_top_ratio_correction
 
             # cS2 bottom should be corrected by photon ionization, but not cS2 top
             cs2_top_corrected = cs2_top

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -81,7 +81,7 @@ class CorrectedAreas(strax.Plugin):
 
     # Photon ionization intensity and cS2 AFT correction
     photon_ionization_intensity = straxen.URLConfig(
-        default='cmt://photoionization_strengths?version=ONLINE&run_id=plugin.run_id',
+        default=0,
         help='Photon ionization intensity'
     )
 

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -100,11 +100,18 @@ class CorrectedAreas(strax.Plugin):
                       (f'{peak_type}cs2_wo_timecorr', np.float32,
                        f'Corrected area of {peak_name} S2 before SEG/EE and elife corrections'
                        f'(s2 xy correction applied) [PE]'),
+                      (f'{peak_type}cs2_area_fraction_top_wo_picorr', np.float32,
+                       f'Fraction of area seen by the top PMT array for corrected {peak_name} S2 before photon ionization correction'),
+                      (f'{peak_type}cs2_bottom_wo_picorr', np.float32,
+                       f'Corrected area of {peak_name} S2 in the bottom PMT array [PE] before photon ionization correction'),
+                      (f'{peak_type}cs2_wo_picorr', np.float32,
+                       f'Corrected area of {peak_name} S2 [PE] before photon ionization correction'),
                       (f'{peak_type}cs2_area_fraction_top', np.float32,
                        f'Fraction of area seen by the top PMT array for corrected {peak_name} S2'),
                       (f'{peak_type}cs2_bottom', np.float32,
                        f'Corrected area of {peak_name} S2 in the bottom PMT array [PE]'),
-                      (f'{peak_type}cs2', np.float32, f'Corrected area of {peak_name} S2 [PE]'), ]
+                      (f'{peak_type}cs2', np.float32,
+                       f'Corrected area of {peak_name} S2 [PE]')]
         return dtype
 
     def ab_region(self, x, y):
@@ -206,14 +213,14 @@ class CorrectedAreas(strax.Plugin):
                 result[f"{peak_type}cs2_wo_elifecorr"][partition_mask] = cs2_top_wo_elifecorr + cs2_bottom_wo_elifecorr
 
                 # cs2aft doesn't need elife/time corrections as they cancel
-                result[f"{peak_type}cs2_area_fraction_top"][partition_mask] = cs2_top_wo_elifecorr / (cs2_top_wo_elifecorr + cs2_bottom_wo_elifecorr)
-                result[f"{peak_type}cs2"][partition_mask] = result[f"{peak_type}cs2_wo_elifecorr"][partition_mask] * elife_correction[partition_mask]
-                result[f"{peak_type}cs2_bottom"][partition_mask] = cs2_bottom_wo_elifecorr * elife_correction[partition_mask]
+                result[f"{peak_type}cs2_area_fraction_top_wo_picorr"][partition_mask] = cs2_top_wo_elifecorr / (cs2_top_wo_elifecorr + cs2_bottom_wo_elifecorr)
+                result[f"{peak_type}cs2_wo_picorr"][partition_mask] = result[f"{peak_type}cs2_wo_elifecorr"][partition_mask] * elife_correction[partition_mask]
+                result[f"{peak_type}cs2_bottom_wo_picorr"][partition_mask] = cs2_bottom_wo_elifecorr * elife_correction[partition_mask]
 
         # Photon ionization intensity and cS2 AFT correction (see #1247)
         for peak_type in ["", "alt_"]:
-            cs2_bottom = result[f"{peak_type}cs2_bottom"]
-            cs2_top = result[f"{peak_type}cs2"] - cs2_bottom
+            cs2_bottom = result[f"{peak_type}cs2_bottom_wo_picorr"]
+            cs2_top = result[f"{peak_type}cs2_wo_picorr"] - cs2_bottom
 
             # Bottom top ratios
             bt = cs2_bottom / cs2_top

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -223,7 +223,7 @@ class CorrectedAreas(strax.Plugin):
                 result[f"{peak_type}cs2"][partition_mask] = result[f"{peak_type}cs2_wo_elifecorr"][partition_mask] * elife_correction[partition_mask]
                 result[f"{peak_type}cs2_bottom"][partition_mask] = cs2_bottom_wo_elifecorr * elife_correction[partition_mask]
 
-        # Photon ionization intensity and cS2 AFT correction
+        # Photon ionization intensity and cS2 AFT correction (see #1247)
         for peak_type in ["", "alt_"]:
             cs2_bottom = result[f"{peak_type}cs2_bottom"]
             cs2_top = result[f"{peak_type}cs2"] - cs2_bottom

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -80,6 +80,7 @@ class CorrectedAreas(strax.Plugin):
     )
 
     # cS2 AFT correction due to photon ionization
+    # https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:zihao:sr1_s2aft_photonionization_correction
     cs2_bottom_top_ratio_correction = straxen.URLConfig(
         default=1,
         help='Scaling factor for cS2 AFT correction due to photon ionization'

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -125,7 +125,7 @@ class CorrectedAreas(strax.Plugin):
 
     def cd_region(self, x, y):
         return ~self.ab_region(x, y)
-    
+
     def s2_map_names(self):
 
         # S2 top and bottom are corrected separately, and cS2 total is the sum of the two
@@ -136,13 +136,13 @@ class CorrectedAreas(strax.Plugin):
         else:
             s2_top_map_name = "map"
             s2_bottom_map_name = "map"
-        
+
         return s2_top_map_name, s2_bottom_map_name
-    
+
     def seg_ee_correction_preparation(self):
         """Get single electron gain and extraction efficiency options"""
         self.regions = {'ab': self.ab_region, 'cd': self.cd_region}
-        
+
         # setup SEG and EE corrections
         # if they are dicts, we just leave them as is
         # if they are not, we assume they are floats and

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -21,7 +21,7 @@ class CorrectedAreas(strax.Plugin):
         cs2_top and cs2_bottom are corrected by the corresponding maps,
         and cs2 is the sum of the two.
     """
-    __version__ = '0.3.1'
+    __version__ = '0.4.0'
 
     depends_on = ['event_basics', 'event_positions']
 

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -87,12 +87,12 @@ class CorrectedAreas(strax.Plugin):
 
     cs2_aft_correction_coefficients = straxen.URLConfig(
         default=(-0.0756, 0.3188),
-        help='cS2 AFT correction coefficients'
+        help='cS2 AFT correction coefficients due to photon ionization'
     )
 
     cs2_aft_correction_average = straxen.URLConfig(
         default=0.7648,
-        help='cS2 AFT correction average'
+        help='cS2 AFT correction average due to photon ionization'
     )
 
     def infer_dtype(self):


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
This PR implements the corrections on S2 due to photon ionization. Detailed study can be found in [the note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:zihao:sr1_s2aft_photonionization_correction).

## Can you briefly describe how it works?
It scales cs2 bottom based on the model and corrects cs2 aft accordingly.

## Can you give a minimal working example (or illustrate with a figure)?
