### PR TITLE
Fixed bug in theta uncertainty in event position contour

### DIFF
--- a/straxen/plugins/events/event_position_uncertainty.py
+++ b/straxen/plugins/events/event_position_uncertainty.py
@@ -300,11 +300,11 @@ class EventPositionUncertainty(strax.Plugin):
             )
             theta_min = np.min(theta_array, axis=1)
             theta_max = np.max(theta_array, axis=1)
-   
+
             # Correction for circular nature of angle (going over pi and -pi boundary)
-            theta_min = (theta_min + np.pi)%(2*np.pi)
-            theta_max = (theta_max + np.pi)%(2*np.pi)
-           
+            theta_min = (theta_min + np.pi) % (2 * np.pi)
+            theta_max = (theta_max + np.pi) % (2 * np.pi)
+
             theta_diff = theta_max - theta_min
 
             # Store uncertainties

--- a/straxen/plugins/events/event_position_uncertainty.py
+++ b/straxen/plugins/events/event_position_uncertainty.py
@@ -224,7 +224,7 @@ class EventPositionUncertainty(strax.Plugin):
 
     """
 
-    __version__ = "0.0.1"
+    __version__ = "0.0.2"
 
     depends_on = ("event_info", "event_position_contour")
     provides = "event_position_uncertainty"
@@ -298,12 +298,18 @@ class EventPositionUncertainty(strax.Plugin):
                 events[f"{type_}_position_contour_cnf_naive"][..., 1],
                 events[f"{type_}_position_contour_cnf_naive"][..., 0],
             )
-            theta_min = np.min(theta_array, axis=1)
-            theta_max = np.max(theta_array, axis=1)
+
+            # Calculate average theta in contour to rotate contour by for correction
+            avg_theta = np.arctan2(
+                np.mean(events[f"{type_}_position_contour_cnf_naive"][..., 1], axis=1),
+                np.mean(events[f"{type_}_position_contour_cnf_naive"][..., 0], axis=1),
+            )
 
             # Correction for circular nature of angle (going over pi and -pi boundary)
-            theta_min = (theta_min + np.pi) % (2 * np.pi)
-            theta_max = (theta_max + np.pi) % (2 * np.pi)
+            avg_theta = np.reshape(avg_theta, (avg_theta.shape[0],1))
+            theta_array_shift = (np.subtract(theta_array, avg_theta) + np.pi)%(2*np.pi)
+            theta_min = np.min(theta_array, axis=1)
+            theta_max = np.max(theta_array, axis=1)
 
             theta_diff = theta_max - theta_min
 

--- a/straxen/plugins/events/event_position_uncertainty.py
+++ b/straxen/plugins/events/event_position_uncertainty.py
@@ -308,8 +308,8 @@ class EventPositionUncertainty(strax.Plugin):
             # Correction for circular nature of angle (going over pi and -pi boundary)
             avg_theta = np.reshape(avg_theta, (avg_theta.shape[0], 1))
             theta_array_shift = (np.subtract(theta_array, avg_theta) + np.pi) % (2 * np.pi)
-            theta_min = np.min(theta_array, axis=1)
-            theta_max = np.max(theta_array, axis=1)
+            theta_min = np.min(theta_array_shift, axis=1)
+            theta_max = np.max(theta_array_shift, axis=1)
 
             theta_diff = theta_max - theta_min
 

--- a/straxen/plugins/events/event_position_uncertainty.py
+++ b/straxen/plugins/events/event_position_uncertainty.py
@@ -306,8 +306,8 @@ class EventPositionUncertainty(strax.Plugin):
             )
 
             # Correction for circular nature of angle (going over pi and -pi boundary)
-            avg_theta = np.reshape(avg_theta, (avg_theta.shape[0],1))
-            theta_array_shift = (np.subtract(theta_array, avg_theta) + np.pi)%(2*np.pi)
+            avg_theta = np.reshape(avg_theta, (avg_theta.shape[0], 1))
+            theta_array_shift = (np.subtract(theta_array, avg_theta) + np.pi) % (2 * np.pi)
             theta_min = np.min(theta_array, axis=1)
             theta_max = np.max(theta_array, axis=1)
 

--- a/straxen/plugins/events/event_position_uncertainty.py
+++ b/straxen/plugins/events/event_position_uncertainty.py
@@ -300,10 +300,12 @@ class EventPositionUncertainty(strax.Plugin):
             )
             theta_min = np.min(theta_array, axis=1)
             theta_max = np.max(theta_array, axis=1)
+   
+            # Correction for circular nature of angle (going over pi and -pi boundary)
+            theta_min = (theta_min + np.pi)%(2*np.pi)
+            theta_max = (theta_max + np.pi)%(2*np.pi)
+           
             theta_diff = theta_max - theta_min
-
-            # Correct for circular nature of angles
-            theta_diff[theta_diff > np.pi] -= 2 * np.pi
 
             # Store uncertainties
             result[f"{type_}_r_position_uncertainty"] = (r_max - r_min) / 2


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
This fixes a bug found by @sebvetter (figure below) in how theta uncertainties were handled due to contours that passed over the -pi and pi boundary. These contours would have an uncertainty that is an order of magnitude smaller than the contours that do not cross this boundary.

![theta_uncertainty_bug_svetter](https://github.com/user-attachments/assets/b6135a06-2597-4d84-ae7c-13b232a22720)

## Can you briefly describe how it works?
The theta uncertainty is calculated as the difference between the min and max theta of a contour. The correction is to rotate the contour around (0,0) by the average $\theta$ within the contour so that the contour is now around $\theta = 0$ to avoid the seam. Then add $\pi$ and modulo $2\pi$ to handle large angular contours, before taking the difference between the minimum and maximum angles.

```
theta_array_shift = (np.subtract(theta_array, avg_theta) + np.pi)%(2*np.pi)
theta_min = np.min(theta_array_shift, axis=1)
theta_max = np.max(theta_array_shift, axis=1)

theta_diff = theta_max - theta_min
```

## Can you give a minimal working example (or illustrate with a figure)?
An example edge case is some generic array around the $-\pi$ and $+\pi$ boundary where the min and max $\theta$ are -3.14 and 3.14 respectively. 
```
test_theta_array = np.hstack([np.random.uniform(3.14, 3.13, 8), np.random.uniform(-3.14, -3.13, 7), np.array([3.14]), np.array([-3.14])])
```
We expect the uncertainty to be `np.pi - 3.14 = 0.0015926535897929917`. 



I have also loaded this with an existing run using a few data points that fall along the -pi and +pi seam. 


### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
