### PR TITLE
Stop support for list of "take" protocol

### DIFF
--- a/straxen/config/protocols.py
+++ b/straxen/config/protocols.py
@@ -65,6 +65,8 @@ def read_json(content: str, **kwargs):
 @URLConfig.register("take")
 def get_key(container: Container, take=None, **kwargs):
     """Return a single element of a container."""
+    if not isinstance(container, dict):
+        raise ValueError(f"Container is not a dict but a {type(container)}")
     if take is None:
         return container
     if not isinstance(take, list):

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -350,10 +350,6 @@ class TestURLConfig(unittest.TestCase):
         self.assertEqual(p.test_config, {i: i + 1 for i in range(n)})
 
     def test_list_to_array(self):
-        import pdb
-
-        pdb.set_trace()
-        print("HERE")
         n = 3
         self.st.set_config({"test_config": f"list-to-array://object-list://{n}"})
         p = self.st.get_single_plugin(nt_test_run_id, "test_data")

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -136,11 +136,6 @@ class TestURLConfig(unittest.TestCase):
         p = self.st.get_single_plugin(nt_test_run_id, "test_data")
         self.assertEqual(p.test_config, 999)
 
-    def test_chained(self):
-        self.st.set_config({"test_config": "take://json://[1,2,3]?take=0"})
-        p = self.st.get_single_plugin(nt_test_run_id, "test_data")
-        self.assertEqual(p.test_config, 1)
-
     def test_take_nested(self):
         self.st.set_config({"test_config": 'take://json://{"a":[1,2,3]}?take=a&take=0'})
         p = self.st.get_single_plugin(nt_test_run_id, "test_data")

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -118,7 +118,7 @@ class TestURLConfig(unittest.TestCase):
         self.assertTrue(abs(p.test_config - 219203.49884000001) < 1e-2)
 
     def test_json_protocol(self):
-        self.st.set_config({"test_config": "json://[1,2,3]"})
+        self.st.set_config({"test_config": "json://{'a':[1,2,3]}?take=a"})
         p = self.st.get_single_plugin(nt_test_run_id, "test_data")
         self.assertEqual(p.test_config, [1, 2, 3])
 
@@ -137,7 +137,7 @@ class TestURLConfig(unittest.TestCase):
         self.assertEqual(p.test_config, 999)
 
     def test_take_nested(self):
-        self.st.set_config({"test_config": 'take://json://{"a":[1,2,3]}?take=a&take=0'})
+        self.st.set_config({"test_config": "take://json://{'a':[1,2,3]}?take=a&take=0"})
         p = self.st.get_single_plugin(nt_test_run_id, "test_data")
         self.assertEqual(p.test_config, 1)
 
@@ -431,7 +431,11 @@ class TestURLConfig(unittest.TestCase):
         """Test that pad_array works as expected."""
 
         self.st.set_config(
-            {"test_config": "pad-array://json://[1,2,3]?pad_left=2&pad_right=3&pad_value=0"}
+            {
+                "test_config": (
+                    "pad-array://json://{'a':[1,2,3]}?take=a&pad_left=2&pad_right=3&pad_value=0"
+                )
+            }
         )
         p = self.st.get_single_plugin(nt_test_run_id, "test_data")
         self.assertEqual(len(p.test_config), 8)


### PR DESCRIPTION
To be compatible with python > 3.9.21

In the actions of https://github.com/XENONnT/straxen/pull/1513, I saw errors like

```
FAILED tests/test_url_config.py::TestURLConfig::test_json_protocol - ValueError: '1,2,3' does not appear to be an IPv4 or IPv6 address
```

For python > 3.9.20, the URL should fulfill the test:

> Added checks to ensure that [ bracketed ] hosts found by urllib.parse.urlsplit() are of IPv6 or IPvFuture format.

, this was introduced from https://www.python.org/downloads/release/python-3921/.

So `"take://json://[1,2,3]?take=0"` will not work. But `'take://json://{"a":1}?take=a'` still works.

This PR adds a check in `"take"` protocol to make sure that the `container` is a `dict`.