### PR TITLE
Fixed default window position

### DIFF
--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -60,7 +60,7 @@ class LEDCalibration(strax.Plugin):
         default=60,
         infer_type=False,
         help=(
-            "The minimum sample index to consider for LED hits. Hits before this sample are"
+            "The minimum sample index to consider for LED hits. Hits before this sample are "
             "ignored."
         ),
     )
@@ -75,9 +75,9 @@ class LEDCalibration(strax.Plugin):
         default=7,
         infer_type=False,
         help=(
-            "The total length of the averaging window for the area calculation."
-            "To mitigate a possiple bias from noise, the area is integrated multiple times with"
-            "sligntly different window lengths and then averaged. integration_averaging_length"
+            "The total length of the averaging window for the area calculation. "
+            "To mitigate a possiple bias from noise, the area is integrated multiple times with "
+            "sligntly different window lengths and then averaged. integration_averaging_length "
             "should be divisible by step."
         ),
     )
@@ -86,9 +86,9 @@ class LEDCalibration(strax.Plugin):
         default=1,
         infer_type=False,
         help=(
-            "The step size used for the different windows, averaged for the area calculation."
-            "To mitigate a possiple bias from noise, the area is integrated multiple times with"
-            "sligntly different window lengths and then averaged. integration_averaging_length"
+            "The step size used for the different windows, averaged for the area calculation. "
+            "To mitigate a possiple bias from noise, the area is integrated multiple times with "
+            "sligntly different window lengths and then averaged. integration_averaging_length "
             "should be divisible by step."
         ),
     )
