### PR TITLE
Find time difference and properties of nearest triggering peaks

### DIFF
--- a/straxen/plugins/events/__init__.py
+++ b/straxen/plugins/events/__init__.py
@@ -66,3 +66,6 @@ from .local_minimum_info import *
 
 from . import multi_scatter
 from .multi_scatter import *
+
+from . import event_nearest_triggering
+from .event_nearest_triggering import *

--- a/straxen/plugins/events/event_nearest_triggering.py
+++ b/straxen/plugins/events/event_nearest_triggering.py
@@ -1,0 +1,105 @@
+import numpy as np
+import strax
+import straxen
+
+export, __all__ = strax.exporter()
+
+
+@export
+class EventNearestTriggering(strax.Plugin):
+    """Time difference and properties of the nearest triggering peaks of main peaks of events."""
+
+    __version__ = "0.0.0"
+    depends_on = ("event_basics", "peak_basics", "peak_nearest_triggering")
+    provides = "event_nearest_triggering"
+    save_when = strax.SaveWhen.EXPLICIT
+
+    def infer_dtype(self):
+        dtype = []
+        common_descr = "of the nearest triggering peak on the"
+        for main_peak, main_peak_desc in zip(["s1_", "s2_"], ["main S1", "main S2"]):
+            for direction in ["left", "right"]:
+                dtype += [
+                    (
+                        (
+                            f"time difference {common_descr} {direction} of {main_peak_desc} [ns]",
+                            f"{main_peak}{direction}_dtime",
+                        ),
+                        np.int64,
+                    ),
+                    (
+                        (
+                            f"time {common_descr} {direction} of {main_peak_desc} [ns]",
+                            f"{main_peak}{direction}_time",
+                        ),
+                        np.int64,
+                    ),
+                    (
+                        (
+                            f"endtime {common_descr} {direction} of {main_peak_desc} [ns]",
+                            f"{main_peak}{direction}_endtime",
+                        ),
+                        np.int64,
+                    ),
+                    (
+                        (
+                            f"center_time {common_descr} {direction} of {main_peak_desc} [ns]",
+                            f"{main_peak}{direction}_center_time",
+                        ),
+                        np.int64,
+                    ),
+                    (
+                        (
+                            f"type {common_descr} {direction} of {main_peak_desc}",
+                            f"{main_peak}{direction}_type",
+                        ),
+                        np.int8,
+                    ),
+                    (
+                        (
+                            f"n_competing {common_descr} {direction} of {main_peak_desc}",
+                            f"{main_peak}{direction}_n_competing",
+                        ),
+                        np.int32,
+                    ),
+                    (
+                        (
+                            f"area {common_descr} {direction} of {main_peak_desc} [PE]",
+                            f"{main_peak}{direction}_area",
+                        ),
+                        np.float32,
+                    ),
+                ]
+        dtype += strax.time_fields
+        return dtype
+
+    def compute(self, events, peaks):
+        split_peaks = strax.split_by_containment(peaks, events)
+        result = np.zeros(len(events), self.dtype)
+
+        straxen.EventBasics.set_nan_defaults(result)
+
+        # 1. Assign peaks features to main S1 and main S2 in the event
+        for event_i, (event, sp) in enumerate(zip(events, split_peaks)):
+            res_i = result[event_i]
+            # Fetch the features of main S1 and main S2
+            for idx, main_peak in zip([event["s1_index"], event["s2_index"]], ["s1_", "s2_"]):
+                if idx >= 0:
+                    for direction in ["left", "right"]:
+                        for field in [
+                            "dtime",
+                            "time",
+                            "endtime",
+                            "center_time",
+                            "type",
+                            "n_competing",
+                            "area",
+                        ]:
+                            res_i[f"{main_peak}{direction}_{field}"] = sp[f"{direction}_{field}"][
+                                idx
+                            ]
+
+        # 2. Set time and endtime for events
+        result["time"] = events["time"]
+        result["endtime"] = strax.endtime(events)
+        return result

