### PR TITLE
Add `storage_graph` to show the plugins stored or needed to be calculated in the dependency tree

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install dependencies
+        run: sudo apt-get install -y graphviz
+
       - name: Install requirements
         run: |
           pip install -r extra_requirements/requirements-tests.txt

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: apt-get install -y graphviz
-      - name: pre-install requirements
+        run: sudo apt-get install -y graphviz
+      - name: Pre-install requirements
         run: pip install -r requirements.txt
       - name: Install straxen
         run: python setup.py install

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -28,6 +28,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: apt-get install -y graphviz
       - name: pre-install requirements
         run: pip install -r requirements.txt
       - name: Install straxen

--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,10 @@ docs/_build
 .coverage
 
 # graphviz
-*.svg
+*.gv
 *.dot
+*.png
+*.svg
 
 # Documentation files
 docs/source/reference/datastructure*

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ docs/_build
 # coverage
 .coverage
 
+# graphviz
+*.svg
+*.dot
+
 # Documentation files
 docs/source/reference/datastructure*
 docs/source/reference/data_kinds*

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 bokeh
 commentjson
 gitpython
+graphviz
 immutabledict
 matplotlib
 multihist>=0.6.3

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from sys import getsizeof, stderr
 import inspect
@@ -441,7 +440,7 @@ def storage_graph(
         fillcolor = save_when_colors[save_when]
 
     if graph is None:
-        graph = graphviz.Digraph(format=format, strict=False)
+        graph = graphviz.Digraph(name=target, strict=True)
         graph.attr(bgcolor="transparent")
     else:
         if not isinstance(graph, graphviz.graphs.Digraph):
@@ -472,6 +471,5 @@ def storage_graph(
 
     # dump the plot if need
     if dump_plot:
-        fn = os.path.join(to_dir, target, ".dot")
-        graph.render(fn)
+        graph.render(format=format)
     return not_stored

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -472,6 +472,6 @@ def storage_graph(
 
     # dump the plot if need
     if dump_plot:
-        fn = os.path.join(to_dir, target)
+        fn = os.path.join(to_dir, target, ".dot")
         graph.render(fn)
     return not_stored

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -418,6 +418,13 @@ def storage_graph(
     :param to_dir: str, directory to save the plot
     :param format: str, format of the plot
     :return: all plugins that will be calculated when running self.make(run_id, target)
+    
+    The colors used in the graph represent the following storage states:
+    - Grey: SaveWhen.NEVER
+    - Red: SaveWhen.EXPLICIT
+    - Orange: SaveWhen.TARGET
+    - Yellow: SaveWhen.ALWAYS
+    - Green: Plugin is stored
 
     """
     save_when_colors = {

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -424,7 +424,7 @@ def storage_graph(
     - Red: strax.SaveWhen.EXPLICIT
     - Orange: strax.SaveWhen.TARGET
     - Yellow: strax.SaveWhen.ALWAYS
-    - Green: Plugin is stored
+    - Green: Target is stored
 
     """
     save_when_colors = {

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -420,11 +420,11 @@ def storage_graph(
     :return: all plugins that will be calculated when running self.make(run_id, target)
 
     The colors used in the graph represent the following storage states:
-    - Grey: strax.SaveWhen.NEVER
-    - Red: strax.SaveWhen.EXPLICIT
-    - Orange: strax.SaveWhen.TARGET
-    - Yellow: strax.SaveWhen.ALWAYS
-    - Green: Target is stored
+    - grey: strax.SaveWhen.NEVER
+    - red: strax.SaveWhen.EXPLICIT
+    - orange: strax.SaveWhen.TARGET
+    - yellow: strax.SaveWhen.ALWAYS
+    - green: target is stored
 
     """
     save_when_colors = {

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -420,10 +420,10 @@ def storage_graph(
     :return: all plugins that will be calculated when running self.make(run_id, target)
     
     The colors used in the graph represent the following storage states:
-    - Grey: SaveWhen.NEVER
-    - Red: SaveWhen.EXPLICIT
-    - Orange: SaveWhen.TARGET
-    - Yellow: SaveWhen.ALWAYS
+    - Grey: strax.SaveWhen.NEVER
+    - Red: strax.SaveWhen.EXPLICIT
+    - Orange: strax.SaveWhen.TARGET
+    - Yellow: strax.SaveWhen.ALWAYS
     - Green: Plugin is stored
 
     """

--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -440,7 +440,7 @@ def storage_graph(
         fillcolor = save_when_colors[save_when]
 
     if graph is None:
-        graph = graphviz.Digraph(name=target, strict=True)
+        graph = graphviz.Digraph(name=f"{run_id}-{target}", strict=True)
         graph.attr(bgcolor="transparent")
     else:
         if not isinstance(graph, graphviz.graphs.Digraph):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -35,7 +35,7 @@ class TestBasics(unittest.TestCase):
         run_df = st.select_runs(available="raw_records")
         print(run_df)
         run_id = run_df.iloc[0]["name"]
-        assert run_id == test_run_id_1T
+        assert run_id == self.run_id
 
     def test_mini_analysis(self):
         @straxen.mini_analysis(requires=("raw_records",))
@@ -84,4 +84,4 @@ class TestBasics(unittest.TestCase):
 
     def test_storage_graph(self):
         """Test the storage graph."""
-        self.st.storage_graph(test_run_id_1T, "event_info")
+        self.st.storage_graph(self.run_id, "event_info")

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -81,3 +81,7 @@ class TestBasics(unittest.TestCase):
         """The raw records lineage may NEVER change, if you ever do, doom ensures."""
         st = straxen.contexts.xenonnt_online()
         self.assertTrue(st.key_for("0", "raw_records").lineage_hash == "rfzvpzj4mf")
+
+    def test_storage_graph(self):
+        """Test the storage graph."""
+        self.st.storage_graph(test_run_id_1T, "event_info")


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Depends on https://github.com/XENONnT/base_environment/pull/1593

[slack thread](https://xenonnt.slack.com/archives/C016UJZ090B/p1712323462029059)

As an example:
```
import straxen
st = straxen.contexts.demo()
test_run_id_1T = "180423_1021"
st.storage_graph(test_run_id_1T, "event_info", format="png")
```
gives you file `180423_1021-event_info.gv.png`:

![event_info gv](https://github.com/XENONnT/straxen/assets/40532474/994e4c07-778d-4393-936c-829e744e7622)

## Can you briefly describe how it works?

1. green means already stored
2. orange means `strax.SaveWhen.ALWAYS` so that it will be saved if you process raw_records
3. yellow means `strax.SaveWhen.TARGET`
4. red means `strax.SaveWhen.EXPLICIT`
5. grey means `strax.SaveWhen.NEVER`

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
