### PR TITLE
Save `event_n_channel` which just contains s1_n_channels fields

### DIFF
--- a/straxen/plugins/events/event_area_per_channel.py
+++ b/straxen/plugins/events/event_area_per_channel.py
@@ -61,7 +61,7 @@ class EventAreaPerChannel(strax.Plugin):
         area_per_channel = np.zeros(len(events), self.dtype["event_area_per_channel"])
         area_per_channel['time'] = events['time']
         area_per_channel['endtime'] = strax.endtime(events)
-        n_channel = np.zeros(len(events), self.dtype["event_area_per_channel"])
+        n_channel = np.zeros(len(events), self.dtype["event_n_channel"])
         n_channel['time'] = events['time']
         n_channel['endtime'] = strax.endtime(events)
 


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Save an extra data_type `event_n_channel` to save `'s1_n_channels', 's1_top_n_channels', 's1_bottom_n_channels'`. 

## Can you briefly describe how it works?

Just copy the fields.

## Can you give a minimal working example (or illustrate with a figure)?

Old vs new `event_pattern_fit` in run_id `049989`.

```
----------
old nan alt_s1_area_fraction_top_continuous_probability 87.0%
new nan alt_s1_area_fraction_top_continuous_probability 87.0%
difference alt_s1_area_fraction_top_continuous_probability 0.0%
mean abs difference alt_s1_area_fraction_top_continuous_probability 0.0e+00
----------
old nan alt_s1_area_fraction_top_discrete_probability 87.0%
new nan alt_s1_area_fraction_top_discrete_probability 87.0%
difference alt_s1_area_fraction_top_discrete_probability 0.0%
mean abs difference alt_s1_area_fraction_top_discrete_probability 0.0e+00
----------
old nan alt_s1_photon_fraction_top_continuous_probability 87.0%
new nan alt_s1_photon_fraction_top_continuous_probability 87.0%
difference alt_s1_photon_fraction_top_continuous_probability 0.0%
mean abs difference alt_s1_photon_fraction_top_continuous_probability 0.0e+00
----------
old nan alt_s1_photon_fraction_top_discrete_probability 87.0%
new nan alt_s1_photon_fraction_top_discrete_probability 87.0%
difference alt_s1_photon_fraction_top_discrete_probability 0.0%
mean abs difference alt_s1_photon_fraction_top_discrete_probability 0.0e+00
----------
old nan alt_s2_2llh 1.8%
new nan alt_s2_2llh 1.8%
difference alt_s2_2llh 0.0%
mean abs difference alt_s2_2llh 0.0e+00
----------
old nan alt_s2_neural_2llh 1.6%
new nan alt_s2_neural_2llh 1.6%
difference alt_s2_neural_2llh 0.0%
mean abs difference alt_s2_neural_2llh 0.0e+00
----------
old nan s1_2llh 31.7%
new nan s1_2llh 31.7%
difference s1_2llh 0.0%
mean abs difference s1_2llh 0.0e+00
----------
old nan s1_area_fraction_top_continuous_probability 24.6%
new nan s1_area_fraction_top_continuous_probability 24.6%
difference s1_area_fraction_top_continuous_probability 0.0%
mean abs difference s1_area_fraction_top_continuous_probability 0.0e+00
----------
old nan s1_area_fraction_top_discrete_probability 24.6%
new nan s1_area_fraction_top_discrete_probability 24.6%
difference s1_area_fraction_top_discrete_probability 0.0%
mean abs difference s1_area_fraction_top_discrete_probability 0.0e+00
----------
old nan s1_bottom_2llh 31.7%
new nan s1_bottom_2llh 31.7%
difference s1_bottom_2llh 0.0%
mean abs difference s1_bottom_2llh 0.0e+00
----------
old nan s1_photon_fraction_top_continuous_probability 24.6%
new nan s1_photon_fraction_top_continuous_probability 24.6%
difference s1_photon_fraction_top_continuous_probability 0.0%
mean abs difference s1_photon_fraction_top_continuous_probability 0.0e+00
----------
old nan s1_photon_fraction_top_discrete_probability 24.6%
new nan s1_photon_fraction_top_discrete_probability 24.6%
difference s1_photon_fraction_top_discrete_probability 0.0%
mean abs difference s1_photon_fraction_top_discrete_probability 0.0e+00
----------
old nan s1_top_2llh 31.7%
new nan s1_top_2llh 31.7%
difference s1_top_2llh 0.0%
mean abs difference s1_top_2llh 0.0e+00
----------
old nan s2_2llh 0.4%
new nan s2_2llh 0.4%
difference s2_2llh 0.0%
mean abs difference s2_2llh 0.0e+00
----------
old nan s2_neural_2llh 0.1%
new nan s2_neural_2llh 0.1%
difference s2_neural_2llh 0.0%
mean abs difference s2_neural_2llh 0.0e+00
----------
```
