### PR TITLE
Load whole run for `VetoIntervals` regardless the run length

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ docutils==0.18.1
 mistune==0.8.4
 pymongo
 requests
-strax>=1.5.0
+strax>=1.6.4
 utilix>=0.5.3
 xedocs

--- a/straxen/plugins/events/veto_proximity.py
+++ b/straxen/plugins/events/veto_proximity.py
@@ -4,10 +4,14 @@ import strax
 import numba
 
 export, __all__ = strax.exporter()
+__all__.extend(["DTYPE_VETO_INTERVALS"])
+
+
+DTYPE_VETO_INTERVALS = np.int64
 
 
 @export
-class VetoProximity(strax.OverlapWindowPlugin):
+class VetoProximity(strax.ExhaustPlugin):
     """Find the closest next/previous veto start w.r.t.
 
     the event time or when a busy happens during an event.
@@ -30,20 +34,6 @@ class VetoProximity(strax.OverlapWindowPlugin):
         ),
     )
 
-    veto_proximity_window = straxen.URLConfig(
-        default=int(300e9), help="Maximum separation between veto stop and start pulses [ns]"
-    )
-    time_no_aqmon_veto_found = straxen.URLConfig(
-        default=int(3.6e12),
-        track=True,
-        type=int,
-        help=(
-            "If no next/previous veto is found, we will fill the fields "
-            "time_to_previous_XX with this time. Set to a large number "
-            "such that one will never cut events that are < YY ns."
-        ),
-    )
-
     veto_names = ["busy", "busy_he", "hev", "straxen_deadtime"]
 
     def infer_dtype(self):
@@ -57,7 +47,7 @@ class VetoProximity(strax.OverlapWindowPlugin):
                         f'Duration of event overlapping with "{name}"-veto [ns]',
                         f"veto_{name}_overlap",
                     ),
-                    np.int64,
+                    DTYPE_VETO_INTERVALS,
                 ),
                 (
                     (
@@ -67,7 +57,7 @@ class VetoProximity(strax.OverlapWindowPlugin):
                         ),
                         f"time_to_previous_{name}",
                     ),
-                    np.int64,
+                    DTYPE_VETO_INTERVALS,
                 ),
                 (
                     (
@@ -77,14 +67,11 @@ class VetoProximity(strax.OverlapWindowPlugin):
                         ),
                         f"time_to_next_{name}",
                     ),
-                    np.int64,
+                    DTYPE_VETO_INTERVALS,
                 ),
             ]
 
         return dtype
-
-    def get_window_size(self):
-        return self.veto_proximity_window
 
     def set_result_for_veto(
         self,
@@ -105,8 +92,8 @@ class VetoProximity(strax.OverlapWindowPlugin):
 
         """
         # Set defaults to be some very long time
-        result_buffer[f"time_to_previous_{veto_name}"] = self.time_no_aqmon_veto_found
-        result_buffer[f"time_to_next_{veto_name}"] = self.time_no_aqmon_veto_found
+        result_buffer[f"time_to_previous_{veto_name}"] = np.iinfo(DTYPE_VETO_INTERVALS).max
+        result_buffer[f"time_to_next_{veto_name}"] = np.iinfo(DTYPE_VETO_INTERVALS).max
 
         selected_intervals = veto_intervals[veto_intervals["veto_type"] == f"{veto_name}_veto"]
         if not len(selected_intervals):
@@ -136,7 +123,7 @@ class VetoProximity(strax.OverlapWindowPlugin):
         vetos_during_event, selected_intervals, event_window, result_buffer
     ):
         """Computes total time each event overlaps with the corresponding veto."""
-        res = np.zeros(len(vetos_during_event), np.int64)
+        res = np.zeros(len(vetos_during_event), DTYPE_VETO_INTERVALS)
 
         for event_i, veto_window in enumerate(vetos_during_event):
             if veto_window[1] - veto_window[0]:

--- a/straxen/plugins/veto_intervals/veto_intervals.py
+++ b/straxen/plugins/veto_intervals/veto_intervals.py
@@ -1,7 +1,6 @@
 import typing
 import numpy as np
 import strax
-import straxen
 
 from straxen.plugins.aqmon_hits.aqmon_hits import AqmonChannels
 
@@ -21,7 +20,7 @@ export, __all__ = strax.exporter()
 
 
 @export
-class VetoIntervals(strax.OverlapWindowPlugin):
+class VetoIntervals(strax.ExhaustPlugin):
     """Find pairs of veto start and veto stop signals and the veto.
 
     duration between them:
@@ -38,22 +37,6 @@ class VetoIntervals(strax.OverlapWindowPlugin):
     provides = "veto_intervals"
     data_kind = "veto_intervals"
 
-    # This option is just showing where the OverlapWindowPlugin fails.
-    # We need to buffer the entire run in order not to run into chunking
-    # issues. A better solution would be using
-    #   github.com/AxFoundation/strax/pull/654
-    max_veto_window = straxen.URLConfig(
-        default=int(7.2e12),
-        track=True,
-        type=int,
-        help=(
-            "Maximum separation between veto stop and start pulses [ns]. "
-            "Set to be >> than the max duration of the run to be able to "
-            "fully store one run into buffer since aqmon-hits are not "
-            "sorted by endtime"
-        ),
-    )
-
     def infer_dtype(self):
         dtype = [
             (("veto interval [ns]", "veto_interval"), np.int64),
@@ -65,10 +48,6 @@ class VetoIntervals(strax.OverlapWindowPlugin):
     def setup(self):
         self.veto_names = ["busy_", "busy_he_", "hev_"]
         self.channel_map = {aq_ch.name.lower(): int(aq_ch) for aq_ch in AqmonChannels}
-
-    def get_window_size(self):
-        # Give a very wide window
-        return self.max_veto_window
 
     def compute(self, aqmon_hits, start, end):
         # Allocate a nice big buffer and throw away the part we don't need later

--- a/tests/test_aqmon.py
+++ b/tests/test_aqmon.py
@@ -196,7 +196,6 @@ class TestAqmonProcessing(TestCase):
         st.set_context_config({"free_options": list(st.config.keys())})
         st._plugin_class_registry = {}
 
-        st.set_config(dict(veto_proximity_window=10**99))
         self.TOTAL_DEADTIME: List = []
         self.TOTAL_SIGNALS: List = []
 


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

Depends on https://github.com/AxFoundation/strax/pull/835 and https://github.com/AxFoundation/strax/pull/855

## What does the code in this PR do / what does it improve?

The `max_veto_window` and `veto_proximity_window` were introduced by https://github.com/XENONnT/straxen/pull/929. They are assuming the run length is no longer than 1 or 2 hrs, but sometimes the run length can be very large so we might lose catching of the busy time of the DAQ, if using the previous configurations.

## Can you briefly describe how it works?

Use `ExhaustPlugin` to load the dependency of the whole run of all dependencies at once. In this way we do not need to consider the overlapping windows.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
