### PR TITLE
remove cnn in s2_recon_pos_diff

### DIFF
--- a/straxen/plugins/events/s2_recon_pos_diff.py
+++ b/straxen/plugins/events/s2_recon_pos_diff.py
@@ -22,7 +22,7 @@ class S2ReconPosDiff(strax.Plugin):
 
     recon_alg_included = straxen.URLConfig(
         help="The list of all reconstruction algorithm considered.",
-        default=("_mlp", "_gcn", "_cnn"),
+        default=("_mlp", "_gcn"),
         infer_type=False,
     )
 


### PR DESCRIPTION
In past study, we ’ve found cnn perform poorly in S2 position reconstruction, so we plan to only use mlp and cnn in calculating reconstruction position difference. 
