### PR TITLE
Parse USERDISK base on hostname in RunDB

### DIFF
--- a/straxen/storage/mongo_storage.py
+++ b/straxen/storage/mongo_storage.py
@@ -260,8 +260,8 @@ class MongoDownloader(GridFsInterface):
         # either specified by the user or we use these defaults:
         if store_files_at is None:
             store_files_at = (
-                "/tmp/straxen_resource_cache/",
                 "./resource_cache",
+                "/tmp/straxen_resource_cache",
             )
         elif not isinstance(store_files_at, (tuple, str, list)):
             raise ValueError(f"{store_files_at} should be tuple of paths!")

--- a/straxen/storage/rundb.py
+++ b/straxen/storage/rundb.py
@@ -133,7 +133,7 @@ class RunDB(strax.StorageFrontend):
             if re.match(regex, self.hostname):
                 self.available_query.append({"host": host_alias})
 
-        # When querying for rucio, add that it should be dali-userdisk (when on dali)
+        # When querying for rucio, add that it should be sparsed by the hostname
         if self.rucio_path is not None and any(
             re.match(regex, self.hostname) for regex in self.hosts.values()
         ):

--- a/straxen/test_utils.py
+++ b/straxen/test_utils.py
@@ -68,6 +68,11 @@ def _is_on_pytest():
     return "PYTEST_CURRENT_TEST" in os_environ
 
 
+@export
+def mongo_uri_not_set():
+    return "TEST_MONGO_URI" not in os.environ
+
+
 def _get_fake_daq_reader():
     class DAQReader(straxen.DAQReader):
         """Dummy version of the DAQ reader to make sure that all the testing data produced here will

--- a/tests/storage/test_database_frontends.py
+++ b/tests/storage/test_database_frontends.py
@@ -194,8 +194,8 @@ class TestRunDBFrontend(unittest.TestCase):
         rd = _rundoc_format(rucio_id)
         did = straxen.key_to_rucio_did(key)
         location = None
-        for host_alias, regex in self.database.userdisks.items():
-            if re.match(regex, self.database.hostname):
+        for host_alias, regex in self.rundb_sf.userdisks.items():
+            if re.match(regex, self.rundb_sf.hostname):
                 location = host_alias
         rd["data"] = [
             {

--- a/tests/storage/test_database_frontends.py
+++ b/tests/storage/test_database_frontends.py
@@ -1,5 +1,4 @@
 import os
-import re
 import unittest
 import strax
 from strax.testutils import Records, Peaks
@@ -63,6 +62,7 @@ class TestRunDBFrontend(unittest.TestCase):
             """Change class to mathc current host too."""
 
             hosts = {"bla": f"{socket.getfqdn()}"}
+            userdisks = {"BLA_USERDISK": f"{socket.getfqdn()}"}
 
         cls.rundb_sf_with_current_host = RunDBTestLocal(
             readonly=False,
@@ -193,21 +193,16 @@ class TestRunDBFrontend(unittest.TestCase):
         self.assertFalse(rucio_id in self.test_run_ids)
         rd = _rundoc_format(rucio_id)
         did = straxen.key_to_rucio_did(key)
-        location = None
-        for host_alias, regex in self.rundb_sf.userdisks.items():
-            if re.match(regex, self.rundb_sf.hostname):
-                location = host_alias
         rd["data"] = [
             {
                 "host": "rucio-catalogue",
+                "location": "BLA_USERDISK",
                 "status": "transferred",
                 "did": did,
                 "number": int(rucio_id),
                 "type": target,
             }
         ]
-        if location is not None:
-            rd["data"][0]["location"] = location
         self.database[self.collection_name].insert_one(rd)
 
         # Make sure we get the backend key using the _find option

--- a/tests/storage/test_mongo_downloader.py
+++ b/tests/storage/test_mongo_downloader.py
@@ -2,10 +2,7 @@ import unittest
 import straxen
 import os
 import pymongo
-
-
-def mongo_uri_not_set():
-    return "TEST_MONGO_URI" not in os.environ
+from straxen import mongo_uri_not_set
 
 
 @unittest.skipIf(mongo_uri_not_set(), "No access to test database")


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

If hostname contains `dali`, use `UC_DALI_USERDISK`.
If hostname contains `midway`, use `UC_MIDWAY_USERDISK`.

This can remove the confusion when users see rucio data on `/dali` but run jobs on node without connection to `/dali`.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
