### PR TITLE
Change dark rate monitoring of the software trigger to seconds

### DIFF
--- a/straxen/config/protocols.py
+++ b/straxen/config/protocols.py
@@ -311,3 +311,21 @@ def open_jax_model(model_path: str, **kwargs):
         serialized_jax_object = file_obj.read()
     # Deserialize the JAX object and return its callable function
     return export.deserialize(serialized_jax_object).call
+
+
+@URLConfig.register("runstart")
+def get_run_start(run_id):
+    """Protocol which returns start time of a given run as unix time in ns."""
+    import pytz
+
+    rundb = utilix.xent_collection()
+    doc = rundb.find_one(
+        {"number": int(run_id)},
+        projection={
+            "start": 1,
+        },
+    )
+    start_time = doc["start"]
+    start_time_unix = start_time.replace(tzinfo=pytz.utc).timestamp()
+    start_time_unix = np.int64(start_time_unix) * 10**9
+    return start_time_unix

--- a/straxen/plugins/peaks/peak_proximity.py
+++ b/straxen/plugins/peaks/peak_proximity.py
@@ -12,7 +12,7 @@ class PeakProximity(strax.OverlapWindowPlugin):
     """Look for peaks around a peak to determine how many peaks are in proximity (in time) of a
     peak."""
 
-    __version__ = "0.4.0"
+    __version__ = "0.4.1"
 
     depends_on = "peak_basics"
     dtype = [
@@ -57,7 +57,9 @@ class PeakProximity(strax.OverlapWindowPlugin):
 
     def compute(self, peaks):
         windows = strax.touching_windows(peaks, peaks, window=self.nearby_window)
-        n_left, n_tot = self.find_n_competing(peaks, windows, fraction=self.min_area_fraction)
+        n_left, n_tot = self.find_n_competing(
+            peaks, peaks, windows, fraction=self.min_area_fraction
+        )
 
         t_to_prev_peak = np.ones(len(peaks), dtype=np.int64) * self.peak_max_proximity_time
         t_to_prev_peak[1:] = peaks["time"][1:] - peaks["endtime"][:-1]
@@ -77,15 +79,17 @@ class PeakProximity(strax.OverlapWindowPlugin):
 
     @staticmethod
     @numba.jit(nopython=True, nogil=True, cache=True)
-    def find_n_competing(peaks, windows, fraction):
+    def find_n_competing(peaks_in_roi, peaks, windows, fraction):
         n_left = np.zeros(len(peaks), dtype=np.int32)
         n_tot = n_left.copy()
+        areas_in_roi = peaks_in_roi["area"]
         areas = peaks["area"]
 
+        dig = np.searchsorted(peaks_in_roi["center_time"], peaks["center_time"])
         for i, peak in enumerate(peaks):
             left_i, right_i = windows[i]
             threshold = areas[i] * fraction
-            n_left[i] = np.sum(areas[left_i:i] > threshold)
-            n_tot[i] = n_left[i] + np.sum(areas[i + 1 : right_i] > threshold)
+            n_left[i] = np.sum(areas_in_roi[left_i : dig[i]] > threshold)
+            n_tot[i] = n_left[i] + np.sum(areas_in_roi[dig[i] : right_i] > threshold)
 
         return n_left, n_tot

--- a/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
+++ b/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
@@ -80,7 +80,7 @@ class nVETORecorder(strax.Plugin):
     )
 
     keep_n_seconds_for_monitoring = straxen.URLConfig(
-        default=30,
+        default=10,
         track=False,
         infer_type=False,
         help=(

--- a/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
+++ b/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
@@ -132,10 +132,10 @@ class nVETORecorder(strax.Plugin):
             }
 
         # Keep all raw data for the very first n seconds of a run.
-        # This case is much much more tricky since it can also be just a
-        # subset of a run and in this case we need to make sure to also keep
-        # all fragments of a pulse...
-        # For performance check first very first fragment if in applicable time range:
+        # This case is tricky since it can also be just a
+        # subset of a chunk and in this case we need to make sure to also keep
+        # all fragments of a pulse beyond the first n seconds boundary.
+        # For performance check very first fragment if in applicable time range:
         _is_first_record_at_run_start = raw_records_nv[0]["time"] < (
             self.run_start + self.keep_n_seconds_for_monitoring * 10**9
         )

--- a/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
+++ b/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
@@ -137,7 +137,7 @@ class nVETORecorder(strax.Plugin):
         # all fragments of a pulse...
         # For performance check first very first fragment if in applicable time range:
         _is_first_record_at_run_start = raw_records_nv[0]["time"] < (
-            self.run_start + self.keep_n_seconds_for_monitoring
+            self.run_start + self.keep_n_seconds_for_monitoring * 10**9
         )
         raw_records_to_keep_without_trigger = np.zeros(0, dtype=raw_records_nv.dtype)
 
@@ -148,7 +148,7 @@ class nVETORecorder(strax.Plugin):
                 raw_records_nv["record_i"] * len_data * raw_records_nv["dt"]
             )
             _pulse_is_in_first_n_seconds = pulse_starts < (
-                self.run_start + self.keep_n_seconds_for_monitoring
+                self.run_start + self.keep_n_seconds_for_monitoring * 10**9
             )
 
             # Now divide the data:

