### PR TITLE
remove resource_cache from dali

### DIFF
--- a/straxen/common.py
+++ b/straxen/common.py
@@ -261,7 +261,6 @@ def resource_from_url(html: str, fmt="text"):
     cache_folders = [
         "./resource_cache",
         "/tmp/straxen_resource_cache",
-        "/dali/lgrandi/strax/resource_cache",
     ]
     for cache_folder in cache_folders:
         try:

--- a/straxen/storage/mongo_storage.py
+++ b/straxen/storage/mongo_storage.py
@@ -261,7 +261,6 @@ class MongoDownloader(GridFsInterface):
         if store_files_at is None:
             store_files_at = (
                 "/tmp/straxen_resource_cache/",
-                "/dali/lgrandi/strax/resource_cache",
                 "./resource_cache",
             )
         elif not isinstance(store_files_at, (tuple, str, list)):


### PR DESCRIPTION
See issue #1362 
The `resource_cache` on dali is just a backup folder to store the caches from url/mongodb. Most of the time, they are stored in users' local folders unless there is a permission issue. To avoid possible mounting issues between Dali and other servers, we removed this backup location from Straxen.
