### PR TITLE
Add `data_start` to temporary dtype for `events_nv`

### DIFF
--- a/straxen/plugins/events_nv/event_waveform_nv.py
+++ b/straxen/plugins/events_nv/event_waveform_nv.py
@@ -44,15 +44,13 @@ class nVETOEventWaveform(strax.Plugin):
         self.to_pe[self.channel_range[0] :] = to_pe[:]
 
     def compute(self, events_nv, records_nv, start, end):
-        events = events_nv
-        events_waveform = np.zeros(len(events), self.dtype)
+        events_waveform = np.zeros(len(events_nv), self.dtype)
 
         # Compute shape like properties:
         _tmp_events = np.zeros(len(events_nv), dtype=_temp_event_data_type())
         strax.copy_to_buffer(events_nv, _tmp_events, "_temp_nv_evts_wf_cpy")
         _tmp_events["length"] = (events_nv["endtime"] - events_nv["time"]) // 2
         _tmp_events["dt"] = 2
-        print(records_nv)
         strax.simple_summed_waveform(records_nv, _tmp_events, self.to_pe)
         strax.compute_widths(_tmp_events)
 
@@ -79,11 +77,7 @@ def veto_event_waveform_dtype(
     return dtype
 
 
-def _temp_event_data_type(
-    n_samples_wf: int = 150,
-    n_pmts: int = 120,
-    n_widths: int = 11,
-) -> list:
+def _temp_event_data_type(n_samples_wf: int = 150, n_widths: int = 11) -> list:
     """Temp.
 
     data type which adds field required to use some of the functions used to compute the shape of
@@ -98,6 +92,11 @@ def _temp_event_data_type(
         ),
         (
             ("Dummy top waveform data in PE/sample (not PE/ns!)", "data_top"),
+            np.float32,
+            n_samples_wf,
+        ),
+        (
+            ("Dummy first waveform data in PE/sample (not PE/ns!)", "data_start"),
             np.float32,
             n_samples_wf,
         ),


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Solve https://github.com/XENONnT/straxen/actions/runs/11293456467/job/31411618929. Since the log of auto test will be removed, I paste it here:

```
FAILED tests/plugins/test_plugins.py::PluginTest::test_event_waveform_nv - KeyError: "Field 'data_start' was not found in record with fields ('Start time since unix epoch [ns]', 'time', 'Length of the interval in samples', 'length', 'Width of one sample [ns]', 'dt', 'Waveform data in PE/sample (not PE/ns!)', 'data', 'Width (in ns) of the central 50% area of the peak', 'range_50p_area', 'Width (in ns) of the central 90% area of the peak', 'range_90p_area', 'Time between 10% and 50% area quantiles [ns]', 'rise_time', 'Dummy, total area of all hitlets in event [pe]', 'area', 'Dummy top waveform data in PE/sample (not PE/ns!)', 'data_top', 'Peak widths in range of central area fraction [ns]', 'width', 'Peak widths: time between nth and 5th area decile [ns]', 'area_decile_from_midpoint')"
```

This should not happen in principle, because this calling https://github.com/AxFoundation/strax/blob/a528e4b9b7d452c6c0a654692ed6fb688b4e3aae/strax/processing/peak_building.py#L243 should have used default arguments `store_in_data_top=False, store_waveform_start=False`.

This PR is an expedient that is similar to @WenzDaniel's temp fix in https://github.com/XENONnT/straxen/pull/1228: https://github.com/XENONnT/straxen/pull/1228/files#diff-d040b9831a59099d71fe7f131f13f9eb4cd8312ca0725771e7bccaef133bd515R100.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
