### PR TITLE
Update to bokeh v3 and holoviews v1, drop py3.8 support

### DIFF
--- a/.github/workflows/pypi_install.yml
+++ b/.github/workflows/pypi_install.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,15 +33,15 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python-version: [ 3.8, 3.9, "3.10" ]
+        python-version: [ "3.9", "3.10", "3.11" ]
         test: [ 'coveralls', 'pytest', 'pytest_no_database' ]
         # Only run on py3.8. Py3.10 is quite slow, so no coveralls
         exclude:
-          - python-version: "3.10"
+          - python-version: "3.11"
             test: coveralls
-          - python-version: 3.9
-            test: pytest_no_database
           - python-version: "3.10"
+            test: pytest_no_database
+          - python-version: "3.11"
             test: pytest_no_database
 
     steps:

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [ 3.9 ]
     steps:
       - name: Setup python
         uses: actions/setup-python@v5.0.0

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.8"
+    python: "3.9"
 
 python:
   install:

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -1,7 +1,7 @@
 Setting up straxen
 ===================
 
-To install straxen locally, follow these steps in a python 3.7, 3.8 or 3.9 environment:
+To install straxen locally, follow these steps in a python 3.9 or 3.10 environment:
 
 1. `git clone https://github.com/XENONnT/straxen`
 2. **Optional**. If you are NOT on the UChicago Midway analysis center please follow step 2. in this `wiki note (restricted) <https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:analysis:guide:straxen_installation>`_.

--- a/notebooks/tutorials/EventDisplayInteractive.ipynb
+++ b/notebooks/tutorials/EventDisplayInteractive.ipynb
@@ -27,6 +27,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "from bokeh.util.warnings import BokehUserWarning\n",
+    "\n",
+    "# Suppress the BokehUserWarning, somehow need to do this after importing strax\n",
+    "warnings.filterwarnings(\"ignore\", category=BokehUserWarning)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -139,7 +152,7 @@
    },
    "outputs": [],
    "source": [
-    "from IPython.core.display import display, HTML\n",
+    "from IPython.display import display, HTML\n",
     "\n",
     "display(HTML(\"<style>.container { width:80% !important; }</style>\"))"
    ]
@@ -437,7 +450,7 @@
    "source": [
     "## Record matrix\n",
     "\n",
-    "The regular event display can be extended by an additional record matrix which is helpful especially for peak building and splitting analyses. To plot the record matrix you have to simply set ` plot_record_matrix=True`. The event display will then automatically check if the specified raw_data is available. The record matrix is build on records, in case only `raw_records` are available the event display will warn you and build the required `records` on the fly.    "
+    "The regular event display can be extended by an additional record matrix which is helpful especially for peak building and splitting analyses. To plot the record matrix you have to simply set `plot_record_matrix=True`. The event display will then automatically check if the specified raw_data is available. The record matrix is build on records, in case only `raw_records` are available the event display will warn you and build the required `records` on the fly.    "
    ]
   },
   {
@@ -479,7 +492,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Please note that in case of ` plot_record_matrix=True` you do not have to call `bklt.show()` as the display library has now changed to panel. Yes I know.... super annoying, but belief me implementing this was even more frustrating....   \n",
+    "Please note that in case of `plot_record_matrix=True` you do not have to call `bklt.show()` as the display library has now changed to panel. Yes I know.... super annoying, but belief me implementing this was even more frustrating....   \n",
     "\n",
     "The record matrix is displayed as as blue squares which are resized depending on the zoom level. Each square is allocated at the center time of the corresponding records. You can change the zoom level by hovering with the mouse over the central peak waveform plot and scrolling up and down with your mouse wheel. As an alternative you can also use the box zoom feature in the same plot. \n",
     "Once you zoomed in far enough, such that the x_range spans only 10 µs (default can be adjusted), the event display will plot all records inside the currently shown window as lines. The line color represents hereby the area of the individual records. If you zoom out again the lines vanish. "

--- a/notebooks/tutorials/EventDisplayInteractive.ipynb
+++ b/notebooks/tutorials/EventDisplayInteractive.ipynb
@@ -392,7 +392,7 @@
    },
    "outputs": [],
    "source": [
-    "div.style[\"color\"] = \"green\""
+    "div.styles[\"color\"] = \"green\""
    ]
   },
   {
@@ -413,7 +413,7 @@
    },
    "outputs": [],
    "source": [
-    "tool_box = fig.children[1].children[0]\n",
+    "tool_box = fig.children[1].children[0][0]\n",
     "tool_box.visible = False"
    ]
   },
