### PR TITLE
change integration window

### DIFF
--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -34,7 +34,7 @@ class LEDCalibration(strax.Plugin):
           from the signal one.
     """
 
-    __version__ = "0.2.3"
+    __version__ = "0.2.4"
 
     depends_on = "raw_records"
     data_kind = "led_cal"

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -47,7 +47,7 @@ class LEDCalibration(strax.Plugin):
     )
 
     led_window = straxen.URLConfig(
-        default=(78, 116),
+        default=(78, 132),
         infer_type=False,
         help="Window (samples) where we expect the signal in LED calibration",
     )


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
The updated code changes the integration window from [78, 116] to [78, 132] ADC

## Can you briefly describe how it works?
This is the ADC window in which the waveform is expected to appear during an LED calibration. This change was necessary because the previous window did not contain the whole waveform (see [this note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:giovo:the_led_window_crisis))
