### PR TITLE
Let xedocs to handle avg seg and seg partitioning

### DIFF
--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -85,12 +85,11 @@ class CorrectedAreas(strax.Plugin):
     # Single electron gain partition
     # AB and CD partitons distiguished based on
     # linear and circular regions
+    # SR0 values set as default
     # https://xe1t-wiki.lngs.infn.it/doku.php?id=jlong:sr0_2_region_se_correction
     # https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:noahhood:corrections:se_gain_ee_final
     single_electron_gain_partition = straxen.URLConfig(
-        default="objects-to-dict://xedocs://avg_se_gains?run_id=plugin.run_id&version=v2&"
-        "field=region_circular&field=region_linear&"
-        "as_list=True&sort=field&key_attr=field&value_attr=value",
+        default={"linear": 28, "circular": 60},
         help=(
             "Two distinct patterns of evolution of single electron corrections between AB and CD. "
             "Distinguish thanks to linear and circular regions"
@@ -150,9 +149,9 @@ class CorrectedAreas(strax.Plugin):
 
     def ab_region(self, x, y):
         new_x, new_y = rotate_perp_wires(x, y)
-        cond = new_x < self.single_electron_gain_partition["region_circular"]
-        cond &= new_x > -self.single_electron_gain_partition["region_circular"]
-        cond &= new_x**2 + new_y**2 < self.single_electron_gain_partition["region_circular"] ** 2
+        cond = new_x < self.single_electron_gain_partition["linear"]
+        cond &= new_x > -self.single_electron_gain_partition["linear"]
+        cond &= new_x**2 + new_y**2 < self.single_electron_gain_partition["circular"] ** 2
         return cond
 
     def cd_region(self, x, y):

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -24,7 +24,7 @@ class CorrectedAreas(strax.Plugin):
 
     """
 
-    __version__ = "0.5.2"
+    __version__ = "0.5.3"
 
     depends_on: Tuple[str, ...] = ("event_basics", "event_positions")
 
@@ -82,19 +82,18 @@ class CorrectedAreas(strax.Plugin):
         help="Relative light yield (allows for time dependence)",
     )
 
-    region_linear = straxen.URLConfig(
-        default=28,
+    # Single electron gain partition
+    # AB and CD partitons distiguished based on
+    # linear and circular regions
+    # https://xe1t-wiki.lngs.infn.it/doku.php?id=jlong:sr0_2_region_se_correction
+    # https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:noahhood:corrections:se_gain_ee_final
+    single_electron_gain_partition = straxen.URLConfig(
+        default="objects-to-dict://xedocs://avg_se_gains?run_id=plugin.run_id&version=v2&"
+        "field=region_circular&field=region_linear&"
+        "as_list=True&sort=field&key_attr=field&value_attr=value",
         help=(
-            "linear cut (cm) for ab region, check out the note"
-            " https://xe1t-wiki.lngs.infn.it/doku.php?id=jlong:sr0_2_region_se_correction"
-        ),
-    )
-
-    region_circular = straxen.URLConfig(
-        default=60,
-        help=(
-            "circular cut (cm) for ab region, check out the note"
-            " https://xe1t-wiki.lngs.infn.it/doku.php?id=jlong:sr0_2_region_se_correction"
+            "Two distinct patterns of evolution of single electron corrections between AB and CD. "
+            "Distinguish thanks to linear and circular regions"
         ),
     )
 
@@ -151,9 +150,9 @@ class CorrectedAreas(strax.Plugin):
 
     def ab_region(self, x, y):
         new_x, new_y = rotate_perp_wires(x, y)
-        cond = new_x < self.region_linear
-        cond &= new_x > -self.region_linear
-        cond &= new_x**2 + new_y**2 < self.region_circular**2
+        cond = new_x < self.single_electron_gain_partition["region_circular"]
+        cond &= new_x > -self.single_electron_gain_partition["region_circular"]
+        cond &= new_x**2 + new_y**2 < self.single_electron_gain_partition["region_circular"] ** 2
         return cond
 
     def cd_region(self, x, y):


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Changed how to handle the TPC partition for AB and CD SEG and avg SEG.

Relevant for [xedocs PR#120](https://github.com/XENONnT/xedocs/pull/120) and [correction PR#273](https://github.com/XENONnT/corrections/pull/273)

## Can you briefly describe how it works?

The partition AB is distinguished from CD based on a linear and a radial cut on the (xy) plane. For the two partitions, we have different average SE gains.

We have add two schemas, one for the definition of AB/CD and one for the avg_se_gain. Here they are implemeneted.


## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_