@@ -725,7 +725,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.18"
   },
   "nbsphinx": {
    "execute": "never"

--- a/notebooks/tutorials/ScadaInterfaceExample.ipynb
+++ b/notebooks/tutorials/ScadaInterfaceExample.ipynb
@@ -277,7 +277,7 @@
     "plt.plot(df[\"para2\"])\n",
     "plt.xlabel(\"Time [UTC]\")\n",
     "plt.ylabel(\"Temperature at TE101 [°C]\")\n",
-    "plt.xticks(rotation=\"45\", horizontalalignment=\"right\")\n",
+    "plt.xticks(rotation=45, horizontalalignment=\"right\")\n",
     "plt.show()"
    ]
   },
@@ -533,7 +533,7 @@
     "dfcet[\"para2\"].plot()\n",
     "plt.xlabel(\"Time [CET]\")\n",
     "plt.ylabel(\"Temperature at TE101 [°C]\")\n",
-    "plt.xticks(rotation=\"45\", horizontalalignment=\"right\")\n",
+    "plt.xticks(rotation=45, horizontalalignment=\"right\")\n",
     "plt.show()"
    ]
   }
@@ -554,7 +554,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.7"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # datashader         # Optional, to enable wf display
 # holoviews          # Optional, to enable wf display
 # tensorflow>=2.3.0  # Optional, to (re)do posrec
