### PR TITLE
Fix a numerical error bug in `events_nv`

### DIFF
--- a/straxen/plugins/events_mv/events_mv.py
+++ b/straxen/plugins/events_mv/events_mv.py
@@ -54,5 +54,5 @@ class muVETOEvents(nVETOEvents):
     def get_window_size(self):
         return self.event_left_extension_mv + self.event_resolving_time_mv + 1
 
-    def compute(self, hitlets_mv, start, end):
-        return super().compute(hitlets_mv, start, end)
+    def compute(self, hitlets_mv):
+        return super().compute(hitlets_mv)

--- a/straxen/plugins/events_nv/events_nv.py
+++ b/straxen/plugins/events_nv/events_nv.py
@@ -12,7 +12,7 @@ export, __all__ = strax.exporter()
 class nVETOEvents(strax.OverlapWindowPlugin):
     """Plugin which computes the boundaries of veto events."""
 
-    __version__ = "0.1.0"
+    __version__ = "0.1.1"
 
     depends_on = "hitlets_nv"
     provides = "events_nv"

--- a/straxen/plugins/events_nv/events_nv.py
+++ b/straxen/plugins/events_nv/events_nv.py
@@ -50,7 +50,7 @@ class nVETOEvents(strax.OverlapWindowPlugin):
     def get_window_size(self):
         return self.event_left_extension_nv + self.event_resolving_time_nv + 1
 
-    def compute(self, hitlets_nv, start, end):
+    def compute(self, hitlets_nv):
         events, hitlets_ids_in_event = find_veto_events(
             hitlets_nv,
             self.event_min_hits_nv,
@@ -139,9 +139,7 @@ def compute_nveto_event_properties(
             if e["n_hits"] > 1 and e["center_time"]:
                 w = hitlets_in_event["area"] / e["area"]  # normalized weights
                 # Definition of variance
-                e["center_time_spread"] = np.sqrt(
-                    np.sum(w * np.power(t - e["center_time"], 2)) / np.sum(w)
-                )
+                e["center_time_spread"] = np.sqrt(np.sum(w * np.power(t - e["center_time"], 2)))
             else:
                 e["center_time_spread"] = np.inf
 


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

If `hitlets_in_event["area"]` contains positive and negative values with very large absolute values, `np.sum(w)` might be 0 even though `event_area` is not 0.

Also, `np.sum(w)` is always 1.0 then we do not need it.

`start` and `end` are not needed either.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [x] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
