### PR TITLE
Add pad-array protocol

### DIFF
--- a/straxen/legacy/xenon1t_url_configs.py
+++ b/straxen/legacy/xenon1t_url_configs.py
@@ -95,3 +95,9 @@ def get_z_bias(offset: str):
         return np.zeros(len(rz)) * int(offset)
 
     return fake_z_bias
+
+
+@URLConfig.register('pad-array')
+def get_paded_array(arr: np.ndarray, pad_value=0, pad_left=0, pad_right=0):
+    """Pad the array with pad_value on the left and right side"""
+    return np.pad(arr, (pad_left, pad_right), constant_values=pad_value)

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -391,3 +391,10 @@ class TestURLConfig(unittest.TestCase):
             self.st.set_config({ 'test_config': "run_doc://mode?run_id=plugin.run_id" })
             p = self.st.get_single_plugin(999999999, 'test_data')
             return p.test_config
+    
+    def test_pad_array(self):
+        self.st.set_config({'test_config': 'pad-array://json://[1,2,3]?pad_left=2&pad_right=3&pad_value=0'})
+        p = self.st.get_single_plugin(nt_test_run_id, 'test_data')
+        self.assertEqual(len(p.test_config), 8)
+        self.assertEqual(p.test_config[0], 0)
+        self.assertEqual(p.test_config[-1], 0)


### PR DESCRIPTION
Adds a URLConfig protocol wich will pad an array on the left or right or both with a configurable number of elements of the specified value

The protocol accepts the arguments pad_left, pad_right and pad_value to specify how many elements to add and what value to fill them with.
