### PR TITLE
Dynamic window merge

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,5 @@
 [bumpversion]
-current_version = 2.2.5
-files = straxen/__init__.py
+current_version = 2.2.4
+files = setup.py straxen/__init__.py
 commit = True
 tag = True
-
-[bumpversion:file:pyproject.toml]
-search = version = "{current_version}"
-replace = version = "{new_version}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,10 @@ updates:
       # Check for updates to GitHub Actions every weekday
       interval: "monthly"
     assignees:
-      - dachengx
+      - JoranAngevaare
   # Maintain the requirements requirements folder
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/extra_requirements"
     schedule:
       # Check for updates to requirements every week
       interval: "daily"
@@ -22,4 +22,4 @@ updates:
     # to pip against the `develop` branch
     target-branch: "master"
     assignees:
-      - dachengx
+      - JoranAngevaare

--- a/.github/workflows/pypi_install.yml
+++ b/.github/workflows/pypi_install.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: pip install build
+        run: pip install wheel
 
       - name: Build package
-        run: python -m build
+        run: python setup.py sdist bdist_wheel
 
       - name: Publish a Python distribution to PyPI
         # Do the publishing

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,7 @@ on:
       - development
 
 jobs:
-  test:
+  update:
     name: "${{ matrix.test }}_py${{ matrix.python-version }}"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -14,7 +14,7 @@ on:
       - master
 
 jobs:
-  install:
+  update:
     name: "py${{ matrix.python-version }}"
     runs-on: ubuntu-latest
     strategy:
@@ -30,8 +30,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt-get install -y graphviz
+      - name: Pre-install requirements
+        run: pip install -r requirements.txt
       - name: Install straxen
-        run: pip install .
+        run: python setup.py install
       - name: Test import
         run: python -c "import straxen; straxen.print_versions()"
       - name: goodbye

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,17 +15,13 @@ repos:
     -   id: black
         args: [--safe, --line-length=100, --preview]
     -   id: black-jupyter
-        types_or: [file]
-        files: \.ipynb$
         args: [--safe, --line-length=100, --preview]
-        language_version: python3
+        language_version: python3.9
 
 -   repo: https://github.com/pycqa/docformatter
     rev: v1.7.5
     hooks:
     -   id: docformatter
-        additional_dependencies: [tomli]
-        args: [--config, pyproject.toml]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,6 +19,8 @@ python:
       path: .
       extra_requirements:
         - docs
+    - method: setuptools
+      path: .
 
 formats:
   - htmlzip

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,11 +1,3 @@
-2.2.5 / 2024-08-17
--------------------
-* Generate only one instance for `MongoDownloader` by @dachengx in https://github.com/XENONnT/straxen/pull/1398
-* Load whole run for `VetoIntervals` regardless the run length by @dachengx in https://github.com/XENONnT/straxen/pull/1399
-
-**Full Changelog**: https://github.com/XENONnT/straxen/compare/v2.2.4...v2.2.5
-
-
 2.2.4 / 2024-07-01
 -------------------
 * Parse USERDISK base on hostname in RunDB by @dachengx in https://github.com/XENONnT/straxen/pull/1384

--- a/docs/source/scripts.rst
+++ b/docs/source/scripts.rst
@@ -26,14 +26,14 @@ For more information on the options, please refer to the help:
     straxer --help
 
 
-straxen_print_versions
+straxen-print_versions
 ----------------------
-``straxen_print_versions`` is a small bin utility that wraps around ``straxen.print_versions``.
+``straxen-print_versions`` is a small bin utility that wraps around ``straxen.print_versions``.
 It allows one to quickly print which installation paths are used, such as for example:
 
 .. code-block:: bash
 
-    straxen_print_versions strax straxen cutax wfsim pema
+    straxen-print_versions strax straxen cutax wfsim pema
 
 
 ajax [DAQ-only]

--- a/extra_requirements/requirements-docs.txt
+++ b/extra_requirements/requirements-docs.txt
@@ -1,0 +1,12 @@
+# File for the requirements of the documentation
+commonmark==0.9.1
+graphviz==0.20.3
+m2r==0.2.1
+mistune==0.8.4
+nbsphinx==0.8.9
+recommonmark==0.7.1
+sphinx==7.1.2
+sphinx_rtd_theme==1.3.0
+Jinja2==3.1.4
+urllib3==2.2.2
+lxml_html_clean

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,0 +1,4 @@
+# File for the requirements of straxen with the automated tests
+sharedarray@https://xenon.isi.edu/python/SharedArray-3.2.3.tar.gz # workaround for numpy 2.0.0 build problem, see XENONnT/base_environment#1718
+git+https://github.com/XENONnT/base_environment
+git+https://github.com/AxFoundation/strax

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+# datashader         # Optional, to enable wf display
+# holoviews          # Optional, to enable wf display
+# tensorflow>=2.3.0  # Optional, to (re)do posrec
+bokeh
+commentjson
+gitpython
+graphviz
+immutabledict
+matplotlib
+multihist>=0.6.3
+numba>=0.50.0
+numpy<2.0.0
+packaging
+m2r==0.2.1
+docutils==0.18.1
+mistune==0.8.4
+pymongo
+requests
+strax>=1.6.4
+utilix>=0.5.3
+xedocs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test=pytest
+
 [mypy]
 disable_error_code = attr-defined
 