--- a/straxen/plugins/events/events.py
+++ b/straxen/plugins/events/events.py
@@ -118,7 +118,7 @@ class Events(strax.OverlapWindowPlugin):
         # Take a large window for safety, events can have long tails
         return 10 * (self.left_event_extension + self.drift_time_max + self.right_event_extension)
 
-    def compute(self, peaks, start, end):
+    def _is_triggering(self, peaks):
         _is_triggering = peaks["area"] > self.trigger_min_area
         _is_triggering &= peaks["n_competing"] <= self.trigger_max_competing
         if self.exclude_s1_as_triggering_peaks:
@@ -127,6 +127,10 @@ class Events(strax.OverlapWindowPlugin):
             is_not_s1 = peaks["type"] != 1
             has_tc_large_enough = peaks["tight_coincidence"] >= self.event_s1_min_coincidence
             _is_triggering &= is_not_s1 | has_tc_large_enough
+        return _is_triggering
+
+    def compute(self, peaks, start, end):
+        _is_triggering = self._is_triggering(peaks)
 
         triggers = peaks[_is_triggering]
 

--- a/straxen/plugins/peaks/__init__.py
+++ b/straxen/plugins/peaks/__init__.py
@@ -42,3 +42,6 @@ from .peak_corrections import *
 
 from . import peaks_subtyping
 from .peaks_subtyping import *
+
+from . import peak_nearest_triggering
+from .peak_nearest_triggering import *

--- a/straxen/plugins/peaks/peak_nearest_triggering.py
+++ b/straxen/plugins/peaks/peak_nearest_triggering.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numba
 import strax
 import straxen
 from .peak_ambience import _quick_assign
@@ -9,7 +10,8 @@ export, __all__ = strax.exporter()
 
 @export
 class PeakNearestTriggering(Events):
-    """Time difference and properties of the nearest triggering peaks."""
+    """Time difference and properties of the nearest triggering peaks in the left and right
+    direction of peaks."""
 
     __version__ = "0.0.0"
     depends_on = ("peak_basics", "peak_proximity")
@@ -22,6 +24,13 @@ class PeakNearestTriggering(Events):
         type=int,
         track=True,
         help="Search for peaks casting time & position shadow in this time window [ns]",
+    )
+
+    only_trigger_min_area = straxen.URLConfig(
+        default=False,
+        type=bool,
+        track=True,
+        help="Whether only require the triggering peak to have area larger than trigger_min_area",
     )
 
     def infer_dtype(self):
@@ -58,42 +67,76 @@ class PeakNearestTriggering(Events):
         return result
 
     def compute_triggering(self, peaks, current_peak):
-        _is_triggering = self._is_triggering(peaks)
-
-        roi_triggering = np.zeros(len(current_peak), dtype=strax.time_fields)
-
+        # sort peaks by center_time,
+        # because later we will use center_time to find the nearest peak
+        _peaks = np.sort(peaks, order="center_time")
+        # only looking at triggering peaks
+        if self.only_trigger_min_area:
+            _is_triggering = _peaks["area"] > self.trigger_min_area
+        else:
+            _is_triggering = self._is_triggering(_peaks)
+        _peaks = _peaks[_is_triggering]
+        # init result
         result = np.zeros(len(current_peak), self.dtype)
         straxen.EventBasics.set_nan_defaults(result)