-bokeh>=2.2.3,<3
+bokeh
 commentjson
 gitpython
 immutabledict

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ setuptools.setup(
     setup_requires=["pytest-runner"],
     install_requires=requires,
     tests_require=requires + tests_requires,
-    # Not testing py3.6 or py3.7 #616
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     extras_require={
         "docs": doc_requirements,
         "microstrax": ["hug"],
@@ -52,9 +51,9 @@ setuptools.setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Intended Audience :: Science/Research",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering :: Physics",

--- a/straxen/analyses/bokeh_waveform_plot.py
+++ b/straxen/analyses/bokeh_waveform_plot.py
@@ -436,7 +436,7 @@ def plot_peak_detail(
 
     tt = straxen.bokeh_utils.peak_tool_tip(p_type)
     tt = [v for k, v in tt.items() if k not in ["time_static", "center_time", "endtime"]]
-    fig.add_tools(bokeh.models.HoverTool(names=[label], tooltips=tt))
+    fig.add_tools(bokeh.models.HoverTool(name=label, tooltips=tt))
 
     source = straxen.bokeh_utils.get_peaks_source(
         peak,
@@ -509,7 +509,7 @@ def plot_peaks(peaks, time_scalar=1, fig=None, colors=("gray", "blue", "green"),
 
         tt = straxen.bokeh_utils.peak_tool_tip(i)
         tt = [v for k, v in tt.items() if k != "time_dynamic"]
-        fig.add_tools(bokeh.models.HoverTool(names=[LEGENDS[i]], tooltips=tt))
+        fig.add_tools(bokeh.models.HoverTool(name=LEGENDS[i], tooltips=tt))
         fig.add_tools(bokeh.models.WheelZoomTool(dimensions="width", name="wheel"))
         fig.toolbar.active_scroll = [t for t in fig.tools if t.name == "wheel"][0]
 
@@ -614,7 +614,7 @@ def plot_pmt_array(
         legend_label=label,
         name=label + "_pmt_array",
     )
-    fig.add_tools(bokeh.models.HoverTool(names=[label + "_pmt_array"], tooltips=tool_tip))
+    fig.add_tools(bokeh.models.HoverTool(name=label + "_pmt_array", tooltips=tool_tip))
     fig.legend.location = "top_left"
     fig.legend.click_policy = "hide"
     fig.legend.orientation = "horizontal"
@@ -708,7 +708,7 @@ def plot_posS2s(peaks, label="", fig=None, s2_type_style_id=0):
     tt = [v for k, v in tt.items() if k not in ["time_dynamic", "amplitude"]]
     fig.add_tools(
         bokeh.models.HoverTool(
-            names=[label], tooltips=[("Position x [cm]", "@x"), ("Position y [cm]", "@y")] + tt
+            name=label, tooltips=[("Position x [cm]", "@x"), ("Position y [cm]", "@y")] + tt
         )
     )
     return fig, p
@@ -740,12 +740,11 @@ def _make_event_title(event, run_id, width=1600):
 
     title = bokeh.models.Div(
         text=text,
-        style={
+        styles={
             "text-align": "left",
         },
         sizing_mode="scale_both",
         width=width,
-        default_size=width,
         # orientation='vertical',
         width_policy="fit",
         margin=(0, 0, -30, 50),

--- a/straxen/analyses/bokeh_waveform_plot.py
+++ b/straxen/analyses/bokeh_waveform_plot.py
@@ -178,18 +178,21 @@ def event_display_interactive(
     else:
         upper_row = [fig_s1, fig_s2, fig_top]
 
-    upper_row = bokeh.layouts.Row(children=upper_row)
+    upper_row = bokeh.layouts.Row(
+        children=upper_row,
+        sizing_mode="scale_width",
+    )
 
     plots = bokeh.layouts.gridplot(
         children=[upper_row, waveform],
-        sizing_mode="scale_both",
+        sizing_mode="scale_width",
         ncols=1,
         merge_tools=True,
         toolbar_location="above",
     )
     event_display = bokeh.layouts.Column(
         children=[title, plots],
-        sizing_mode="scale_both",
+        sizing_mode="scale_width",
         max_width=1600,
     )
 
@@ -245,7 +248,9 @@ def event_display_interactive(
         # Set x-range of event plot:
         bokeh_set_x_range(waveform, straxen._BOKEH_X_RANGE, debug=False)
         event_display = panel.Column(
-            event_display, wf * records_in_window, sizing_mode="scale_width"
+            event_display,
+            wf * records_in_window,
+            sizing_mode="scale_width",
         )
 
     return event_display
@@ -743,7 +748,7 @@ def _make_event_title(event, run_id, width=1600):
         styles={
             "text-align": "left",
         },
-        sizing_mode="scale_both",
+        sizing_mode="scale_width",
         width=width,
         # orientation='vertical',
         width_policy="fit",

--- a/straxen/analyses/bokeh_waveform_plot.py
+++ b/straxen/analyses/bokeh_waveform_plot.py
@@ -792,6 +792,12 @@ class DataSelectionHist:
         :param size: Edge size of the figure in pixel.
 
         """
+        raise NotImplementedError(
+            "This function does not work with"
+            " the latest bokeh version. If you are still using"
+            " this function please let us know in tech-support"
+            " by the 01.04.2024, else we reomve this function."
+        )
         self.name = name
         self.selection_index = None
         self.size = size

--- a/straxen/analyses/bokeh_waveform_plot.py
+++ b/straxen/analyses/bokeh_waveform_plot.py
@@ -740,7 +740,7 @@ def _make_event_title(event, run_id, width=1600):
 
     title = bokeh.models.Div(
         text=text,
-        styles={
+        style={
             "text-align": "left",
         },
         sizing_mode="scale_both",

--- a/straxen/analyses/bokeh_waveform_plot.py
+++ b/straxen/analyses/bokeh_waveform_plot.py
@@ -740,7 +740,7 @@ def _make_event_title(event, run_id, width=1600):
 
     title = bokeh.models.Div(
         text=text,
-        style={
+        styles={
             "text-align": "left",
         },
         sizing_mode="scale_both",

--- a/straxen/analyses/holoviews_waveform_display.py
+++ b/straxen/analyses/holoviews_waveform_display.py
@@ -62,9 +62,10 @@ def hvdisp_plot_pmt_pattern(*, config, records, to_pe, array="bottom"):
             hv.Dimension("area", label="Area", unit="PE"),
         ],
     )
-    pmts = pmts.to(
-        hv.Points, vdims=["area", "i"], group="PMTPattern", label=array.capitalize()
-    ).opts(
+    pmts = pmts.to(hv.Points, vdims=["area", "i"], group="PMTPattern", label=array.capitalize())
+
+    hv.opts.apply_groups(
+        pmts,
         plot=dict(color_index=2, tools=["hover"], show_grid=False),
         style=dict(size=17, cmap="plasma"),
     )
@@ -189,7 +190,10 @@ def _hvdisp_plot_records_2d(
             streams=[time_stream],
         ),
         threshold=0.1,
-    ).opts(
+    )
+
+    hv.opts.apply_groups(
+        shader,
         plot=dict(
             aspect=4,
             responsive="width",
@@ -199,7 +203,7 @@ def _hvdisp_plot_records_2d(
             default_tools=list(default_tools),
             fontsize={"labels": 12},
             show_grid=True,
-        )
+        ),
     )
 
     return shader, records, time_stream
@@ -366,10 +370,21 @@ def hvdisp_plot_peak_waveforms(
                 kdims=time_dim,
                 vdims=hv.Dimension("amplitude", label="Amplitude", unit="PE/ns"),
                 group="PeakSumWaveform",
-            ).opts(style=dict(color=color))
+            )
         )
 
-    return hv.Overlay(items=curves).opts(plot=dict(width=width))
+        hv.opts.apply_groups(
+            curves[-1],
+            style=dict(color=color),
+        )
+
+    overlay = hv.Overlay(items=curves)
+    hv.opts.apply_groups(
+        overlay,
+        plot=dict(width=width),
+    )
+
+    return overlay
 
 
 def _range_plot(f, full_time_range, t_reference, **kwargs):

--- a/straxen/bokeh_utils.py
+++ b/straxen/bokeh_utils.py
@@ -160,8 +160,7 @@ def default_fig(width=400, height=400, title="", **kwargs):
     fig = bklt.figure(
         width=width,
         height=height,
-        sizing_mode="scale_both",
-        aspect_ratio=width / height,
+        sizing_mode="scale_width",
         title=title,
         tools="pan,box_zoom,reset,save",
         **kwargs,

--- a/straxen/bokeh_utils.py
+++ b/straxen/bokeh_utils.py
@@ -81,7 +81,7 @@ def _patches_x_y(peak, keep_amplitude_per_sample=False):
     """Creates x,y coordinates needed to draw peaks via bokeh.models.patches.
 
     :param peak: Peak for which we need the x/y samples
-    :param keep_amplitude_per_sample: If y-data should be in units of     "per sample" or "per ns".
+    :param keep_amplitude_per_sample: If y-data should be in units of "per sample" or "per ns".
     :return: Tuple of x, y
 
     """
@@ -158,8 +158,8 @@ def default_fig(width=400, height=400, title="", **kwargs):
 
     """
     fig = bklt.figure(
-        plot_width=width,
-        plot_height=height,
+        width=width,
+        height=height,
         sizing_mode="scale_both",
         aspect_ratio=width / height,
         title=title,

--- a/straxen/bokeh_utils.py
+++ b/straxen/bokeh_utils.py
@@ -164,6 +164,6 @@ def default_fig(width=400, height=400, title="", **kwargs):
         aspect_ratio=width / height,
         title=title,
         tools="pan,box_zoom,reset,save",
-        **kwargs
+        **kwargs,
     )
     return fig

--- a/straxen/scada.py
+++ b/straxen/scada.py
@@ -202,7 +202,7 @@ class SCADAInterface:
         if not time_selection_kwargs:
             time_selection_kwargs = {"full_range": True}
 
-        if np.all((run_id, self.context)):
+        if run_id is not None and self.context is not None:
             # User specified a valid context and run_id, so get the start
             # and end time for our query:
             if isinstance(run_id, (list, tuple)):

--- a/tests/test_mini_analyses.py
+++ b/tests/test_mini_analyses.py
@@ -322,31 +322,32 @@ class TestMiniAnalyses(unittest.TestCase):
         from straxen.analyses.bokeh_waveform_plot import DataSelectionHist
 
         p = self.st.get_array(nt_test_run_id, "peak_basics", seconds_range=(0, 10))
-        ds = DataSelectionHist("ds")
-        fig = ds.histogram2d(
-            p,
-            p["area"],
-            p["area"],
-            bins=10,
-            hist_range=((0, 200), (0, 2000)),
-            log_color_scale=True,
-            clim=(10, None),
-            undeflow_color="white",
-        )
+        with self.assertRaises(NotImplementedError):
+            ds = DataSelectionHist("ds")
+            fig = ds.histogram2d(
+                p,
+                p["area"],
+                p["area"],
+                bins=10,
+                hist_range=((0, 200), (0, 2000)),
+                log_color_scale=True,
+                clim=(10, None),
+                undeflow_color="white",
+            )
 
-        import bokeh.plotting as bklt
+            import bokeh.plotting as bklt
 
-        save_as = "test_data_selector.html"
-        bklt.save(fig, save_as)
-        self.assertTrue(os.path.exists(save_as))
-        os.remove(save_as)
-        self.assertFalse(os.path.exists(save_as))
-        # Also test if we can write it to the wiki
-        straxen.bokeh_to_wiki(fig)
-        straxen.bokeh_to_wiki(fig, save_as)
-        self.assertTrue(os.path.exists(save_as))
-        os.remove(save_as)
-        self.assertFalse(os.path.exists(save_as))
+            save_as = "test_data_selector.html"
+            bklt.save(fig, save_as)
+            self.assertTrue(os.path.exists(save_as))
+            os.remove(save_as)
+            self.assertFalse(os.path.exists(save_as))
+            # Also test if we can write it to the wiki
+            straxen.bokeh_to_wiki(fig)
+            straxen.bokeh_to_wiki(fig, save_as)
+            self.assertTrue(os.path.exists(save_as))
+            os.remove(save_as)
+            self.assertFalse(os.path.exists(save_as))
 
     def test_nt_daq_plot(self):
         """Make an nt DAQ plot."""


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Close https://github.com/XENONnT/straxen/issues/1206

Depends on https://github.com/XENONnT/ax_env/pull/362 and https://github.com/XENONnT/ax_env/pull/363

Drop python 3.8 because bokeh>=3.2.0 stops support py3.8.

The test for Python 3.11 is experimental, not expect can pass. nestpy==2.0.0 does not support py3.11 now.

Also, minor update of SCADA interface: `if np.all((run_id, self.context)):` to `if run_id is not None and self.context is not None:` for numpy compatibility.

## Can you briefly describe how it works?

1. change `plot_width` to `width` and `plot_height` to `height` for `bokeh.plotting.figure`
2. change `style` to `styles` for `bokeh.models.Div`
3. change `names=list` to `name=str` for `bokeh.models.HoverTool`
4. set all `sizing_mode` to `"scale_width"` for better visualization in the jupyter notebook
5. use `hv.opts.apply_groups` to set grouped options, to be compatible with https://github.com/holoviz/holoviews/blob/62b7f1ea47461173253a123765a7d555a0c239ea/holoviews/core/accessors.py#L573

## Can you give a minimal working example (or illustrate with a figure)?
