### PR TITLE
let xedocs handles the seg partition

### DIFF
--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -90,7 +90,7 @@ class CorrectedAreas(strax.Plugin):
         default="cmt://single_electron_gain_partition?version=ONLINE&run_id=plugin.run_id",
         help="Two distinct patterns of evolution of single electron corrections between A+B and C+D. Distinguish thanks to linear and circular regions",
     )
-    
+
     # cS2 AFT correction due to photon ionization
     # https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:zihao:sr1_s2aft_photonionization_correction
     cs2_bottom_top_ratio_correction = straxen.URLConfig(
@@ -144,9 +144,9 @@ class CorrectedAreas(strax.Plugin):
 
     def ab_region(self, x, y):
         new_x, new_y = rotate_perp_wires(x, y)
-        cond = new_x < self.single_electron_gain_partition['linear']
-        cond &= new_x > -self.single_electron_gain_partition['linear']
-        cond &= new_x**2 + new_y**2 < self.single_electron_gain_partition['circular']**2
+        cond = new_x < self.single_electron_gain_partition["linear"]
+        cond &= new_x > -self.single_electron_gain_partition["linear"]
+        cond &= new_x**2 + new_y**2 < self.single_electron_gain_partition["circular"] ** 2
         return cond
 
     def cd_region(self, x, y):

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -82,22 +82,15 @@ class CorrectedAreas(strax.Plugin):
         help="Relative light yield (allows for time dependence)",
     )
 
-    region_linear = straxen.URLConfig(
-        default=28,
-        help=(
-            "linear cut (cm) for ab region, check out the note"
-            " https://xe1t-wiki.lngs.infn.it/doku.php?id=jlong:sr0_2_region_se_correction"
-        ),
+    # Single electron gain partition
+    # AB and CD partitons distiguished based on
+    # linear and circular regions
+    # https://xe1t-wiki.lngs.infn.it/doku.php?id=jlong:sr0_2_region_se_correction
+    single_electron_gain_partition = straxen.URLConfig(
+        default="cmt://single_electron_gain_partition?version=ONLINE&run_id=plugin.run_id",
+        help="Two distinct patterns of evolution of single electron corrections between A+B and C+D. Distinguish thanks to linear and circular regions",
     )
-
-    region_circular = straxen.URLConfig(
-        default=60,
-        help=(
-            "circular cut (cm) for ab region, check out the note"
-            " https://xe1t-wiki.lngs.infn.it/doku.php?id=jlong:sr0_2_region_se_correction"
-        ),
-    )
-
+    
     # cS2 AFT correction due to photon ionization
     # https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:zihao:sr1_s2aft_photonionization_correction
     cs2_bottom_top_ratio_correction = straxen.URLConfig(
@@ -151,9 +144,9 @@ class CorrectedAreas(strax.Plugin):
 
     def ab_region(self, x, y):
         new_x, new_y = rotate_perp_wires(x, y)
-        cond = new_x < self.region_linear
-        cond &= new_x > -self.region_linear
-        cond &= new_x**2 + new_y**2 < self.region_circular**2
+        cond = new_x < self.single_electron_gain_partition['linear']
+        cond &= new_x > -self.single_electron_gain_partition['linear']
+        cond &= new_x**2 + new_y**2 < self.single_electron_gain_partition['circular']**2
         return cond
 
     def cd_region(self, x, y):

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -24,7 +24,7 @@ class CorrectedAreas(strax.Plugin):
 
     """
 
-    __version__ = "0.5.2"
+    __version__ = "0.5.3"
 
     depends_on: Tuple[str, ...] = ("event_basics", "event_positions")
 

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -86,9 +86,13 @@ class CorrectedAreas(strax.Plugin):
     # AB and CD partitons distiguished based on
     # linear and circular regions
     # https://xe1t-wiki.lngs.infn.it/doku.php?id=jlong:sr0_2_region_se_correction
+    # https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:noahhood:corrections:se_gain_ee_final
     single_electron_gain_partition = straxen.URLConfig(
         default="cmt://single_electron_gain_partition?version=ONLINE&run_id=plugin.run_id",
-        help="Two distinct patterns of evolution of single electron corrections between A+B and C+D. Distinguish thanks to linear and circular regions",
+        help=(
+            "Two distinct patterns of evolution of single electron corrections between AB and CD. "
+            "Distinguish thanks to linear and circular regions"
+        ),
     )
 
     # cS2 AFT correction due to photon ionization


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Changed how to handle the TPC partition for AB and CD SEG.

## Can you briefly describe how it works?

The partition AB is distinguished from CD based on a linear and a radial cut on the (xy) plane. The values are take from xedocs+corection repo.

Right now this PR depends on [PR#273 in correction](https://github.com/XENONnT/corrections/pull/273)  and [PR#120 in xedocs](https://github.com/XENONnT/xedocs/pull/120)

## Can you give a minimal working example (or illustrate with a figure)?

You have to be on the specific xedocs and correction branches for run the following code

```
PATH_TO_REPO = 'path_to_correction'
st.set_config({'single_electron_gain_partition': f'objects-to-dict://xedocs://single_electron_gain_partition?run_id=plugin.run_id&version=v1&region=linear&region=circular&as_list=True&sort=region&key_attr=region&value_attr=value&db=local_folder&db__path={PATH_TO_REPO}'})

linear, circular, run_ok = [], [], []
for r in tqdm.tqdm(runs):
        plugin = st.get_single_plugin(f'0{r}', 'corrected_areas')
        linear.append(plugin.single_electron_gain_partition['linear'])
        circular.append(plugin.single_electron_gain_partition['circular'])
        run_ok.append(r)
```

![immagine](https://github.com/XENONnT/straxen/assets/38431109/c9d991e5-a6a9-42d9-b477-29a430d8d9cf)
 
_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_
