### PR TITLE
Add level in the tree when drawing dependency tree

### DIFF
--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -421,6 +421,7 @@ def dependency_tree(
     st,
     target="event_info",
     include_class=False,
+    include_level=False,
     exclude_pattern=None,
     dump_plot=True,
     to_dir="./",
@@ -452,9 +453,15 @@ def dependency_tree(
     for d, p in plugins.items():
         if any([fnmatch.fnmatch(d, pattern) for pattern in exclude_pattern]):
             continue
+        label = d
+        if include_class:
+            label += f"\n{p.__class__.__name__}"
+        if include_level:
+            label += f"\nlevel: {st.tree_levels[d]['level']} "
+            label += f"order: {st.tree_levels[d]['order']}"
         graph.node(
             d,
-            label=f"{d}\n{p.__class__.__name__}" if include_class else None,
+            label=label,
             style="filled",
             fillcolor=kind_colors.get(p.data_kind_for(d), "grey"),
         )


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

This is a follow-up PR of https://github.com/AxFoundation/strax/pull/896

## What does the code in this PR do / what does it improve?

It will print the level and order of a `data_type` in a tree if `include_level=True`.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