@@ -28,3 +31,10 @@ per-file-ignores =
     straxen/scripts/microstrax.py: F821
     tests/plugins/test_plugins.py: F401
     docs/source/build_datastructure_doc.py: E501
+
+[docformatter]
+in-place = true
+blank = true
+style = sphinx
+wrap-summaries = 100
+wrap-descriptions = 100

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,61 @@
+import setuptools
+
+
+def open_requirements(path):
+    with open(path) as f:
+        requires = [r.split("/")[-1] if r.startswith("git+") else r for r in f.read().splitlines()]
+    return requires
+
+
+# Get requirements from requirements.txt, stripping the version tags
+requires = open_requirements("requirements.txt")
+tests_requires = open_requirements("extra_requirements/requirements-tests.txt")
+doc_requirements = open_requirements("extra_requirements/requirements-docs.txt")
+
+with open("README.md") as file:
+    readme = file.read()
+
+with open("HISTORY.md") as file:
+    history = file.read()
+
+setuptools.setup(
+    name="straxen",
+    version="2.2.4",
+    description="Streaming analysis for XENON",
+    author="Straxen contributors, the XENON collaboration",
+    url="https://github.com/XENONnT/straxen",
+    long_description=readme + "\n\n" + history,
+    long_description_content_type="text/markdown",
+    setup_requires=["pytest-runner"],
+    install_requires=requires,
+    tests_require=requires + tests_requires,
+    python_requires=">=3.9",
+    extras_require={
+        "docs": doc_requirements,
+        "microstrax": ["hug"],
+    },
+    scripts=[
+        "bin/bootstrax",
+        "bin/restrax",
+        "bin/straxer",
+        "bin/fake_daq",
+        "bin/microstrax",
+        "bin/ajax",
+        "bin/refresh_raw_records",
+        "bin/straxen-print_versions",
+    ],
+    packages=setuptools.find_packages() + ["extra_requirements"],
+    package_dir={"extra_requirements": "extra_requirements"},
+    package_data={"extra_requirements": ["requirements-docs.txt", "requirements-tests.txt"]},
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Intended Audience :: Science/Research",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Topic :: Scientific/Engineering :: Physics",
+    ],
+    zip_safe=False,
+)

--- a/straxen/__init__.py
+++ b/straxen/__init__.py
@@ -1,5 +1,5 @@
 # mypy: disable-error-code="no-redef"
-__version__ = "2.2.5"
+__version__ = "2.2.4"
 
 from utilix import uconfig
 from .common import *

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -159,7 +159,7 @@ class LEDCalibration(strax.Plugin):
 
         temp['triggered'] = triggered
         temp["hit_position"] = led_windows[:, 0] - self.led_hit_extension[0]
-        temp['integration_window'] = led_windows#.astype(np.uint8)
+        temp['integration_window'] = led_windows
         return temp
 
 
@@ -260,6 +260,8 @@ def get_led_windows(
         default_hit_position = minimum_led_position
     else:
         default_hit_position, _ = sps.mode(hits['left'])
+        if isinstance(default_hit_position, np.ndarray):
+            default_hit_position = default_hit_position[0]
 
     triggered = np.zeros(len(records), dtype=bool)
 

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -102,7 +102,7 @@ class LEDCalibration(strax.Plugin):
         help="List of PMTs. Defalt value: all the PMTs",
     )
 
