### PR TITLE
Add xedocs version to context config, only if xedocs is called

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,3 +1,4 @@
 # File for the requirements of straxen with the automated tests
+sharedarray@https://xenon.isi.edu/python/SharedArray-3.2.3.tar.gz # workaround for numpy 2.0.0 build problem, see XENONnT/base_environment#1718
 strax==1.6.4
 git+https://github.com/XENONnT/base_environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ immutabledict
 matplotlib
 multihist>=0.6.3
 numba>=0.50.0
-numpy
+numpy<2.0.0
 packaging
 m2r==0.2.1
 docutils==0.18.1

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -475,6 +475,7 @@ def apply_cmt_version(context: strax.Context, cmt_global_version: str) -> None:
 
     context.set_config(cmt_config)
 
+
 @strax.Context.add_method
 def apply_xedocs_configs(context: strax.Context, db="straxen_db", **kwargs) -> None:
     import xedocs
@@ -492,7 +493,7 @@ def apply_xedocs_configs(context: strax.Context, db="straxen_db", **kwargs) -> N
 
     if len(global_config):
         context.set_config(global_config)
-        context.set_context_config({'xedocs_version':filter_kwargs['version']})
+        context.set_context_config({"xedocs_version": filter_kwargs["version"]})
     else:
         warnings.warn(
             f"Could not find any context configs matchin {filter_kwargs}",

--- a/straxen/corrections_services.py
+++ b/straxen/corrections_services.py
@@ -475,7 +475,6 @@ def apply_cmt_version(context: strax.Context, cmt_global_version: str) -> None:
 
     context.set_config(cmt_config)
 
-
 @strax.Context.add_method
 def apply_xedocs_configs(context: strax.Context, db="straxen_db", **kwargs) -> None:
     import xedocs
@@ -493,6 +492,7 @@ def apply_xedocs_configs(context: strax.Context, db="straxen_db", **kwargs) -> N
 
     if len(global_config):
         context.set_config(global_config)
+        context.set_context_config({'xedocs_version':filter_kwargs['version']})
     else:
         warnings.warn(
             f"Could not find any context configs matchin {filter_kwargs}",


### PR DESCRIPTION
Part of this [PR](https://github.com/XENONnT/cutax/pull/429), following [this old conversation](https://xenonnt.slack.com/archives/C016UJZ090B/p1717834028186609).

## What does the code in this PR do / what does it improve?
Very minor addition: It adds the global version used in the context to the straxen context_configs. This is just to help to know what global version they are on, because some analysis have frozen global versions (Warnings when a frozen global version is not the same as the specified version is given by the cutax PR 429 as well)

Note: Doing st.set_context_config() after the initialization still does not change the global version (and it is not encouraged to change it mid-analysis). This addition does nothing to the actual processing other than make this information available :) 

## Can you briefly describe how it works?
Only adds a new key 'xedocs_version' to the context_configs, and only if the analysis actually uses xedocs during initialization.

## Can you give a minimal working example (or illustrate with a figure)?
On this branch of straxen,

`st=cutax.xenonnt_offline()  #or any other context`
`st.context_config `

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
