### PR TITLE
Inherit `area_fraction_top`, `center_time` and `median_time` from peaklets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ docs/source/reference/data_kinds*
 docs/source/reference/release_notes.rst
 
 test_dict.json
+
+*.pkl
+*.pkl.gz

--- a/straxen/plugins/events/event_basics_vanilla.py
+++ b/straxen/plugins/events/event_basics_vanilla.py
@@ -114,7 +114,8 @@ class EventBasicsVanilla(strax.Plugin):
         # Properties to store for each peak (main and alternate S1 and S2)
         self.peak_properties = (
             ("time", np.int64, "start time since unix epoch [ns]"),
-            ("center_time", np.int64, "weighted center time since unix epoch [ns]"),
+            ("center_time", np.int64, "weighted average center time since unix epoch [ns]"),
+            ("median_time", np.float32, "weighted relative median time of the peak [ns]"),
             ("endtime", np.int64, "end time since unix epoch [ns]"),
             ("area", np.float32, "area, uncorrected [PE]"),
             ("n_channels", np.int16, "count of contributing PMTs"),

--- a/straxen/plugins/events/event_top_bottom_params.py
+++ b/straxen/plugins/events/event_top_bottom_params.py
@@ -129,7 +129,7 @@ class EventTopBottomParams(strax.Plugin):
                 result[f"{type_}_center_time_{arr_}"][mask] += recalc_ctime[mask].astype(int)
                 # computing widths ##
                 # zero or undefined area peaks should have nans
-                strax.compute_widths(fpeaks_)
+                strax.compute_center_time_widths(fpeaks_)
                 result[f"{type_}_rise_time_{arr_}"][:] = np.nan
                 result[f"{type_}_rise_time_{arr_}"][mask] = -fpeaks_["area_decile_from_midpoint"][
                     mask

--- a/straxen/plugins/events/event_top_bottom_params.py
+++ b/straxen/plugins/events/event_top_bottom_params.py
@@ -91,6 +91,9 @@ class EventTopBottomParams(strax.Plugin):
 
     def compute(self, events):
         result = np.zeros(events.shape, dtype=self.dtype)
+        if not len(events):
+            return result
+
         result["time"], result["endtime"] = events["time"], strax.endtime(events)
         peak_dtype = strax.peak_dtype(n_channels=straxen.n_tpc_pmts, store_data_top=False)
         for type_ in self.ptypes:

--- a/straxen/plugins/events/event_top_bottom_params.py
+++ b/straxen/plugins/events/event_top_bottom_params.py
@@ -129,15 +129,13 @@ class EventTopBottomParams(strax.Plugin):
                 result[f"{type_}_center_time_{arr_}"][mask] += recalc_ctime[mask].astype(int)
                 # computing widths ##
                 # zero or undefined area peaks should have nans
-                strax.compute_properties(fpeaks_)
+                _, width, area_decile_from_midpoint = strax.compute_widths(fpeaks_)
                 result[f"{type_}_rise_time_{arr_}"][:] = np.nan
-                result[f"{type_}_rise_time_{arr_}"][mask] = -fpeaks_["area_decile_from_midpoint"][
-                    mask
-                ][:, 1]
+                result[f"{type_}_rise_time_{arr_}"][mask] = -area_decile_from_midpoint[mask][:, 1]
                 result[f"{type_}_range_50p_area_{arr_}"][:] = np.nan
-                result[f"{type_}_range_50p_area_{arr_}"][mask] = fpeaks_["width"][mask][:, 5]
+                result[f"{type_}_range_50p_area_{arr_}"][mask] = width[mask][:, 5]
                 result[f"{type_}_range_90p_area_{arr_}"][:] = np.nan
-                result[f"{type_}_range_90p_area_{arr_}"][mask] = fpeaks_["width"][mask][:, 9]
+                result[f"{type_}_range_90p_area_{arr_}"][mask] = width[mask][:, 9]
             # Difference between center times of top and bottom arrays
             result[f"{type_}_center_time_diff_top_bot"] = (
                 result[f"{type_}_center_time_top"] - result[f"{type_}_center_time_bot"]

--- a/straxen/plugins/events/event_top_bottom_params.py
+++ b/straxen/plugins/events/event_top_bottom_params.py
@@ -129,7 +129,7 @@ class EventTopBottomParams(strax.Plugin):
                 result[f"{type_}_center_time_{arr_}"][mask] += recalc_ctime[mask].astype(int)
                 # computing widths ##
                 # zero or undefined area peaks should have nans
-                strax.compute_center_time_widths(fpeaks_)
+                strax.compute_properties(fpeaks_)
                 result[f"{type_}_rise_time_{arr_}"][:] = np.nan
                 result[f"{type_}_rise_time_{arr_}"][mask] = -fpeaks_["area_decile_from_midpoint"][
                     mask

--- a/straxen/plugins/events_nv/event_waveform_nv.py
+++ b/straxen/plugins/events_nv/event_waveform_nv.py
@@ -52,7 +52,7 @@ class nVETOEventWaveform(strax.Plugin):
         _tmp_events["length"] = (events_nv["endtime"] - events_nv["time"]) // 2
         _tmp_events["dt"] = 2
         strax.simple_summed_waveform(records_nv, _tmp_events, self.to_pe)
-        strax.compute_center_time_widths(_tmp_events)
+        strax.compute_properties(_tmp_events)
 
         strax.copy_to_buffer(_tmp_events, events_waveform, "_temp_nv_evts_cpy")
         events_waveform["range_50p_area"] = _tmp_events["width"][:, 5]

--- a/straxen/plugins/events_nv/event_waveform_nv.py
+++ b/straxen/plugins/events_nv/event_waveform_nv.py
@@ -52,7 +52,7 @@ class nVETOEventWaveform(strax.Plugin):
         _tmp_events["length"] = (events_nv["endtime"] - events_nv["time"]) // 2
         _tmp_events["dt"] = 2
         strax.simple_summed_waveform(records_nv, _tmp_events, self.to_pe)
-        strax.compute_widths(_tmp_events)
+        strax.compute_center_time_widths(_tmp_events)
 
         strax.copy_to_buffer(_tmp_events, events_waveform, "_temp_nv_evts_cpy")
         events_waveform["range_50p_area"] = _tmp_events["width"][:, 5]
@@ -66,9 +66,7 @@ class nVETOEventWaveform(strax.Plugin):
 def veto_event_waveform_dtype(
     n_samples_wf: int = 200,
 ) -> list:
-    dtype = []
-    dtype += strax.time_dt_fields  # because mutable
-    dtype += [
+    dtype = strax.time_dt_fields + [
         (("Waveform data in PE/sample (not PE/ns!)", "data"), np.float32, n_samples_wf),
         (("Width (in ns) of the central 50% area of the peak", "range_50p_area"), np.float32),
         (("Width (in ns) of the central 90% area of the peak", "range_90p_area"), np.float32),
@@ -100,6 +98,8 @@ def _temp_event_data_type(n_samples_wf: int = 150, n_widths: int = 11) -> list:
             np.float32,
             n_samples_wf,
         ),
+        (("Weighted average center time of the peak [ns]", "center_time"), np.int64),
+        (("Weighted relative median time of the peak [ns]", "median_time"), np.float32),
         (("Peak widths in range of central area fraction [ns]", "width"), np.float32, n_widths),
         (
             ("Peak widths: time between nth and 5th area decile [ns]", "area_decile_from_midpoint"),

--- a/straxen/plugins/merged_s2s/merged_s2s.py
+++ b/straxen/plugins/merged_s2s/merged_s2s.py
@@ -141,19 +141,20 @@ class MergedS2s(strax.OverlapWindowPlugin):
         lh["length"] = lh["right_integration"] - lh["left_integration"]
         lh = strax.sort_by_time(lh)
 
-        _n_top_pmts = self.n_top_pmts if "data_top" in self.dtype.names else -1
+        _store_data_top = "data_top" in self.dtype.names
         _store_data_start = "data_start" in self.dtype.names
         strax.add_lone_hits(
             merged_s2s,
             lh,
             self.to_pe,
-            n_top_channels=_n_top_pmts,
+            n_top_channels=self.n_top_pmts,
+            store_data_top=_store_data_top,
             store_data_start=_store_data_start,
         )
 
-        strax.compute_widths(merged_s2s)
+        strax.compute_center_time_widths(merged_s2s)
 
-        if (_n_top_pmts <= 0) or (not _store_data_start):
+        if (not _store_data_top) or (not _store_data_start):
             merged_s2s = drop_data_field(merged_s2s, self.dtype, "_drop_data_field_merged_s2s")
 
         return merged_s2s

--- a/straxen/plugins/merged_s2s/merged_s2s.py
+++ b/straxen/plugins/merged_s2s/merged_s2s.py
@@ -20,6 +20,10 @@ class MergedS2s(strax.OverlapWindowPlugin):
     data_kind = "merged_s2s"
     provides = "merged_s2s"
 
+    n_tpc_pmts = straxen.URLConfig(type=int, help="Number of TPC PMTs")
+
+    n_top_pmts = straxen.URLConfig(type=int, help="Number of top TPC array PMTs")
+
     s2_merge_max_duration = straxen.URLConfig(
         default=50_000,
         infer_type=False,
@@ -51,10 +55,6 @@ class MergedS2s(strax.OverlapWindowPlugin):
             "It's now possible for a S1 to be inside a S2 post merging"
         ),
     )
-
-    n_top_pmts = straxen.URLConfig(type=int, help="Number of top TPC array PMTs")
-
-    n_tpc_pmts = straxen.URLConfig(type=int, help="Number of TPC PMTs")
 
     merged_s2s_get_window_size_factor = straxen.URLConfig(
         default=5, type=int, track=False, help="Factor of the window size for the merged_s2s plugin"

--- a/straxen/plugins/merged_s2s/merged_s2s.py
+++ b/straxen/plugins/merged_s2s/merged_s2s.py
@@ -152,7 +152,7 @@ class MergedS2s(strax.OverlapWindowPlugin):
             store_data_start=_store_data_start,
         )
 
-        strax.compute_center_time_widths(merged_s2s)
+        strax.compute_properties(merged_s2s, n_top_channels=self.n_top_pmts)
 
         if (not _store_data_top) or (not _store_data_start):
             merged_s2s = drop_data_field(merged_s2s, self.dtype, "_drop_data_field_merged_s2s")

--- a/straxen/plugins/peaklets/peaklet_classification_vanilla.py
+++ b/straxen/plugins/peaklets/peaklet_classification_vanilla.py
@@ -42,8 +42,6 @@ class PeakletClassificationVanilla(strax.Plugin):
         ),
     )
 
-    n_top_pmts = straxen.URLConfig(default=straxen.n_top_pmts, type=int, help="Number of top PMTs")
-
     s1_max_rise_time_post100 = straxen.URLConfig(
         default=200, type=(int, float), help="Maximum S1 rise time for > 100 PE [ns]"
     )
@@ -75,10 +73,6 @@ class PeakletClassificationVanilla(strax.Plugin):
         # Properties needed for classification:
         rise_time = -peaklets["area_decile_from_midpoint"][:, 1]
         n_channels = (peaklets["area_per_channel"] > 0).sum(axis=1)
-        n_top = self.n_top_pmts
-        area_top = peaklets["area_per_channel"][:, :n_top].sum(axis=1)
-        area_total = peaklets["area_per_channel"].sum(axis=1)
-        area_fraction_top = area_top / area_total
 
         is_large_s1 = peaklets["area"] >= 100
         is_large_s1 &= rise_time <= self.s1_max_rise_time_post100
@@ -91,7 +85,7 @@ class PeakletClassificationVanilla(strax.Plugin):
         )
 
         is_small_s1 &= rise_time < self.upper_rise_time_aft_boundary(
-            area_fraction_top,
+            peaklets["area_fraction_top"],
             *self.s1_risetime_aft_parameters,
             *self.s1_flatten_threshold_aft,
         )

--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -260,19 +260,18 @@ class Peaklets(strax.Plugin):
         self.clip_peaklet_times(hitlets, start, end)
         rlinks = strax.record_links(records)
 
-        # If store_data_top is false, don't digitize the top array
-        _n_top_pmts = self.n_top_pmts if self.store_data_top else -1
         strax.sum_waveform(
             peaklets,
             hitlets,
             records,
             rlinks,
             self.to_pe,
-            n_top_channels=_n_top_pmts,
+            n_top_channels=self.n_top_pmts,
+            store_data_top=self.store_data_top,
             store_data_start=self.store_data_start,
         )
 
-        strax.compute_widths(peaklets)
+        strax.compute_center_time_widths(peaklets)
 
         # Split peaks using low-split natural breaks;
         # see https://github.com/XENONnT/straxen/pull/45
@@ -289,7 +288,8 @@ class Peaklets(strax.Plugin):
             filter_wing_width=self.peak_split_filter_wing_width,
             min_area=self.peak_split_min_area,
             do_iterations=self.peak_split_iterations,
-            n_top_channels=_n_top_pmts,
+            n_top_channels=self.n_top_pmts,
+            store_data_top=self.store_data_top,
             store_data_start=self.store_data_start,
         )
 
@@ -306,12 +306,13 @@ class Peaklets(strax.Plugin):
                 self.to_pe,
                 reference_length=self.saturation_reference_length,
                 min_reference_length=self.saturation_min_reference_length,
-                n_top_channels=_n_top_pmts,
+                n_top_channels=self.n_top_pmts,
+                store_data_top=self.store_data_top,
                 store_data_start=self.store_data_start,
             )
 
             # Compute the width again for corrected peaks
