### PR TITLE
Update NaN filtering in InterpolatingMap

### DIFF
--- a/tests/test_itp_map.py
+++ b/tests/test_itp_map.py
@@ -81,8 +81,7 @@ class TestItpMaps(TestCase):
 
         # Test querying nonfinite values gives NaNs, not errors
         for itp_map in itp_maps:
-            map_at_random_point = itp_map([
-                [0, np.nan, 0], [0, 0, -140]])
+            map_at_random_point = itp_map([[0, np.nan, 0], [0, 0, -140]])
             # Shape is still correct
             assert map_at_random_point.shape == (2, 2)
             # First point gives NaN

--- a/tests/test_itp_map.py
+++ b/tests/test_itp_map.py
@@ -1,4 +1,5 @@
 from unittest import TestCase, skipIf
+import numpy as np
 from straxen import utilix_is_configured, get_resource
 from straxen import InterpolatingMap, save_interpolation_formatted_map
 
@@ -77,3 +78,14 @@ class TestItpMaps(TestCase):
 
             self.assertAlmostEqual(map_at_random_point[1][0], 2.17815179, places=places)
             self.assertAlmostEqual(map_at_random_point[1][1], 9.47282782, places=places)
+
+        # Test querying nonfinite values gives NaNs, not errors
+        for itp_map in itp_maps:
+            map_at_random_point = itp_map([
+                [0, np.nan, 0], [0, 0, -140]])
+            # Shape is still correct
+            assert map_at_random_point.shape == (2, 2)
+            # First point gives NaN
+            assert np.all(np.isnan(map_at_random_point[0]))
+            # Second point does not
+            assert not np.any(np.isnan(map_at_random_point[1]))


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Fixes InterpolatingMap so we do not crash with scipy 1.11.

## Can you briefly describe how it works?

Scipy 1.11's kdtree no longer accepts nonfinite values (https://github.com/scipy/scipy/pull/18502). However, we sometimes use NaN to represent missing/undefined values, e.g. for drift time if an event has no S1.

Currently we pass all points to InterpolatingMap, then force the result to NaN for points that have nonfinite distance to the neighbours the kdtree finds. That's fine in our current scipy 1.10 environment, but once we update (https://github.com/XENONnT/ax_env/pull/353) there will be problems.

This PR instead checks for NaN before passing the points to InterpolatingMap to avoid crashing.

## Can you give a minimal working example (or illustrate with a figure)?

See the new unit test. 

I tried processing a small run 026195 locally with scipy 1.11.3, and it crashed here https://github.com/XENONnT/straxen/blob/933cc547dcd0931252f606d5c1692f36b367cc48/straxen/plugins/events/event_positions.py#L164 where events with NaN drift time are being passed to a map. Now it no longer crashes.