-    led_cal_hit_min_height_over_noise = straxen.URLConfig(
+    LED_cal_hit_min_height_over_noise = straxen.URLConfig(
         default=6,
         infer_type=False,
         help=(
@@ -145,8 +145,8 @@ class LEDCalibration(strax.Plugin):
             records,
             self.minimum_led_position,
             self.led_hit_extension,
-            self.led_cal_hit_min_height_over_noise,
-            self.led_cal_record_length,
+            self.LED_cal_hit_min_height_over_noise,
+            self.LED_cal_record_length,
             self.area_averaging_length,
         )
 

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -122,7 +122,7 @@ class LEDCalibration(strax.Plugin):
         (("Length of the interval in samples", "length"), np.int32),
         (("Whether there was a hit found in the record", "triggered"), bool),
         (("Sample index of the hit that defines the window position", "hit_position"), np.uint8),
-        (("Window used for integration", "integration_window"), np.uint8, (2,))
+        (("Window used for integration", "integration_window"), np.uint8, (2,)),
     ]
 
     def compute(self, raw_records):
@@ -157,9 +157,9 @@ class LEDCalibration(strax.Plugin):
         area = get_area(records, led_windows, self.area_averaging_length, self.area_averaging_step)
         temp["area"] = area["area"]
 
-        temp['triggered'] = triggered
+        temp["triggered"] = triggered
         temp["hit_position"] = led_windows[:, 0] - self.led_hit_extension[0]
-        temp['integration_window'] = led_windows
+        temp["integration_window"] = led_windows
         return temp
 
 
@@ -217,7 +217,7 @@ def get_led_windows(
     led_hit_extension,
     hit_min_height_over_noise,
     record_length,
-    area_averaging_length
+    area_averaging_length,
 ):
     """Search for hits in the records, if a hit is found, return an interval around the hit given by
     led_hit_extension. If no hit is found in the record, return the default window.
@@ -243,7 +243,7 @@ def get_led_windows(
         min_height_over_noise=hit_min_height_over_noise,
     )
 
-    hits = hits[hits['left'] >= minimum_led_position]
+    hits = hits[hits["left"] >= minimum_led_position]
     # Check if the records are sorted properly by 'record_i' first and 'time' second and sort them
     # if they are not
     record_i = hits["record_i"]
@@ -256,10 +256,10 @@ def get_led_windows(
     ):
         hits.sort(order=["record_i", "time"])
 
-    if len(hits) == 0: # This really should not be the case. But in case it is:
+    if len(hits) == 0:  # This really should not be the case. But in case it is:
         default_hit_position = minimum_led_position
     else:
-        default_hit_position, _ = sps.mode(hits['left'])
+        default_hit_position, _ = sps.mode(hits["left"])
         if isinstance(default_hit_position, np.ndarray):
             default_hit_position = default_hit_position[0]
 
@@ -282,8 +282,8 @@ def _get_led_windows(
     for hit in hits:
         if hit["record_i"] == last:
             continue  # If there are multiple hits in one record, ignore after the first
-        
-        triggered[hit['record_i']] = True
+
+        triggered[hit["record_i"]] = True
 
         hit_left = hit["left"]
         # Limit the position of the window so it stays inside the record.

--- a/straxen/plugins/raw_records/daqreader.py
+++ b/straxen/plugins/raw_records/daqreader.py
@@ -75,7 +75,7 @@ class ArtificialDeadtimeInserted(UserWarning):
     # DAQReader settings
     strax.Option(
         "safe_break_in_pulses",
-        default=strax.DEFAULT_CHUNK_SPLIT_NS,
+        default=1000,
         track=False,
         infer_type=False,
         help=(

--- a/straxen/scripts/microstrax.py
+++ b/straxen/scripts/microstrax.py
@@ -173,18 +173,6 @@ def set_state():
     update_thread.start()
 
 
-def main():
-    load_context(args.context, extra_dirs=args.extra_dirs)
-    set_state()
-
-    while True:
-        try:
-            hug.API(__name__).http.serve(port=args.port)
-        except pymongo.errors.NotMasterError:
-            print("Ran into the infamous pymongo.errors.NotMasterError. Sleep for a sec")
-            time.sleep(60)
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Start a microservice to return strax data as json"
@@ -201,4 +189,12 @@ if __name__ == "__main__":
     max_load_mb = args.max_load_mb
     max_return_mb = args.max_return_mb
 
-    main()
+    load_context(args.context, extra_dirs=args.extra_dirs)
+    set_state()
+
+    while True:
+        try:
+            hug.API(__name__).http.serve(port=args.port)
+        except pymongo.errors.NotMasterError:
+            print("Ran into the infamous pymongo.errors.NotMasterError. Sleep for a sec")
+            time.sleep(60)

--- a/straxen/scripts/straxen_print_versions.py
+++ b/straxen/scripts/straxen_print_versions.py
@@ -1,7 +1,7 @@
 """Small utility to print versions of software.
 
 Example:
-    straxen_print_versions strax straxen cutax wfsim pema
+    straxen-print_versions strax straxen cutax wfsim pema
 
 """
 

--- a/tests/storage/test_database_frontends.py
+++ b/tests/storage/test_database_frontends.py
@@ -174,11 +174,11 @@ class TestRunDBFrontend(unittest.TestCase):
             r = self.test_run_ids[0]
             keys = [self.st.key_for(r, t) for t in self.all_targets]
             self.rundb_sf.find_several(keys, fuzzy_for=self.all_targets)
-        with self.assertRaises(strax.RunMetadataNotAvailable):
-            self.rundb_sf.find(self.st.key_for("_superrun", self.all_targets[0]))
-        with self.assertRaises(strax.RunMetadataNotAvailable):
+        with self.assertRaises(strax.DataNotAvailable):
+            self.rundb_sf.find(self.st.key_for("_super-run", self.all_targets[0]))
+        with self.assertRaises(strax.DataNotAvailable):
             self.rundb_sf._find(
-                self.st.key_for("_superrun", self.all_targets[0]),
+                self.st.key_for("_super-run", self.all_targets[0]),
                 write=False,
                 allow_incomplete=False,
                 fuzzy_for=[],


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
The fixed default window leads to a time depended bias in how much untriggered PEs are seen.

## Can you briefly describe how it works?
This is fixed by positioning the default window at the mode of the position of all hits found in one chunk. Given the distribution of the positions is constant, this will result in a constant fraction of untriggered PE to be seen.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [x] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
