### PR TITLE
No need to apply `strax.check_chunk_n` individually

### DIFF
--- a/straxen/storage/rucio_local.py
+++ b/straxen/storage/rucio_local.py
@@ -158,7 +158,6 @@ class RucioLocalBackend(strax.FileSytemBackend):
         with open(metadata_path, mode='r') as f:
             return json.loads(f.read())
 
-    @strax.check_chunk_n
     def _read_chunk(self, did, chunk_info, dtype, compressor):
         scope, name = did.split(':')
         did = f"{scope}:{chunk_info['filename']}"

--- a/straxen/storage/rucio_remote.py
+++ b/straxen/storage/rucio_remote.py
@@ -138,7 +138,6 @@ class RucioRemoteBackend(strax.FileSytemBackend):
         with open(metadata_path, mode='r') as f:
             return json.loads(f.read())
 
-    @strax.check_chunk_n
     def _read_chunk(self, dset_did, chunk_info, dtype, compressor):
         base_dir = os.path.join(self.staging_dir, did_to_dirname(dset_did))
         chunk_file = chunk_info['filename']


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

After https://github.com/AxFoundation/strax/pull/758 is merged, there is no need to apply `strax.check_chunk_n` individually to each `StorageBackend`.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?
