### PR TITLE
Garbage collection after calculated each chunk in `peak_positions_mlp`

### DIFF
--- a/straxen/plugins/peaks/peak_positions_mlp.py
+++ b/straxen/plugins/peaks/peak_positions_mlp.py
@@ -12,6 +12,7 @@ class PeakPositionsMLP(PeakPositionsBaseNT):
 
     provides = "peak_positions_mlp"
     algorithm = "mlp"
+    gc_collect_after_compute = True
 
     tf_model_mlp = straxen.URLConfig(
         default=(


### PR DESCRIPTION
Depends on https://github.com/AxFoundation/strax/pull/922.

Because `peak_positions_mlp` is memory-consuming:

![image](https://github.com/user-attachments/assets/d5993a0d-bd08-48bb-94af-fa5ebcb4e417). Garbage collection after we make increments in the calculation might be helpful.

[slack thread](https://xenonnt.slack.com/archives/C016UJZ090B/p1730856872805989)