-        for direction in ["left", "right"]:
-            result[f"{direction}_dtime"] = self.shadow_time_window_backward
-            if direction == "left":
-                roi_triggering["time"] = (
-                    current_peak["center_time"] - self.shadow_time_window_backward
-                )
-                roi_triggering["endtime"] = current_peak["center_time"].copy()
-                split_peaks = strax.touching_windows(peaks[_is_triggering], roi_triggering)
-                indices = np.clip(split_peaks[:, 1] - 1, 0, _is_triggering.sum() - 1)
-                result[f"{direction}_dtime"] = np.where(
-                    (split_peaks[:, 0] - split_peaks[:, 1] != 0) & (split_peaks[:, 1] != 0),
-                    current_peak["center_time"] - peaks["center_time"][_is_triggering][indices],
-                    self.shadow_time_window_backward,
-                )
-            elif direction == "right":
-                # looking for peaks right to the current peaks
-                roi_triggering["time"] = current_peak["center_time"].copy()
-                roi_triggering["endtime"] = (
-                    current_peak["center_time"] + self.shadow_time_window_backward
-                )
-                split_peaks = strax.touching_windows(peaks[_is_triggering], roi_triggering)
-                indices = np.clip(split_peaks[:, 0], 0, _is_triggering.sum() - 1)
-                result[f"{direction}_dtime"] = np.where(
-                    (split_peaks[:, 0] - split_peaks[:, 1] != 0)
-                    & (split_peaks[:, 0] != _is_triggering.sum()),
-                    peaks["center_time"][_is_triggering][indices] - current_peak["center_time"],
-                    self.shadow_time_window_backward,
-                )
-            for field in ["time", "endtime", "center_time", "type", "n_competing", "area"]:
-                result[direction + "_" + field] = peaks[field][_is_triggering][indices]
+
+        # use center_time as the anchor of things
+        things = np.zeros(len(_peaks), dtype=strax.time_fields)
+        things["time"] = _peaks["center_time"]
+        things["endtime"] = _peaks["center_time"]
+        # also se center_time as the anchor of containers
+        containers = np.zeros(len(current_peak), dtype=strax.time_fields)
+        containers["time"] = current_peak["center_time"] - self.shadow_time_window_backward
+        containers["endtime"] = current_peak["center_time"] + self.shadow_time_window_backward
+
+        # find indices of the nearest peaks in left and right direction
+        split_peaks = strax.touching_windows(things, containers)
+        left_indices, right_indices = self.nearest_indices(
+            current_peak["center_time"],
+            _peaks["center_time"],
+            split_peaks,
+        )
+        # assign fields
+        result["left_dtime"] = np.where(
+            left_indices != -1,
+            current_peak["center_time"] - _peaks["center_time"][left_indices],
+            self.shadow_time_window_backward,
+        )
+        result["right_dtime"] = np.where(
+            right_indices != -1,
+            _peaks["center_time"][right_indices] - current_peak["center_time"],
+            self.shadow_time_window_backward,
+        )
+        for field in ["time", "endtime", "center_time", "type", "n_competing", "area"]:
+            result["left_" + field] = np.where(
+                left_indices != -1, _peaks[field][left_indices], result["left_" + field]
+            )
+            result["right_" + field] = np.where(
+                right_indices != -1, _peaks[field][right_indices], result["right_" + field]
+            )
         result["time"] = current_peak["time"]
         result["endtime"] = strax.endtime(current_peak)
         return result
+
+    @staticmethod
+    @numba.njit
+    def nearest_indices(reference_time, nearest_time, touching_windows):
+        """Find the nearest indices in the left and right direction."""
+        left_indices = np.full(len(reference_time), -1, dtype=np.int64)
+        right_indices = np.full(len(reference_time), -1, dtype=np.int64)
+        for r_i, r in enumerate(reference_time):
+            indices = touching_windows[r_i]
+            if indices[0] == indices[1]:
+                continue
+            center_time = nearest_time[indices[0] : indices[1]]
+            left_dtime = r - center_time[0]
+            right_dtime = center_time[-1] - r
+            # make sure that the dtime is positive
+            for p_i, t in enumerate(center_time):
+                if t < r and r - t <= left_dtime:
+                    left_dtime = r - t
+                    left_indices[r_i] = indices[0] + p_i
+                elif t > r and t - r <= right_dtime:
+                    right_dtime = t - r
+                    right_indices[r_i] = indices[0] + p_i
+        return left_indices, right_indices

