### PR TITLE
Fix numerical comparison error of `test_patternfit_stats`

### DIFF
--- a/tests/test_patternfit.py
+++ b/tests/test_patternfit.py
@@ -1,3 +1,4 @@
+import math
 from hypothesis import strategies, given, settings, example
 from straxen.plugins.events.event_pattern_fit import (
     binom_test,
@@ -14,7 +15,8 @@ import scipy.stats as sps
 @given(strategies.floats(0.0, 1.0), strategies.floats(0.01, 0.99), strategies.floats(2.0, 1000))
 def test_patternfit_stats(aftobs, aft, s1tot):
     s1top = aftobs * s1tot
-    assert (binom_test(s1top, s1tot, aft) >= 0) & (binom_test(s1top, s1tot, aft) <= 1)
+    r = binom_test(s1top, s1tot, aft)
+    assert (math.isclose(r, 0.0) | (r >= 0.0)) & math.isclose(r, 1.0) | (r <= 1.0)
 
 
 @settings(deadline=None)


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

An error is seen in test: https://github.com/XENONnT/straxen/actions/runs/7918467685/job/21616952222, from a numerical comparison `assert (1.0000000000000002 >= 0 & 1.0000000000000002 <= 1)`.

## Can you briefly describe how it works?

This PR uses `math.isclose` in the test to solve the error. When `1.0000000000000002` is close to `1.0`, the argument of `assert` is still true.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_
