### PR TITLE
Correct elife for `cs2_wo_timecorr`

### DIFF
--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -21,7 +21,7 @@ class CorrectedAreas(strax.Plugin):
         cs2_top and cs2_bottom are corrected by the corresponding maps,
         and cs2 is the sum of the two.
     """
-    __version__ = '0.5.0'
+    __version__ = '0.5.1'
 
     depends_on = ['event_basics', 'event_positions']
 
@@ -104,6 +104,11 @@ class CorrectedAreas(strax.Plugin):
             for i, name in enumerate(names):
                 if i == len(names) - 1:
                     description = ''
+                elif i == 0:
+                    # special treatment for wo_timecorr, apply elife correction
+                    description = ' (before ' + ' + '.join(descriptions[i + 1:-1])
+                    description += ', after ' + ' + '.join(
+                        descriptions[:i + 1] + descriptions[-1:]) + ')'
                 else:
                     description = ' (before ' + ' + '.join(descriptions[i + 1:])
                     description += ', after ' + ' + '.join(descriptions[:i + 1]) + ')'
@@ -219,9 +224,9 @@ class CorrectedAreas(strax.Plugin):
                 seg_ee_corr[partition_mask] = seg[partition] / avg_seg[partition] * ee[partition]
 
             # apply S2 xy correction
-            result[f"{peak_type}cs2_wo_timecorr"] = cs2_top_xycorr + cs2_bottom_xycorr
-            result[f"{peak_type}cs2_area_fraction_top_wo_timecorr"] = (
-                cs2_top_xycorr / result[f"{peak_type}cs2_wo_timecorr"])
+            cs2_xycorr = cs2_top_xycorr + cs2_bottom_xycorr
+            result[f"{peak_type}cs2_wo_timecorr"] = cs2_xycorr * elife_correction
+            result[f"{peak_type}cs2_area_fraction_top_wo_timecorr"] = cs2_top_xycorr / cs2_xycorr
 
             # apply SEG and EE correction
             cs2_top_wo_picorr = cs2_top_xycorr / seg_ee_corr


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

In https://github.com/XENONnT/straxen/pull/1258, the elife correction of `cs2_wo_timecorr` in `corrected_areas` was removed. To be aligned with `PeakCorrectedAreas` https://github.com/XENONnT/straxen/blob/7e49677eead6e88d9dffb12e6f6d457a67daeb6b/straxen/plugins/peaks/peak_corrections.py#L10, we should correct the elife also for `cs2_wo_timecorr`.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

From https://straxen--1260.org.readthedocs.build/en/1260/reference/datastructure_nT.html#corrected-areas:
![image](https://github.com/XENONnT/straxen/assets/40532474/0b72b986-0484-4f8d-b14b-14efb13a4b3d)

Comparison between old and new results of run `051806`, blinded events removed:

```
----------
old nan cs2 23.2%
new nan cs2 23.2%
difference cs2 0.0%
mean abs difference cs2 0.0e+00
----------
old nan cs2_area_fraction_top 0.0%
new nan cs2_area_fraction_top 0.0%
difference cs2_area_fraction_top 0.0%
mean abs difference cs2_area_fraction_top 0.0e+00
----------
old nan cs2_area_fraction_top_wo_elifecorr 0.0%
new nan cs2_area_fraction_top_wo_elifecorr 0.0%
difference cs2_area_fraction_top_wo_elifecorr 0.0%
mean abs difference cs2_area_fraction_top_wo_elifecorr 0.0e+00
----------
old nan cs2_area_fraction_top_wo_picorr 0.0%
new nan cs2_area_fraction_top_wo_picorr 0.0%
difference cs2_area_fraction_top_wo_picorr 0.0%
mean abs difference cs2_area_fraction_top_wo_picorr 0.0e+00
----------
old nan cs2_area_fraction_top_wo_timecorr 0.0%
new nan cs2_area_fraction_top_wo_timecorr 0.0%
difference cs2_area_fraction_top_wo_timecorr 27.9%
mean abs difference cs2_area_fraction_top_wo_timecorr 1.6e-08
----------
old nan cs2_wo_elifecorr 0.0%
new nan cs2_wo_elifecorr 0.0%
difference cs2_wo_elifecorr 0.0%
mean abs difference cs2_wo_elifecorr 0.0e+00
----------
old nan cs2_wo_picorr 0.0%
new nan cs2_wo_picorr 0.0%
difference cs2_wo_picorr 0.0%
mean abs difference cs2_wo_picorr 0.0e+00
----------
old nan cs2_wo_timecorr 0.0%
new nan cs2_wo_timecorr 23.2%
difference cs2_wo_timecorr 100.0%
mean abs difference cs2_wo_timecorr 4.9e+03
----------
old nan endtime 0.0%
new nan endtime 0.0%
difference endtime 0.0%
mean abs difference endtime 0.0e+00
----------
old nan time 0.0%
new nan time 0.0%
difference time 0.0%
mean abs difference time 0.0e+00
----------
```

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [x] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_
