### PR TITLE
Clean `deprecate_kwarg`

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -4,7 +4,6 @@ from typing import Dict, Any, List, Optional
 from immutabledict import immutabledict
 import socket
 
-from pandas.util._decorators import deprecate_kwarg
 import strax
 import straxen
 
@@ -164,10 +163,6 @@ def find_rucio_local_path(include_rucio_local, _rucio_local_path):
     return _include_rucio_local, __rucio_local_path
 
 
-@deprecate_kwarg("_minimum_run_number", "minimum_run_number")
-@deprecate_kwarg("_maximum_run_number", "maximum_run_number")
-@deprecate_kwarg("_include_rucio_remote", "include_rucio_remote")
-@deprecate_kwarg("_add_online_monitor_frontend", "include_online_monitor")
 def xenonnt_online(
     output_folder: str = "./strax_data",
     we_are_the_daq: bool = False,


### PR DESCRIPTION
Close: https://github.com/XENONnT/straxen/issues/1469

These `kwargs` should be deprecated because no one should use them since straxen 3.0.0.