### PR TITLE
Drop 3.11 support for now

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: [ "3.9", "3.10" ]
         test: [ 'coveralls', 'pytest', 'pytest_no_database' ]
         # Only run on py3.8. Py3.10 is quite slow, so no coveralls
         exclude:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         python-version: [ "3.9", "3.10" ]
         test: [ 'coveralls', 'pytest', 'pytest_no_database' ]
-        # Only run on py3.8. Py3.10 is quite slow, so no coveralls
+        # Drop some not crucial tests for python 3.10 and 3.11
         exclude:
           - python-version: "3.11"
             test: coveralls

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setuptools.setup(
         "Natural Language :: English",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Intended Audience :: Science/Research",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering :: Physics",


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

We see that the error of https://github.com/XENONnT/straxen/actions/runs/7538153970/job/20518224474 is not easily solved and we do not have a 3.11 environment for testing and debugging.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?
