### PR TITLE
Use the new S1 optical map for global_v12 reprocessing.

### DIFF
--- a/straxen/plugins/events/event_pattern_fit.py
+++ b/straxen/plugins/events/event_pattern_fit.py
@@ -44,7 +44,7 @@ class EventPatternFit(strax.Plugin):
         help='S1 (x, y, z) optical/pattern map.', infer_type=False,
         default='itp_map://'
                 'resource://'
-                'XENONnT_s1_xyz_patterns_corrected_qes_MCva43fa9b_wires.pkl'
+                'XENONnT_S1_xyz_patterns_sparse_binning_LCE_with-QEs_MCv4.4.0_wires.pkl'
                 '?fmt=pkl')
 
     s2_optical_map = straxen.URLConfig(


### PR DESCRIPTION
Use the newer S1 pattern map for global_v12 reprocessing. Related note: [https://xe1t-wiki.lngs.infn.it/doku.php?id=min:s1opticalmap_comparison](url).
