### PR TITLE
Loosen `save_when` of `Events`

### DIFF
--- a/straxen/plugins/events/events.py
+++ b/straxen/plugins/events/events.py
@@ -29,7 +29,7 @@ class Events(strax.OverlapWindowPlugin):
     provides = "events"
     data_kind = "events"
 
-    save_when = strax.SaveWhen.NEVER
+    save_when = strax.SaveWhen.EXPLICIT
 
     dtype = [
         ("event_number", np.int64, "Event number in this dataset"),


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Allow users to save `events` for debugging. Related to https://github.com/XENONnT/outsource/pull/127.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?