### PR TITLE
Initialize `MongoDownloader` only once to limit unnecessary connection to DB

### DIFF
--- a/straxen/analyses/daq_waveforms.py
+++ b/straxen/analyses/daq_waveforms.py
@@ -6,6 +6,7 @@ import pandas
 import pymongo
 import straxen
 import utilix
+from ..storage import mongo_downloader
 
 
 @straxen.mini_analysis()
@@ -82,8 +83,7 @@ def _board_to_host_link(daq_config: dict, board: int, add_crate=True) -> str:
 
 def _get_cable_map(name: str = "xenonnt_cable_map.csv") -> pandas.DataFrame:
     """Download the cable map and return as a pandas dataframe."""
-    down = straxen.MongoDownloader()
-    cable_map = down.download_single(name)
+    cable_map = mongo_downloader.download_single(name)
     cable_map = pandas.read_csv(cable_map)
     return cable_map
 

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -17,6 +17,7 @@ import pandas as pd
 import numba
 import strax
 import straxen
+from .storage import mongo_downloader, mongo_downloader_files
 
 export, __all__ = strax.exporter()
 __all__.extend(
@@ -222,9 +223,8 @@ def get_resource(x: str, fmt="text"):
         return open_resource(x, fmt=fmt)
     # 3. load from database
     elif straxen.uconfig is not None:
-        downloader = straxen.MongoDownloader()
-        if x in downloader.list_files():
-            path = downloader.download_single(x)
+        if x in mongo_downloader_files:
+            path = mongo_downloader.download_single(x)
             return open_resource(path, fmt=fmt)
     # 4. load from URL
     if "://" in x:

--- a/straxen/config/protocols.py
+++ b/straxen/config/protocols.py
@@ -18,6 +18,8 @@ from immutabledict import immutabledict
 from utilix import xent_collection
 from scipy.interpolate import interp1d
 
+from ..storage import mongo_downloader
+
 
 def get_item_or_attr(obj, key, default=None):
     if isinstance(obj, dict):
@@ -42,8 +44,7 @@ def get_resource(name: str, fmt: str = "text", **kwargs):
     """Fetch a straxen resource Allow a direct download using <fmt='abs_path'> otherwise kwargs are
     passed directly to straxen.get_resource."""
     if fmt == "abs_path":
-        downloader = straxen.MongoDownloader()
-        return downloader.download_single(name)
+        return mongo_downloader.download_single(name)
     return straxen.get_resource(name, fmt=fmt)
 
 

--- a/straxen/storage/__init__.py
+++ b/straxen/storage/__init__.py
@@ -12,3 +12,7 @@ from .rundb import *
 
 from . import mongo_storage
 from .mongo_storage import *
+
+
+mongo_downloader = mongo_storage.MongoDownloader()
+mongo_downloader_files = mongo_downloader.list_files()


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Started from [slack thread](https://xenonnt.slack.com/archives/C0172947DFW/p1717974709915159?thread_ts=1717597229.473489&cid=C0172947DFW), we need to find a way to limit connections to DB.

This line controls the connection to DB: https://github.com/XENONnT/straxen/blob/b8fe520deca55b8c5ac0cb53249b38639f0ae5de/straxen/common.py#L225. Since in fuse we used a lot of resource protocol to download maps: https://github.com/XENONnT/straxen/blob/b8fe520deca55b8c5ac0cb53249b38639f0ae5de/straxen/config/protocols.py#L47, each calling of resource protocol will trigger a connection.

This PR checks if the cached file exist BEFORE build the connection to DB: caching `downloader.list_files()` in line https://github.com/XENONnT/straxen/blob/b8fe520deca55b8c5ac0cb53249b38639f0ae5de/straxen/common.py#L226C17-L226C40 for future reference so that you will not need to initialize `straxen.MongoDownloader` each time you call resource protocol.

## Can you briefly describe how it works?

Put `mongo_downloader = mongo_storage.MongoDownloader()` and `mongo_downloader_files = mongo_downloader.list_files()` in `straxen/storage/__init__.py` and replace `downloader = straxen.MongoDownloader()` with `mongo_downloader`.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
