### PR TITLE
Bump to v2.2.6

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.4
+current_version = 2.2.6
 files = setup.py straxen/__init__.py
 commit = True
 tag = True

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,12 @@
+2.2.6 / 2024-10-08
+-------------------
+* Specify strax version in pytest.yml by @chnlkx in https://github.com/XENONnT/straxen/pull/1431
+* Update definition of the SE Score (previously the SE density) for SR1 WIMP by @chnlkx in https://github.com/XENONnT/straxen/pull/1430
+* Copy https://github.com/XENONnT/straxen/pull/1417 by @dachengx in https://github.com/XENONnT/straxen/pull/1438
+
+**Full Changelog**: https://github.com/XENONnT/straxen/compare/v2.2.4...v2.2.6
+
+
 2.2.4 / 2024-07-01
 -------------------
 * Parse USERDISK base on hostname in RunDB by @dachengx in https://github.com/XENONnT/straxen/pull/1384

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("HISTORY.md") as file:
 
 setuptools.setup(
     name="straxen",
-    version="2.2.4",
+    version="2.2.6",
     description="Streaming analysis for XENON",
     author="Straxen contributors, the XENON collaboration",
     url="https://github.com/XENONnT/straxen",

--- a/straxen/__init__.py
+++ b/straxen/__init__.py
@@ -1,5 +1,5 @@
 # mypy: disable-error-code="no-redef"
-__version__ = "2.2.4"
+__version__ = "2.2.6"
 
 from utilix import uconfig
 from .common import *


### PR DESCRIPTION
Note: this is a bump version from `sr1_leftovers` branch, not `master`. Because `master` is for post-SR1 analysis.