### PR TITLE
Drop python 3.9

### DIFF
--- a/.github/workflows/pypi_install.yml
+++ b/.github/workflows/pypi_install.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: "3.10"
 
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -28,8 +28,6 @@ jobs:
 
       - name: Publish a Python distribution to PyPI
         # Do the publishing
-        # Might want to add but does not work on workflow_dispatch :
-        # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: ${{ secrets.token }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,14 +33,12 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python-version: [ "3.9", "3.10" ]
-        test: [ 'coveralls', 'pytest', 'pytest_no_database' ]
+        python-version: ["3.10", "3.11"]
+        test: ["coveralls", "pytest", "pytest_no_database"]
         # Drop some not crucial tests for python 3.10 and 3.11
         exclude:
           - python-version: "3.11"
             test: coveralls
-          - python-version: "3.10"
-            test: pytest_no_database
           - python-version: "3.11"
             test: pytest_no_database
 
@@ -62,6 +60,7 @@ jobs:
           pip install pytest hypothesis coverage coveralls
           pip install git+https://github.com/XENONnT/base_environment.git --force-reinstall
           pip install git+https://github.com/AxFoundation/strax.git --force-reinstall
+          pip install .
 
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.11.0
@@ -103,6 +102,7 @@ jobs:
         run: |
           coverage run --source=straxen -m pytest --durations 0
           coverage report
+
       - name: Coveralls
         # Make the coverage report and upload
         env:
@@ -128,5 +128,6 @@ jobs:
           bash .github/scripts/create_pre_apply_function.sh $HOME
           coverage run --append --source=straxen -m pytest -v
           coveralls --service=github
+
       - name: goodbye
