### PR TITLE
Remove some packages requirements from `requirements-tests.txt`

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,7 +1,3 @@
 # File for the requirements of straxen with the automated tests
 git+https://github.com/AxFoundation/strax
 git+https://github.com/XENONnT/base_environment
-nbmake
-pytest-xdist
-xedocs==0.2.25
-ipython==8.12.1


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

After https://github.com/XENONnT/straxen/pull/1169, we have dropped support for python 3.8, so we do not need to further fix this package. The requirement of xedocs version is already met in [base_environment](https://github.com/XENONnT/base_environment) so we do not need to set version of it, otherwiase there will be conflicts like: https://github.com/XENONnT/straxen/actions/runs/7953226064/job/21708925392?pr=1335

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?
