### PR TITLE
Tolerate more exceptions when can not import admix

### DIFF
--- a/straxen/storage/rucio_remote.py
+++ b/straxen/storage/rucio_remote.py
@@ -12,7 +12,7 @@ try:
     from rucio.common.exception import DataIdentifierNotFound
 
     HAVE_ADMIX = True
-except ImportError:
+except (ImportError, AttributeError):
     HAVE_ADMIX = False
 
 export, __all__ = strax.exporter()


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Previously, when importing without `utilix` configuration, we will get an error:
```
>>> import straxen
2024-04-22 13:55:52,425 - utilix - WARNING - Could not load a configuration file. You can create one at /home/xudc/.xenon_config, or set a custom path using

export XENON_CONFIG=path/to/your/config

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/xudc/straxen/straxen/__init__.py", line 26, in <module>
    from . import storage
  File "/home/xudc/straxen/straxen/storage/__init__.py", line 4, in <module>
    from . import rucio_remote
  File "/home/xudc/straxen/straxen/storage/rucio_remote.py", line 11, in <module>
    import admix
  File "/opt/miniconda3/envs/XENONnT_2024.03.1/lib/python3.9/site-packages/admix/__init__.py", line 20, in <module>  
    logger = get_logger()
  File "/opt/miniconda3/envs/XENONnT_2024.03.1/lib/python3.9/site-packages/admix/__init__.py", line 13, in get_logger
    ch.setLevel(uconfig.logging_level)
AttributeError: 'NoneType' object has no attribute 'logging_level'
```

This PR includes `AttributeError` also into the exception to capture this error.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
