### PR TITLE
Switch to master for docformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         language_version: python3
 
 -   repo: https://github.com/pycqa/docformatter
-    rev: v1.7.5
+    rev: master
     hooks:
     -   id: docformatter
         additional_dependencies: [tomli]


### PR DESCRIPTION
It seems that the maintainers of [docformatter](https://github.com/pycqa/docformatter) don't make new releases frequently (the last one was on July 2023...) 
So we should better use the master branch.

Close: https://github.com/XENONnT/straxen/issues/1450