--- a/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
+++ b/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
@@ -219,7 +219,8 @@ class nVETORecorder(strax.Plugin):
         lrs["endtime"] = end
 
         # Now combine results of with and without software trigger:
-        rr = np.concatenate([raw_records_to_keep_without_trigger, rr])
+        if _is_first_record_at_run_start:
+            rr = np.concatenate([raw_records_to_keep_without_trigger, rr])
 
         return {
             "raw_records_coin_nv": rr,

--- a/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
+++ b/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
@@ -219,7 +219,7 @@ class nVETORecorder(strax.Plugin):
         lrs["endtime"] = end
 
         # Now combine results of with and without software trigger:
-        rr = np.concatante([raw_records_to_keep_without_trigger, rr])
+        rr = np.concatenate([raw_records_to_keep_without_trigger, rr])
 
         return {
             "raw_records_coin_nv": rr,

--- a/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
+++ b/straxen/plugins/raw_records_coin_nv/nveto_recorder.py
@@ -79,14 +79,21 @@ class nVETORecorder(strax.Plugin):
         help="Crash if any of the pulses in raw_records overlap with others in the same channel",
     )
 
-    keep_n_chunks_for_monitoring = straxen.URLConfig(
-        default=5,
+    keep_n_seconds_for_monitoring = straxen.URLConfig(
+        default=30,
         track=False,
         infer_type=False,
         help=(
-            "How many chunks at a begining of a run should be "
-            "kept to monitor the detector performance."
+            "Number of seconds which should be stored without applying the software trigger."
+            "Use -1 if all records should be kept without applying the software trigger."
         ),
+    )
+
+    run_start = straxen.URLConfig(
+        default="runstart://plugin.run_id?",
+        track=False,
+        infer_type=False,
+        help=("Returns run start in utc unix time in ns."),
     )
 
     def setup(self):
@@ -114,12 +121,8 @@ class nVETORecorder(strax.Plugin):
         if self.check_raw_record_overlaps_nv:
             straxen.check_overlaps(raw_records_nv, n_channels=3000)
 
-        # Cover the case if we do not want to have any coincidence
-        # Keep all raw data for the very first 5 chunks of data for
-        # monitoring purposes.
-        _keep_all_raw_records = (self.coincidence_level_recorder_nv <= 1) or (
-            chunk_i < self.keep_n_chunks_for_monitoring
-        )
+        # Cover the case if we do not want to have any coincidence:
+        _keep_all_raw_records = self.keep_n_seconds_for_monitoring == -1
         if _keep_all_raw_records:
             rr = raw_records_nv
             lrs = np.zeros(0, dtype=self.dtype["lone_raw_record_statistics_nv"])
@@ -127,6 +130,30 @@ class nVETORecorder(strax.Plugin):
                 "raw_records_coin_nv": rr,
                 "lone_raw_record_statistics_nv": lrs,
             }
+
+        # Keep all raw data for the very first n seconds of a run.
+        # This case is much much more tricky since it can also be just a
+        # subset of a run and in this case we need to make sure to also keep
+        # all fragments of a pulse...
+        # For performance check first very first fragment if in applicable time range:
+        _is_first_record_at_run_start = raw_records_nv[0]["time"] < (
+            self.run_start + self.keep_n_seconds_for_monitoring
+        )
+        raw_records_to_keep_without_trigger = np.zeros(0, dtype=raw_records_nv.dtype)
+
+        if _is_first_record_at_run_start:
+            len_data = len(raw_records_nv[0]["data"])
+            # Now compute all pulse starts to make sure that all fragments of a pulse are saved:
+            pulse_starts = raw_records_nv["time"] - (
+                raw_records_nv["record_i"] * len_data * raw_records_nv["dt"]
+            )
+            _pulse_is_in_first_n_seconds = pulse_starts < (
+                self.run_start + self.keep_n_seconds_for_monitoring
+            )
+
+            # Now divide the data:
+            raw_records_to_keep_without_trigger = raw_records_nv[_pulse_is_in_first_n_seconds]
+            raw_records_nv = raw_records_nv[~_pulse_is_in_first_n_seconds]
 
         # Search for hits to define coincidence intervals:
         temp_records = strax.raw_to_records(raw_records_nv)
@@ -190,6 +217,9 @@ class nVETORecorder(strax.Plugin):
         lrs, lr = compute_lone_records(lr, self.channel_map["nveto"], 0)
         lrs["time"] = start
         lrs["endtime"] = end
+
+        # Now combine results of with and without software trigger:
+        rr = np.concatante([raw_records_to_keep_without_trigger, rr])
 
         return {
             "raw_records_coin_nv": rr,


### PR DESCRIPTION
In this PR we change the exception for the software trigger from chunks to seconds. This means that always in the very first N seconds of a run no software trigger is applied. 

The plot below shows the number of raw records fragments per 0.1 s as function of time of a small test run. As it can be seen after 30 s the rate of fragments drops thanks to the software trigger. 

![example](https://github.com/user-attachments/assets/b7973dbe-8219-438f-957b-a2c22925e125)
