### PR TITLE
Use `straxen.EventBasics.set_nan_defaults` to set default values

### DIFF
--- a/straxen/plugins/events/event_shadow.py
+++ b/straxen/plugins/events/event_shadow.py
@@ -1,6 +1,8 @@
 import numpy as np
 import strax
 
+import straxen
+
 export, __all__ = strax.exporter()
 
 
@@ -102,21 +104,11 @@ class EventShadow(strax.Plugin):
         dtype += strax.time_fields
         return dtype
 
-    @staticmethod
-    def set_nan_defaults(result):
-        """When constructing the dtype, take extra care to set values to np.Nan / -1 (for ints) as 0
-        might have a meaning."""
-        for field in result.dtype.names:
-            if np.issubdtype(result.dtype[field], np.integer):
-                result[field][:] = -1
-            else:
-                result[field][:] = np.nan
-
     def compute(self, events, peaks):
         split_peaks = strax.split_by_containment(peaks, events)
         result = np.zeros(len(events), self.dtype)
 
-        self.set_nan_defaults(result)
+        straxen.EventBasics.set_nan_defaults(result)
 
         # 1. Assign peaks features to main S1 and main S2 in the event
         for event_i, (event, sp) in enumerate(zip(events, split_peaks)):

--- a/straxen/plugins/peaks/peak_per_event.py
+++ b/straxen/plugins/peaks/peak_per_event.py
@@ -1,6 +1,8 @@
 import strax
 import numpy as np
 
+import straxen
+
 
 export, __all__ = strax.exporter()
 
@@ -30,7 +32,7 @@ class EventPeaks(strax.Plugin):
         split_peaks = strax.split_by_containment(peaks, events)
         split_peaks_ind = strax.fully_contained_in(peaks, events)
         result = np.zeros(len(peaks), self.dtype)
-        result.fill(np.nan)
+        straxen.EventBasics.set_nan_defaults(result)
 
         # Assign peaks features to main S1 and main S2 in the event
         for event_i, (event, sp) in enumerate(zip(events, split_peaks)):


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

With the old code and `numpy==1.26.3`, we will see error like:

```
FAILED tests/plugins/test_plugins.py::PluginTest::test_event_ms_naive - ValueError: cannot convert float NaN to integer
```

This is due to https://github.com/XENONnT/straxen/blob/2c48b773a56f446d0f46bb42e664a918a5620b99/straxen/plugins/peaks/peak_per_event.py#L33 is not compatible anymore with the new numpy when there is `int` in `result`.

So this PR use `straxen.EventBasics.set_nan_defaults` to set the default value of result.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?
