### PR TITLE
More flexible input of `find_n_competing` function

### DIFF
--- a/straxen/plugins/peaks/peak_proximity.py
+++ b/straxen/plugins/peaks/peak_proximity.py
@@ -12,7 +12,7 @@ class PeakProximity(strax.OverlapWindowPlugin):
     """Look for peaks around a peak to determine how many peaks are in proximity (in time) of a
     peak."""
 
-    __version__ = "0.4.0"
+    __version__ = "0.4.1"
 
     depends_on = "peak_basics"
     dtype = [


### PR DESCRIPTION
The result will only slightly change because of using `center_time`. But make `find_n_competing` take more flexible inputs. Sometimes we can exclude certain types of peaks, like S0. If so, use

```
# only consider S1 and S2 peaks
mask = np.isin(peaks["type"], [1, 2])
windows = strax.touching_windows(peaks[mask], peaks, window=self.nearby_window)
n_left, n_tot = self.find_n_competing(
    peaks[mask], peaks, windows, fraction=self.min_area_fraction
)
```