-        run: echo "tests done, bye bye"
+        run: echo 'tests done, bye bye'

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.9 ]
+        python-version: ["3.10"]
     steps:
       - name: Setup python
         uses: actions/setup-python@v5.3.0

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.9"
+    python: "3.10"
 
 python:
   install:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -183,7 +183,7 @@ texinfo_documents = [
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 
 def setup(app):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,9 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "License :: OSI Approved :: BSD License",
   "Natural Language :: English",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Intended Audience :: Science/Research",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Scientific/Engineering :: Physics",
@@ -29,8 +30,8 @@ straxen_print_versions = "straxen.scripts.straxen_print_versions:main"
 straxer = "straxen.scripts.straxer:main"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
-strax = ">=2.0.3"
+python = ">=3.10,<3.13"
+strax = ">=2.0.5"
 bokeh = "*"
 commentjson = "*"
 gitpython = "*"

--- a/straxen/common.py
+++ b/straxen/common.py
@@ -172,7 +172,7 @@ def open_resource(file_name: str, fmt="text"):
 
 
 @export
-def get_resource(x: str, fmt="text"):
+def get_resource(x: str, fmt="text", readable=False):
     """
     Get the resource from an online source to be opened here. We will
         sequentially try the following:
@@ -201,7 +201,7 @@ def get_resource(x: str, fmt="text"):
     elif straxen.uconfig is not None:
         downloader = utilix.mongo_storage.MongoDownloader()
         if x in downloader.list_files():
-            path = downloader.download_single(x)
+            path = downloader.download_single(x, human_readable_file_name=readable)
             return open_resource(path, fmt=fmt)
     # 4. load from URL
     if "://" in x:

--- a/straxen/config/protocols.py
+++ b/straxen/config/protocols.py
@@ -27,12 +27,12 @@ def get_item_or_attr(obj, key, default=None):
 
 
 @URLConfig.register("resource")
-def get_resource(name: str, fmt: str = "text", **kwargs):
+def get_resource(name: str, fmt: str = "text", readable: bool = False, **kwargs):
     """Fetch a straxen resource Allow a direct download using <fmt='abs_path'> otherwise kwargs are
     passed directly to straxen.get_resource."""
     if fmt == "abs_path":
         downloader = utilix.mongo_storage.MongoDownloader()
-        return downloader.download_single(name)
+        return downloader.download_single(name, human_readable_file_name=readable)
     return straxen.get_resource(name, fmt=fmt)
 
 

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -58,7 +58,7 @@ class CorrectedAreas(strax.Plugin):
         "Data will be corrected to this value",
     )
 
-    # se gain for this run, allowing for using CMT. default to online
+    # se gain for this run, allowing for using xedocs. default to online
     se_gain = straxen.URLConfig(
         default="take://objects-to-dict://"
         "xedocs://se_gains"
@@ -67,7 +67,7 @@ class CorrectedAreas(strax.Plugin):
         help="Actual SE gain for a given run (allows for time dependence)",
     )
 
-    # relative extraction efficiency which can change with time and modeled by CMT.
+    # relative extraction efficiency which can change with time and modeled by xedocs.
     rel_extraction_eff = straxen.URLConfig(
         default="take://objects-to-dict://"
         "xedocs://rel_extraction_effs"

--- a/straxen/plugins/events/event_pattern_fit.py
+++ b/straxen/plugins/events/event_pattern_fit.py
@@ -44,8 +44,7 @@ class EventPatternFit(strax.Plugin):
         help="S1 (x, y, z) optical/pattern map.",
         infer_type=False,
         default=(
-            "itp_map://"
-            "resource://"
+            "itp_map://resource://"
             "XENONnT_s1_xyz_patterns_corrected_qes_MCva43fa9b_wires.pkl"
             "?fmt=pkl"
         ),
@@ -55,8 +54,7 @@ class EventPatternFit(strax.Plugin):
         help="S2 (x, y) optical/pattern map.",
         infer_type=False,
         default=(
-            "itp_map://"
-            "resource://"
+            "itp_map://resource://"
             "XENONnT_s2_xy_patterns_LCE_corrected_qes_MCva43fa9b_wires.pkl"
             "?fmt=pkl"
         ),
@@ -66,8 +64,7 @@ class EventPatternFit(strax.Plugin):
         help="S2 (x, y) optical data-driven model",
         infer_type=False,
         default=(
-            "tf://"
-            "resource://"
+            "tf://resource://"
             "XENONnT_s2_optical_map_data_driven_ML_v0_2021_11_25.tar.gz"
             "?custom_objects=plugin.s2_map_custom_objects"
             "&fmt=abs_path"

--- a/straxen/plugins/events/event_positions.py
+++ b/straxen/plugins/events/event_positions.py
@@ -12,8 +12,8 @@ class EventPositions(strax.Plugin):
     """Computes the observed and corrected position for the main S1/S2 pairs in an event.
 
     For XENONnT data, it returns the FDC corrected positions of the
-    default_reconstruction_algorithm. In case the fdc_map is given as a file (not through CMT), then
-    the coordinate system should be given as (x, y, z), not (x, y, drift_time).
+    default_reconstruction_algorithm. In case the fdc_map is given as a file (not through xedocs),
+    then the coordinate system should be given as (x, y, z), not (x, y, drift_time).
 
     """
 

--- a/straxen/plugins/events/event_s1_positions_cnn.py
+++ b/straxen/plugins/events/event_s1_positions_cnn.py
@@ -15,14 +15,14 @@ class EventS1PositionCNN(EventS1PositionBase):
 
     tf_model_s1_cnn = straxen.URLConfig(
         default=(
-            f"tf://"
-            f"resource://"
-            f"xedocs://posrec_models"
-            f"?version=ONLINE"
-            f"&run_id=plugin.run_id"
-            f"&kind=s1_cnn"
-            f"&fmt=abs_path"
-            f"&attr=value"
+            "tf://"
+            "resource://"
+            "xedocs://posrec_models"
+            "?version=ONLINE"
+            "&run_id=plugin.run_id"
+            "&kind=s1_cnn"
+            "&fmt=abs_path"
+            "&attr=value"
         ),
         help=(
             's1 position 3d reconstruction cnn model. Should be opened using the "tf" descriptor. '

--- a/straxen/plugins/peaks/peak_s1_positions_cnn.py
+++ b/straxen/plugins/peaks/peak_s1_positions_cnn.py
@@ -16,14 +16,14 @@ class PeakS1PositionCNN(PeakS1PositionBase):
 
     tf_model_s1_cnn = straxen.URLConfig(
         default=(
-            f"tf://"
-            f"resource://"
-            f"xedocs://posrec_models"
-            f"?version=ONLINE"
-            f"&run_id=plugin.run_id"
-            f"&kind=s1_cnn"
-            f"&fmt=abs_path"
-            f"&attr=value"
+            "tf://"
+            "resource://"
+            "xedocs://posrec_models"
+            "?version=ONLINE"
+            "&run_id=plugin.run_id"
+            "&kind=s1_cnn"
+            "&fmt=abs_path"
+            "&attr=value"
         ),
         help=(
             's1 position 3d reconstruction cnn model. Should be opened using the "tf" descriptor. '

--- a/tests/plugins/peak_building.py
+++ b/tests/plugins/peak_building.py
@@ -68,7 +68,7 @@ def test_tight_coincidence(self: PluginTestCase):
     peaklets = self.st.get_array(self.run_id, "peaklets", progress_bar=False)
     message = "There might be some issue in tight_coincidence."
     sum_tight_coincidence = np.sum(peaklets["tight_coincidence"])
-    assert np.abs(sum_tight_coincidence - 1990) < 5, message
+    assert sum_tight_coincidence == 1991, message
 
 
 if __name__ == "__main__":

--- a/tests/plugins/posrec_plugins.py
+++ b/tests/plugins/posrec_plugins.py
@@ -20,12 +20,12 @@ def test_posrec_set_path(
 
     # Get current config
     plugin = self.st.get_single_plugin(self.run_id, target)
-    cmt_config = plugin.config[config_name]
-    cmt_config_without_tf = cmt_config.replace("tf://", "")
+    config = plugin.config[config_name]
+    config_without_tf = config.replace("tf://", "")
 
     # Hack URLConfigs to give back intermediate results (this should be easier..)
     st_fixed_path = self.st.new_context()
-    st_fixed_path.set_config({config_name: cmt_config_without_tf})
+    st_fixed_path.set_config({config_name: config_without_tf})
     plugin_fixed = st_fixed_path.get_single_plugin(self.run_id, target)
     file_name = getattr(plugin_fixed, config_name)
     self.assertTrue(os.path.exists(file_name))

--- a/tests/plugins/s1_posrec_plugins.py
+++ b/tests/plugins/s1_posrec_plugins.py
@@ -19,11 +19,11 @@ def test_posrec_set_path(
 
     # Get current config
     plugin = self.st.get_single_plugin(self.run_id, target)
-    cmt_config = plugin.config[config_name]
-    cmt_config_without_tf = cmt_config.replace("tf://", "")
+    config = plugin.config[config_name]
+    config_without_tf = config.replace("tf://", "")
     # Hack URLConfigs to give back intermediate results (this should be easier..)
     st_fixed_path = self.st.new_context()
-    st_fixed_path.set_config({config_name: cmt_config_without_tf})
+    st_fixed_path.set_config({config_name: config_without_tf})
     plugin_fixed = st_fixed_path.get_single_plugin(self.run_id, target)
     file_name = getattr(plugin_fixed, config_name)
     self.assertTrue(os.path.exists(file_name))

--- a/tests/test_mini_analyses.py
+++ b/tests/test_mini_analyses.py
@@ -220,7 +220,7 @@ class TestMiniAnalyses(unittest.TestCase):
         )
 
     def test_event_display(self):
-        """Event display plot, needs CMT."""
+        """Event display plot, needs xedocs."""
         self.st.event_display(nt_test_run_id, time_within=self.first_event)
 
     def test_event_display_no_rr(self):

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -161,7 +161,7 @@ class TestURLConfig(unittest.TestCase):
         # Either g1 is 0, bodega changed or someone broke URLConfigs
         self.assertTrue(p.test_config)
 
-    @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test CMT.")
+    @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test xedocs.")
     def test_itp_dict(self, ab_value=20, cd_value=21, dump_as="json"):
         """Test that we are getting ~the same value from interpolating at the central date in a
         dict.
@@ -310,7 +310,7 @@ class TestURLConfig(unittest.TestCase):
         self.assertEqual(filtered2, all_kwargs)
         func2(**filtered2)
 
-    @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test CMT.")
+    @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test xedocs.")
     def test_dry_evaluation(self):
         """Check that running a dry evaluation can be done outside of the context of a URL config
         and yield the same result."""


### PR DESCRIPTION
Similar to https://github.com/AxFoundation/strax/pull/962

We wanted to upgrade to `tensorflow==2.18.0` + `keras==3.8.0`. This is needed if we want to use higher numpy version (numpy>=2) and numba versions.

We tried in https://github.com/XENONnT/straxen/pull/1505#issuecomment-2595984974. But `s2_tf_model` need also be updated https://github.com/XENONnT/straxen/blob/242c8b272bb1ea0329e9bd253024cd7d3a546015/straxen/plugins/events/event_pattern_fit.py#L65 to make the transition.

In this PR, we can not release the constraint of numpy.