-            strax.compute_widths(peaklets, select_peaks_indices=peak_list)
+            strax.compute_center_time_widths(peaklets, select_peaks_indices=peak_list)
 
         # Compute tight coincidence level.
         # Making this a separate plugin would
@@ -347,7 +348,7 @@ class Peaklets(strax.Plugin):
         peaklets["n_hits"] = counts
 
         # Drop the data_top or data_start field
-        if (_n_top_pmts <= 0) or (not self.store_data_start):
+        if (not self.store_data_top) or (not self.store_data_start):
             peaklets = drop_data_field(peaklets, self.dtype_for("peaklets"))
 
         # Check channel of peaklets
@@ -441,6 +442,7 @@ def peak_saturation_correction(
     min_reference_length=20,
     use_classification=False,
     n_top_channels=0,
+    store_data_top=False,
     store_data_start=False,
 ):
     """Correct the area and per pmt area of peaks from saturation.
@@ -538,6 +540,7 @@ def peak_saturation_correction(
         rlinks,
         to_pe,
         n_top_channels,
+        store_data_top,
         store_data_start,
         select_peaks_indices=peak_list,
     )

--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -539,9 +539,9 @@ def peak_saturation_correction(
         records,
         rlinks,
         to_pe,
-        n_top_channels,
-        store_data_top,
-        store_data_start,
+        n_top_channels=n_top_channels,
+        store_data_top=store_data_top,
+        store_data_start=store_data_start,
         select_peaks_indices=peak_list,
     )
     return peak_list

--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -271,7 +271,7 @@ class Peaklets(strax.Plugin):
             store_data_start=self.store_data_start,
         )
 
-        strax.compute_center_time_widths(peaklets)
+        strax.compute_properties(peaklets, n_top_channels=self.n_top_pmts)
 
         # Split peaks using low-split natural breaks;
         # see https://github.com/XENONnT/straxen/pull/45
@@ -312,7 +312,9 @@ class Peaklets(strax.Plugin):
             )
 
             # Compute the width again for corrected peaks
-            strax.compute_center_time_widths(peaklets, select_peaks_indices=peak_list)
+            strax.compute_properties(
+                peaklets, n_top_channels=self.n_top_pmts, select_peaks_indices=peak_list
+            )
 
         # Compute tight coincidence level.
         # Making this a separate plugin would

--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -458,6 +458,8 @@ def peak_saturation_correction(
         samples
     :param use_classification: Option of using classification to pick only S2
     :param n_top_channels: Number of top array channels.
+    :param store_data_top: Boolean which indicates whether to store the top array waveform in the
+        peak.
     :param store_data_start: Boolean which indicates whether to store the first samples of the
         waveform in the peak.
 

--- a/straxen/plugins/peaks/peak_basics_vanilla.py
+++ b/straxen/plugins/peaks/peak_basics_vanilla.py
@@ -1,5 +1,6 @@
 import numpy as np
 import strax
+import straxen
 
 
 export, __all__ = strax.exporter()
@@ -16,6 +17,18 @@ class PeakBasicsVanilla(strax.Plugin):
     __version__ = "0.1.5"
     depends_on = "peaks"
     provides = "peak_basics"
+
+    check_peak_sum_area_rtol = straxen.URLConfig(
+        default=None,
+        track=False,
+        infer_type=False,
+        help=(
+            "Check if the sum area and the sum of area per "
+            "channel are the same. If None, don't do the "
+            "check. To perform the check, set to the desired "
+            " rtol value used e.g. '1e-4' (see np.isclose)."
+        ),
+    )
 
     def infer_dtype(self):
         dtype = strax.time_fields + [

--- a/straxen/plugins/peaks/peak_top_bottom_params.py
+++ b/straxen/plugins/peaks/peak_top_bottom_params.py
@@ -90,7 +90,7 @@ class PeakTopBottomParams(strax.Plugin):
             result[f"center_time_{arr_}"] = peaks["time"]
             result[f"center_time_{arr_}"][mask] += recalc_ctime[mask].astype(int)
             # computing widths times
-            strax.compute_widths(fpeaks_)
+            strax.compute_center_time_widths(fpeaks_)
             result[f"rise_time_{arr_}"][:] = np.nan
             result[f"rise_time_{arr_}"][mask] = -fpeaks_["area_decile_from_midpoint"][mask][:, 1]
             result[f"range_50p_area_{arr_}"][:] = np.nan

--- a/straxen/plugins/peaks/peak_top_bottom_params.py
+++ b/straxen/plugins/peaks/peak_top_bottom_params.py
@@ -90,7 +90,7 @@ class PeakTopBottomParams(strax.Plugin):
             result[f"center_time_{arr_}"] = peaks["time"]
             result[f"center_time_{arr_}"][mask] += recalc_ctime[mask].astype(int)
             # computing widths times
-            strax.compute_center_time_widths(fpeaks_)
+            strax.compute_properties(fpeaks_)
             result[f"rise_time_{arr_}"][:] = np.nan
             result[f"rise_time_{arr_}"][mask] = -fpeaks_["area_decile_from_midpoint"][mask][:, 1]
             result[f"range_50p_area_{arr_}"][:] = np.nan

--- a/tests/test_peaklet_processing.py
+++ b/tests/test_peaklet_processing.py
@@ -18,6 +18,7 @@ def get_filled_peaks(peak_length, data_length, n_widths):
     ]
     if n_widths is not None:
         dtype += [
+            (("median_time of p", "median_time"), np.float64),
             (("width of p", "width"), (np.float64, n_widths)),
             (
                 ("area_decile_from_midpoint of p", "area_decile_from_midpoint"),

--- a/tests/test_peaks.py
+++ b/tests/test_peaks.py
@@ -39,21 +39,6 @@ class TestComputePeakBasics(unittest.TestCase):
 
     @settings(deadline=None)
     @given(
-        strategies.integers(min_value=0, max_value=TEST_DATA_LENGTH - 1),
-    )
-    def test_aft_equals1(self, test_peak_idx):
-        """Fill top array with area 1."""
-        test_data = self.get_test_peaks()
-        test_data[test_peak_idx]["area_per_channel"][: self.n_top] = 1
-        test_data[test_peak_idx]["area"] = np.sum(test_data[test_peak_idx]["area_per_channel"])
-        test_data[test_peak_idx]["data"][: test_data[test_peak_idx]["length"]] = (
-            test_data[test_peak_idx]["area"] / test_data[test_peak_idx]["length"]
-        )
-        peaks = self.peaks_basics.compute(test_data)
-        assert peaks[test_peak_idx]["area_fraction_top"] == 1
-
-    @settings(deadline=None)
-    @given(
         strategies.floats(
             min_value=0,
             max_value=2,


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Depends on https://github.com/AxFoundation/strax/pull/941

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
