### PR TITLE
Deprecate the usage of `XENONnT/ax_env`

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,6 +1,6 @@
 # File for the requirements of straxen with the automated tests
 git+https://github.com/AxFoundation/strax
-git+https://github.com/XENONnT/ax_env
+git+https://github.com/XENONnT/base_environment
 nbmake
 pytest-xdist
 xedocs==0.2.25

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -160,8 +160,7 @@ def find_rucio_local_path(include_rucio_local, _rucio_local_path):
         __rucio_local_path = "/project/lgrandi/rucio/"
         print(
             "You specified _auto_append_rucio_local=True and you are not on dali compute nodes, "
-            "so we will add the following rucio local path: ",
-            __rucio_local_path,
+            f"so we will add the following rucio local path: {__rucio_local_path}"
         )
 
     return _include_rucio_local, __rucio_local_path


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Use base_environment for pytest, following https://github.com/XENONnT/base_environment/pull/1487.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?
