### PR TITLE
Hint unstaged repo as well for `print_versions`

### DIFF
--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -124,7 +124,13 @@ def _version_info_for_module(module_name, include_git):
                 commit_hash = repo.head.object.hexsha
             except TypeError:
                 commit_hash = 'unknown'
+            try:
+                is_dirty = repo.is_dirty()
+            except TypeError:
+                is_dirty = None
             git = f'branch:{branch} | {commit_hash[:7]}'
+            if is_dirty:
+                git += ' + unstaged'
     return version, module_path, git
 
 


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Sometimes we accidentally or by purpose change the code without a trackable commit. This PR print ` + unstaged` if there is uncommitted changes.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_
