### PR TITLE
Check RSE in `_find` method of `RucioRemoteFrontend`

### DIFF
--- a/straxen/storage/rucio_remote.py
+++ b/straxen/storage/rucio_remote.py
@@ -71,9 +71,10 @@ class RucioRemoteFrontend(strax.StorageFrontend):
                 "continuous"
             )
         try:
-            rses = [b._get_rse(did, state="OK") for b in self.backends]
-            if rses:
-                return "RucioRemoteBackend", did
+            for b in self.backends:
+                rse = b._get_rse(did, state="OK")
+                if rse:
+                    return "RucioRemoteBackend", did
         except DataIdentifierNotFound:
             pass
 

--- a/straxen/storage/rucio_remote.py
+++ b/straxen/storage/rucio_remote.py
@@ -54,7 +54,7 @@ class RucioRemoteFrontend(strax.StorageFrontend):
         else:
             self.log.warning(
                 "You passed use_remote=True to rucio fronted, "
-                "but you don't have access to admix/rucio! Using local backed only."
+                "but you don't have access to admix/rucio! Using local backend only."
             )
 
     def find_several(self, keys, **kwargs):
@@ -71,8 +71,8 @@ class RucioRemoteFrontend(strax.StorageFrontend):
                 "continuous"
             )
         try:
-            rules = admix.rucio.list_rules(did, state="OK")
-            if len(rules):
+            rses = [b._get_rse(did, state="OK") for b in self.backends]
+            if rses:
                 return "RucioRemoteBackend", did
         except DataIdentifierNotFound:
             pass
@@ -120,7 +120,7 @@ class RucioRemoteBackend(strax.FileSytemBackend):
         self.download_heavy = download_heavy
         self.rses_only = strax.to_str_tuple(rses_only)
 
-    def _get_rse(self, dset_did):
+    def _get_rse(self, dset_did, **filters):
         """Determine the appropriate Rucio Storage Element (RSE) for a dataset.
 
         :param dset_did (str) :The dataset identifier.
@@ -129,7 +129,7 @@ class RucioRemoteBackend(strax.FileSytemBackend):
         Uses self.rses_only to filter available RSEs if set.
 
         """
-        rses = admix.rucio.get_rses(dset_did)
+        rses = admix.rucio.get_rses(dset_did, **filters)
         rses = list(set(rses) & set(self.rses_only)) if self.rses_only else rses
         rse = admix.downloader.determine_rse(rses)
         return rse


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

Only being able to search the rules by `admix.rucio.list_rules` can not ensure the availability of `did`. We need to make sure the procedures to determine whether the data can be found are the same in `RucioRemoteFrontend._find` and `RucioRemoteBackend._get_rse`.

## Can you briefly describe how it works?

Directly use `RucioRemoteBackend._get_rse` in `RucioRemoteFrontend._find`.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
