### PR TITLE
Fix photoionization correction to conserve cS2

### DIFF
--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -258,7 +258,8 @@ class CorrectedAreas(strax.Plugin):
             # apply SEG and EE correction
             cs2_top_wo_picorr = cs2_top_xycorr / seg_ee_corr
             cs2_bottom_wo_picorr = cs2_bottom_xycorr / seg_ee_corr
-            result[f"{peak_type}cs2_wo_picorr"] = cs2_top_wo_picorr + cs2_bottom_wo_picorr
+            cs2_wo_picorr = cs2_top_wo_picorr + cs2_bottom_wo_picorr
+            result[f"{peak_type}cs2_wo_picorr"] = cs2_wo_picorr
             result[f"{peak_type}cs2_area_fraction_top_wo_picorr"] = (
                 cs2_top_wo_picorr / result[f"{peak_type}cs2_wo_picorr"]
             )
@@ -267,7 +268,13 @@ class CorrectedAreas(strax.Plugin):
             # cS2 bottom should be corrected by photon ionization, but not cS2 top
             cs2_top_wo_elifecorr = cs2_top_wo_picorr
             cs2_bottom_wo_elifecorr = cs2_bottom_wo_picorr * self.cs2_bottom_top_ratio_correction
-            result[f"{peak_type}cs2_wo_elifecorr"] = cs2_top_wo_elifecorr + cs2_bottom_wo_elifecorr
+            cs2_wo_elifecorr = cs2_top_wo_elifecorr + cs2_bottom_wo_elifecorr
+            # scale top and bottom to ensure total cS2 is conserved, since the time
+            # dependence of it has been already corrected by SEG correction
+            cs2_top_wo_elifecorr *= cs2_wo_picorr / cs2_wo_elifecorr
+            cs2_bottom_wo_elifecorr *= cs2_wo_picorr / cs2_wo_elifecorr
+            cs2_wo_elifecorr = cs2_wo_picorr
+            result[f"{peak_type}cs2_wo_elifecorr"] = cs2_wo_elifecorr
             result[f"{peak_type}cs2_area_fraction_top_wo_elifecorr"] = (
                 cs2_top_wo_elifecorr / result[f"{peak_type}cs2_wo_elifecorr"]
             )


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

This PR fixes the implementation of photoionization correction. Since the time dependence of total S2 has already been corrected by SEG correction, in photoionization correction we should ensure total S2 is not changed but only AFT is corrected.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [x] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [x] _Does it solve one of the open issues on github?_
