### PR TITLE
Fix singleton pattern for `MongoDownloader`

### DIFF
--- a/straxen/storage/mongo_storage.py
+++ b/straxen/storage/mongo_storage.py
@@ -255,15 +255,23 @@ class MongoDownloader(GridFsInterface):
     """Class to download files from GridFs."""
 
     _instances: Dict[Tuple, "MongoDownloader"] = {}
+    _initialized: Dict[Tuple, bool] = {}
 
     def __new__(cls, *args, **kwargs):
         key = (args, frozenset(kwargs.items()))
         if key not in cls._instances:
             cls._instances[key] = super(MongoDownloader, cls).__new__(cls)
-            cls._instances[key].__init__(*args, **kwargs)
+            cls._initialized[key] = False
         return cls._instances[key]
 
-    def __init__(self, store_files_at=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
+        key = (args, frozenset(kwargs.items()))
+        if not self._initialized[key]:
+            self._instances[key].initialize(*args, **kwargs)
+            self._initialized[key] = True
+        return
+
+    def initialize(self, store_files_at=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # We are going to set a place where to store the files. It's


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Further fix https://github.com/XENONnT/straxen/pull/1398

`__new__` will be called before `__init__`, so the previous fix will not work perfectly because the `__init__` will be called twice.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
