### PR TITLE
`_text_formats` should include txt but not text

### DIFF
--- a/straxen/common.py
+++ b/straxen/common.py
@@ -130,7 +130,7 @@ def pmt_positions(xenon1t=False):
 _resource_cache: Dict[str, Any] = dict()
 
 # Formats for which the original file is text, not binary
-_text_formats = ["text", "csv", "json"]
+_text_formats = ["txt", "csv", "json"]
 
 
 @export


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

When judging whether the file is a text file in `resource_from_url`, the text file should end with `txt` but not `text`.

https://github.com/XENONnT/straxen/blob/476bf1afd9dcf5015f6931c8dd1b27811ea6f1b9/straxen/common.py#L275

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