@@ -107,7 +107,7 @@ class LEDCalibration(strax.Plugin):
         default=6,
         infer_type=False,
         help=(
-            "Minimum hit amplitude in numbers of baseline_rms above baseline."
+            "Minimum hit amplitude in numbers of baseline_rms above baseline. "
             "Actual threshold used is max(hit_min_amplitude, hit_min_"
             "height_over_noise * baseline_rms)."
         ),

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -62,7 +62,7 @@ class LEDCalibration(strax.Plugin):
         help=(
             "The minimum sample index to consider for LED hits. Hits before this sample are"
             "ignored."
-        )
+        ),
     )
 
     led_hit_extension = straxen.URLConfig(
@@ -224,8 +224,8 @@ def get_led_windows(
     led_hit_extension. If no hit is found in the record, return the default window.
 
     :param records: Array of the records to search for LED hits.
-    :param minimum_led_position: The minimum simple index of the LED hits. Hits before this sample are
-        ignored.
+    :param minimum_led_position: The minimum simple index of the LED hits. Hits before this sample
+        are ignored.
     :param led_hit_extension: The integration window around the first hit found to use. A tuple of
         form (samples_before, samples_after) the first LED hit.
     :param hit_min_amplitude: Minimum amplitude of the signal to be considered a hit.

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -276,9 +276,7 @@ def get_led_windows(
 
 
 @numba.jit(nopython=True)
-def _get_led_windows(
-    hits, default_windows, led_hit_extension, maximum_led_position, triggered
-):
+def _get_led_windows(hits, default_windows, led_hit_extension, maximum_led_position, triggered):
     windows = default_windows
     last = -1
 

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -70,7 +70,7 @@ class LEDCalibration(strax.Plugin):
     )
 
     area_averaging_length = straxen.URLConfig(
-        default=8,
+        default=7,
         infer_type=False,
         help=(
             "The total length of the averaging window for the area calculation."
@@ -81,7 +81,7 @@ class LEDCalibration(strax.Plugin):
     )
 
     area_averaging_step = straxen.URLConfig(
-        default=2,
+        default=1,
         infer_type=False,
         help=(
             "The step size used for the different windows, averaged for the area calculation."

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -234,7 +234,7 @@ def get_led_windows(
 
     """
     if len(records) == 0:  # If input is empty, return empty arrays of correct shape
-        return np.empty((0, 2), dtype=np.int64), np.empty((0, 1), dtype=bool)
+        return np.empty((0, 2), dtype=np.int64), np.empty(0, dtype=bool)
 
     hits = strax.find_hits(
         records,

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -233,8 +233,8 @@ def get_led_windows(
     :param area_averaging_length: The length (samples) of the window to do the averaging on.
 
     """
-    if len(records) == 0:  # If input is empty
-        return np.empty((0, 2), dtype=np.int64)  # Return empty array of correct shape
+    if len(records) == 0:  # If input is empty, return empty arrays of correct shape
+        return np.empty((0, 2), dtype=np.int64), np.empty((0, 1), dtype=bool)
 
     hits = strax.find_hits(
         records,

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -124,6 +124,7 @@ class LEDCalibration(strax.Plugin):
         (("Whether there was a hit found in the record", "triggered"), bool),
         (("Sample index of the hit that defines the window position", "hit_position"), np.uint8),
         (("Window used for integration", "integration_window"), np.uint8, (2,)),
+        (("Baseline from the record", "baseline"), np.float32),
     ]
 
     def compute(self, raw_records):
@@ -161,6 +162,7 @@ class LEDCalibration(strax.Plugin):
         temp["triggered"] = triggered
         temp["hit_position"] = led_windows[:, 0] - self.led_hit_extension[0]
         temp["integration_window"] = led_windows
+        temp["baseline"] = records["baseline"]
         return temp
 
 

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -59,8 +59,10 @@ class LEDCalibration(strax.Plugin):
     minimum_led_position = straxen.URLConfig(
         default=60,
         infer_type=False,
-        help="Default window (samples) to integrate and get the maximum amplitude \
-            if no hit was found in the record.",
+        help=(
+            "The minimum sample index to consider for LED hits. Hits before this sample are"
+            "ignored."
+        )
     )
 
     led_hit_extension = straxen.URLConfig(
@@ -222,7 +224,7 @@ def get_led_windows(
     led_hit_extension. If no hit is found in the record, return the default window.
 
     :param records: Array of the records to search for LED hits.
-    :param minimum_led_position: The minimum position of the LED hits. Hits before this sample are
+    :param minimum_led_position: The minimum simple index of the LED hits. Hits before this sample are
         ignored.
     :param led_hit_extension: The integration window around the first hit found to use. A tuple of
         form (samples_before, samples_after) the first LED hit.

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -77,8 +77,8 @@ class LEDCalibration(strax.Plugin):
         help=(
             "The total length of the averaging window for the area calculation. "
             "To mitigate a possiple bias from noise, the area is integrated multiple times with "
-            "sligntly different window lengths and then averaged. integration_averaging_length "
-            "should be divisible by step."
+            "sligntly different window lengths and then averaged. area_averaging_length should "
+            "be divisible by area_averaging_step."
         ),
     )
 
@@ -88,8 +88,8 @@ class LEDCalibration(strax.Plugin):
         help=(
             "The step size used for the different windows, averaged for the area calculation. "
             "To mitigate a possiple bias from noise, the area is integrated multiple times with "
-            "sligntly different window lengths and then averaged. integration_averaging_length "
-            "should be divisible by step."
+            "sligntly different window lengths and then averaged. area_averaging_length should "
+            "be divisible by area_averaging_step."
         ),
     )
 

--- a/straxen/storage/mongo_storage.py
+++ b/straxen/storage/mongo_storage.py
@@ -255,15 +255,23 @@ class MongoDownloader(GridFsInterface):
     """Class to download files from GridFs."""
 
     _instances: Dict[Tuple, "MongoDownloader"] = {}
+    _initialized: Dict[Tuple, bool] = {}
 
     def __new__(cls, *args, **kwargs):
         key = (args, frozenset(kwargs.items()))
         if key not in cls._instances:
             cls._instances[key] = super(MongoDownloader, cls).__new__(cls)
-            cls._instances[key].__init__(*args, **kwargs)
+            cls._initialized[key] = False
         return cls._instances[key]
 
-    def __init__(self, store_files_at=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
+        key = (args, frozenset(kwargs.items()))
+        if not self._initialized[key]:
+            self._instances[key].initialize(*args, **kwargs)
+            self._initialized[key] = True
+        return
+
+    def initialize(self, store_files_at=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # We are going to set a place where to store the files. It's


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
The fixed default window leads to a time depended bias in how much untriggered PEs are seen.

See here the note: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:pmt:gains:dynamic_led_window

## Can you briefly describe how it works?
This is fixed by positioning the default window on the mode of the position of all hits found in one chunk.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [x] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
