### PR TITLE
Generate only one instance for `MongoDownloader`

### DIFF
--- a/straxen/storage/mongo_storage.py
+++ b/straxen/storage/mongo_storage.py
@@ -3,6 +3,7 @@ import tempfile
 from datetime import datetime
 from warnings import warn
 import pytz
+from typing import Tuple, Dict
 from strax import exporter, to_str_tuple
 import gridfs
 from tqdm import tqdm
@@ -252,6 +253,15 @@ class MongoUploader(GridFsInterface):
 @export
 class MongoDownloader(GridFsInterface):
     """Class to download files from GridFs."""
+
+    _instances: Dict[Tuple, "MongoDownloader"] = {}
+
+    def __new__(cls, *args, **kwargs):
+        key = (args, frozenset(kwargs.items()))
+        if key not in cls._instances:
+            cls._instances[key] = super(MongoDownloader, cls).__new__(cls)
+            cls._instances[key].__init__(*args, **kwargs)
+        return cls._instances[key]
 
     def __init__(self, store_files_at=None, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Similar to https://github.com/XENONnT/straxen/pull/1397 but in another approach. When trying `downloader = straxen.MongoDownloader()`, unless `*args` or `**kwargs` changed for  `MongoDownloader`, return the already existed instance of `MongoDownloader`.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