--- a/straxen/plugins/peaks/peak_nearest_triggering.py
+++ b/straxen/plugins/peaks/peak_nearest_triggering.py
@@ -1,0 +1,120 @@
+import numpy as np
+import numba
+import strax
+import straxen
+from .peak_ambience import _quick_assign
+from ..events import Events
+
+export, __all__ = strax.exporter()
+
+
+@export
+class PeakNearestTriggering(Events):
+    """Time difference and properties of the nearest triggering peaks."""
+
+    __version__ = "0.0.0"
+    depends_on = ("peak_basics", "peak_proximity")
+    provides = "peak_nearest_triggering"
+    data_kind = "peaks"
+    save_when = strax.SaveWhen.EXPLICIT
+
+    shadow_time_window_backward = straxen.URLConfig(
+        default=int(1e9),
+        type=int,
+        track=True,
+        help="Search for peaks casting time & position shadow in this time window [ns]",
+    )
+
+    def infer_dtype(self):
+        dtype = []
+        common_descr = "of the nearest triggering peak on the"
+        for direction in ["left", "right"]:
+            dtype += [
+                (
+                    (f"time difference {common_descr} {direction} [ns]", f"{direction}_dtime"),
+                    np.int64,
+                ),
+                ((f"time {common_descr} {direction} [ns]", f"{direction}_time"), np.int64),
+                ((f"endtime {common_descr} {direction} [ns]", f"{direction}_endtime"), np.int64),
+                (
+                    (f"center_time {common_descr} {direction} [ns]", f"{direction}_center_time"),
+                    np.int64,
+                ),
+                ((f"type {common_descr} {direction}", f"{direction}_type"), np.int8),
+                ((f"n_competing {common_descr} {direction}", f"{direction}_n_competing"), np.int32),
+                ((f"area {common_descr} {direction} [PE]", f"{direction}_area"), np.float32),
+            ]
+        dtype += strax.time_fields
+        return dtype
+
+    def get_window_size(self):
+        # This method is required by the OverlapWindowPlugin class
+        return 10 * self.shadow_time_window_backward
+
+    def compute(self, peaks):
+        result = self.compute_triggering(peaks, peaks)
+        return result
+
+    def compute_triggering(self, peaks, current_peak):
+        _is_triggering = self._is_triggering(peaks)
+
+        roi_triggering = np.zeros(len(current_peak), dtype=strax.time_fields)
+
+        result = np.zeros(len(current_peak), self.dtype)
+        straxen.EventBasics.set_nan_defaults(result)
+        for direction, reference in zip(["right", "left"], ["endtime", "time"]):
+            _result = result.copy()
+            _result[f"{direction}_dtime"] = self.shadow_time_window_backward
+            argsort = np.argsort(current_peak[reference], kind="mergesort")
+            _current_peak = np.sort(current_peak, order=reference)
+            # the calculation of the time difference seems weird,
+            # but it is following the functionality of strax.find_peak_groups and strax.find_peaks
+            # https://github.com/AxFoundation/strax/blob/21cc96e011b0e4099138979791f34e8b1addedb7/strax/processing/peak_building.py#L102
+            # record the time difference to the nearest previous peak
+            if direction == "left":
+                roi_triggering["time"] = _current_peak[reference] - self.shadow_time_window_backward
+                roi_triggering["endtime"] = _current_peak[reference].copy()
+                split_peaks = strax.touching_windows(peaks[_is_triggering], roi_triggering)
+                indices = self.peaks_triggering_indices(
+                    _current_peak["time"], peaks["endtime"][_is_triggering], split_peaks
+                )
+                _result[f"{direction}_dtime"] = np.where(
+                    indices != -1,
+                    _current_peak["time"] - peaks["endtime"][_is_triggering][indices],
+                    self.shadow_time_window_backward,
+                )
+            elif direction == "right":
+                roi_triggering["time"] = _current_peak[reference].copy()
+                roi_triggering["endtime"] = (
+                    _current_peak[reference] + self.shadow_time_window_backward
+                )
+                split_peaks = strax.touching_windows(peaks[_is_triggering], roi_triggering)
+                indices = self.peaks_triggering_indices(
+                    _current_peak["endtime"], peaks["time"][_is_triggering], split_peaks
+                )
+                _result[f"{direction}_dtime"] = np.where(
+                    indices != -1,
+                    peaks["time"][_is_triggering][indices] - _current_peak["endtime"],
+                    self.shadow_time_window_backward,
+                )
+            for field in ["time", "endtime", "center_time", "type", "n_competing", "area"]:
+                _result[direction + "_" + field] = peaks[field][_is_triggering][indices]
+            # When reference is 'endtime', the current_peak[reference] is not sorted,
+            # so the _quick_assign will assign the _result to correct peaks.
+            # So direction must be first right then left.
+            _quick_assign(argsort, result, _result)
+        result["time"] = current_peak["time"]
+        result["endtime"] = strax.endtime(current_peak)
+        return result
+
+    @staticmethod
+    @numba.njit
+    def peaks_triggering_indices(reference, triggering, touching_windows):
+        indices = np.ones_like(reference) * -1
+        for p_i in range(len(reference)):
+            if touching_windows[p_i, 1] - touching_windows[p_i, 0] == 0:
+                continue
+            indices[p_i] = touching_windows[p_i, 0] + np.argmin(
+                reference[p_i] - triggering[touching_windows[p_i, 0] : touching_windows[p_i, 1]]
+            )
+        return indices

