### PR TITLE
Handle the case where no hitlets are fully contained in peaklets

### DIFF
--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -416,6 +416,10 @@ class Peaklets(strax.Plugin):
     @staticmethod
     def add_hit_features(hitlets, peaklets):
         """Create hits timing features."""
+        peaklets["max_diff"] = -1
+        peaklets["min_diff"] = -1
+        peaklets["first_channel"] = DIGITAL_SUM_WAVEFORM_CHANNEL
+        peaklets["last_channel"] = DIGITAL_SUM_WAVEFORM_CHANNEL
         split_hits = strax.split_by_containment(hitlets, peaklets)
         for peaklet, _hitlets in zip(peaklets, split_hits):
             if len(_hitlets) == 0:

--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -418,6 +418,8 @@ class Peaklets(strax.Plugin):
         """Create hits timing features."""
         split_hits = strax.split_by_containment(hitlets, peaklets)
         for peaklet, _hitlets in zip(peaklets, split_hits):
+            if len(_hitlets) == 0:
+                continue
             argsort = strax.stable_argsort(_hitlets["max_time"])
             sorted_hitlets = _hitlets[argsort]
             time_diff = np.diff(sorted_hitlets["max_time"])


### PR DESCRIPTION
Just a minor fix.

These cases happen because of peaklets splitting and saturation correction.