### PR TITLE
Return the edge closer to the target in `_numeric_derivative`

### DIFF
--- a/straxen/plugins/events/event_pattern_fit.py
+++ b/straxen/plugins/events/event_pattern_fit.py
@@ -569,7 +569,11 @@ def _numeric_derivative(y0, y1, err, target, x_min, x_max, x0, x1):
     """Get close to <target> by doing a numeric derivative."""
     if abs(y1 - y0) < err:
         # break by passing dx == 0
-        return 0.0, x1, x1
+        if abs(y0 - target) < abs(y1 - target):
+            x = x0
+        else:
+            x = x1
+        return 0.0, x, x
 
     x = (target - y0) / (y1 - y0) * (x1 - x0) + x0
     x = min(x, x_max)


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Try to fix https://github.com/XENONnT/straxen/issues/1354

The change is minor so I will not update the version of plugins.

## Can you briefly describe how it works?

Like the MWE in https://github.com/XENONnT/straxen/issues/1354 listed, when
```
aftobs, aft, s1tot = 1.0, 0.18243408203125003, 2.0
```

The `j_min` and `j_max` are too close (`j_min` is 0, and `j_max` is 2.8076670357142592e-05) and the difference between their corresponding `y0` and `y1` is smaller than `err=1e-7`. Then before this PR, this line https://github.com/XENONnT/straxen/blob/92bcf54cc236d3de1c86544fa0fd720cb8daf088/straxen/plugins/events/event_pattern_fit.py#L572 will directly return `j_max`. But in principle, it should return the `x` which will give the `y` closer to the `target`. And in the MWE of https://github.com/XENONnT/straxen/issues/1354, it should return `j_min`.

## Can you give a minimal working example (or illustrate with a figure)?

![image](https://github.com/XENONnT/straxen/assets/40532474/b03c0317-adde-4fcb-958d-be505e52ba1f)
The vertical lines are `j_min` and `j_max` which are very close.

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