--- a/straxen/plugins/peaks/peak_nearest_triggering.py
+++ b/straxen/plugins/peaks/peak_nearest_triggering.py
@@ -116,6 +116,8 @@ class PeakNearestTriggering(Events):
             )
         result["time"] = current_peak["time"]
         result["endtime"] = strax.endtime(current_peak)
+        for direction in ["left", "right"]:
+            assert np.all(result[f"{direction}_dtime"] > 0), f"{direction}_dtime should be positive"
         return result
 
     @staticmethod

--- a/straxen/plugins/peaks/peak_nearest_triggering.py
+++ b/straxen/plugins/peaks/peak_nearest_triggering.py
@@ -76,7 +76,7 @@ class PeakNearestTriggering(Events):
                 roi_triggering["endtime"] = _current_peak[reference].copy()
                 split_peaks = strax.touching_windows(peaks[_is_triggering], roi_triggering)
                 indices = self.peaks_triggering_indices(
-                    _current_peak["time"], peaks["endtime"][_is_triggering], split_peaks
+                    direction, _current_peak["time"], peaks["endtime"][_is_triggering], split_peaks
                 )
                 _result[f"{direction}_dtime"] = np.where(
                     indices != -1,
@@ -90,7 +90,7 @@ class PeakNearestTriggering(Events):
                 )
                 split_peaks = strax.touching_windows(peaks[_is_triggering], roi_triggering)
                 indices = self.peaks_triggering_indices(
-                    _current_peak["endtime"], peaks["time"][_is_triggering], split_peaks
+                    direction, _current_peak["endtime"], peaks["time"][_is_triggering], split_peaks
                 )
                 _result[f"{direction}_dtime"] = np.where(
                     indices != -1,
@@ -109,12 +109,17 @@ class PeakNearestTriggering(Events):
 
     @staticmethod
     @numba.njit
-    def peaks_triggering_indices(reference, triggering, touching_windows):
+    def peaks_triggering_indices(direction, reference, triggering, touching_windows):
         indices = np.ones_like(reference) * -1
         for p_i in range(len(reference)):
             if touching_windows[p_i, 1] - touching_windows[p_i, 0] == 0:
                 continue
-            indices[p_i] = touching_windows[p_i, 0] + np.argmin(
-                reference[p_i] - triggering[touching_windows[p_i, 0] : touching_windows[p_i, 1]]
-            )
+            if direction == "left":
+                indices[p_i] = touching_windows[p_i, 0] + np.argmax(
+                    triggering[touching_windows[p_i, 0] : touching_windows[p_i, 1]]
+                )
+            elif direction == "right":
+                indices[p_i] = touching_windows[p_i, 0] + np.argmin(
+                    triggering[touching_windows[p_i, 0] : touching_windows[p_i, 1]]
+                )
         return indices


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Add a plugin to find the nearest triggering peaks. "triggering" is defined the same as the `Events` plugin.

The plugin is required by study https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:ar37_l_shell_sensi:ac_validation, which is further required by https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:ar37_l_shell_sensi.

## Can you briefly describe how it works?

First look for all triggering peaks, then find the groups of triggering peaks for each peak within a two-side window defined by `shadow_time_window_backward`. Then calculate the time difference of the nearest triggering peak to the left and right the each peak. If not found, assign `shadow_time_window_backward` to the time difference.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
