### PR TITLE
Add a simply function to plot the dependency tree

### DIFF
--- a/docs/source/build_datastructure_doc.py
+++ b/docs/source/build_datastructure_doc.py
@@ -11,12 +11,13 @@ For extra credit, the SVGs are clickable.
 from collections import defaultdict
 import os
 import shutil
+from immutabledict import immutabledict
+import numpy as np
 import pandas as pd
 import graphviz
 import strax
 import straxen
-from immutabledict import immutabledict
-import numpy as np
+from straxen import kind_colors
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -112,21 +113,6 @@ titles = {
     "_mv": "Straxen {xT} datastructure for muon veto",
 }
 tree_suffices = list(titles.keys())
-
-kind_colors = dict(
-    events="#ffffff",
-    peaks="#98fb98",
-    hitlets="#0066ff",
-    peaklets="#d9ff66",
-    merged_s2s="#ccffcc",
-    lone_hits="#CAFF70",
-    records="#ffa500",
-    raw_records="#ff4500",
-    raw_records_aqmon="#ff4500",
-    raw_records_aux_mv="#ff4500",
-    online_peak_monitor="deepskyblue",
-    online_monitor="deepskyblue",
-)
 
 suffices = ["_he", "_nv", "_mv"]
 for suffix in suffices:


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

The function is different from the one in `docs/source/build_datastructure_doc.py:build_datastructure_doc`. The new function is a much more simplified version.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
