### PR TITLE
Add corrections_run_id for mini analysis

### DIFF
--- a/straxen/mini_analysis.py
+++ b/straxen/mini_analysis.py
@@ -68,7 +68,9 @@ def mini_analysis(
                 to_pe = context.config["gain_model"]
                 if isinstance(to_pe, str):
                     if "corrections_run_id" in kwargs:
-                        to_pe = straxen.URLConfig.evaluate_dry(to_pe, run_id=kwargs["corrections_run_id"])
+                        to_pe = straxen.URLConfig.evaluate_dry(
+                            to_pe, run_id=kwargs["corrections_run_id"]
+                        )
                     else:
                         to_pe = straxen.URLConfig.evaluate_dry(to_pe, run_id=run_id)
                 kwargs["to_pe"] = to_pe

--- a/straxen/mini_analysis.py
+++ b/straxen/mini_analysis.py
@@ -39,7 +39,8 @@ def mini_analysis(
             known_kwargs = (
                 "time_range seconds_range time_within time_selection "
                 "ignore_time_warning "
-                "selection_str t_reference to_pe config"
+                "selection_str t_reference to_pe config "
+                "corrections_run_id"
             ).split()
             for k in kwargs:
                 if k not in known_kwargs and k not in parameters:
@@ -66,7 +67,10 @@ def mini_analysis(
             if "to_pe" in parameters and "to_pe" not in kwargs:
                 to_pe = context.config["gain_model"]
                 if isinstance(to_pe, str):
-                    to_pe = straxen.URLConfig.evaluate_dry(to_pe, run_id=run_id)
+                    if "corrections_run_id" in kwargs:
+                        to_pe = straxen.URLConfig.evaluate_dry(to_pe, run_id=kwargs["corrections_run_id"])
+                    else:
+                        to_pe = straxen.URLConfig.evaluate_dry(to_pe, run_id=run_id)
                 kwargs["to_pe"] = to_pe
 
             # Prepare selection arguments


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
In the mini analysis code, `straxen` will look for the gain_model for the `run_id` specified. However, for MC runs the `run_id` is meaningless and should not be used to find corrections. Instead, a `corrections_run_id` should be provided for fuse/WFSim-based runs.

## Can you briefly describe how it works?
Add an extra key argument in the `mini_analysis` base class called "corrections_run_id". If this is provided, find the gain_model according to the `corrections_run_id`.

## Can you give a minimal working example (or illustrate with a figure)?

```python
import fuse
import cutax
import bokeh.plotting as bklt

st = fuse.context.full_chain_context(output_folder="./fuse_data",
                                     corrections_version='global_v14')

st.set_config({"path": "/project2/lgrandi/xenonnt/simulations/testing",
               "file_name": "pmt_neutrons_100.root",
               "entry_stop": 2,
               })

run_number = "mc_00"
st.make(run_number, "raw_records")
peaks = st.get_array(run_number,"peaks")
events = st.get_array(run_number,"event_basics")

fig = st.event_display_interactive(run_number, time_range=(events[0]['time'], events[0]['endtime']), corrections_run_id="026000")

bklt.output_file(filename="demo.html")
bklt.save(fig)
```

Before this PR straxen will try to load gain_model for run "mc_00", which will raise an error. Now it works.