### PR TITLE
Check non-positive lone_hits

### DIFF
--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -226,6 +226,8 @@ class Peaklets(strax.Plugin):
             save_outside_hits=(self.peak_left_extension, self.peak_right_extension),
             n_channels=len(self.to_pe),
         )
+        if np.any(lone_hits["right_integration"] - lone_hits["left_integration"] <= 0):
+            raise ValueError("Find lone_hits with non-positive length!")
 
         # Compute basic peak properties -- needed before natural breaks
         hits = hits[~is_lone_hit]


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

If `lone_hits["right_integration"] - lone_hits["left_integration"] <= 0`, later at https://github.com/XENONnT/straxen/blob/33992c2c8d0de8a7b1cc13a97f42b79f26c05f86/straxen/plugins/merged_s2s/merged_s2s.py#L140, `lh["length"]` will be non-positive, so that error will shown later at `strax.add_lone_hits`: https://github.com/XENONnT/straxen/blob/33992c2c8d0de8a7b1cc13a97f42b79f26c05f86/straxen/plugins/merged_s2s/merged_s2s.py#L145.

Related to https://github.com/XENONnT/straxen/issues/1357.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_
