### PR TITLE
Exclude non-triggering peaks when assigning main/alt peaks

### DIFF
--- a/straxen/plugins/events/event_basics_som.py
+++ b/straxen/plugins/events/event_basics_som.py
@@ -25,7 +25,3 @@ class EventBasicsSOM(EventBasicsVanilla):
             ("loc_y_som", np.int16, "y location of the peak(let) in the SOM"),
         ]
         self.peak_properties = tuple(self.peak_properties)
-
-    def compute(self, events, peaks):
-        result = super().compute(events, peaks)
-        return result


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Stop S1/2 from being main/alt S1/2 if S1/2 is not included in triggering peaks. However, we should not apply this selection if we do not discriminate if S1 is triggering (`exclude_s1_as_triggering_peaks = True`).

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
