### PR TITLE
Make sure all subruns have the same configs

### DIFF
--- a/straxen/config/__init__.py
+++ b/straxen/config/__init__.py
@@ -1,3 +1,4 @@
 from .url_config import *
 from .protocols import *
 from .preprocessors import *
+from .check_superruns import *

--- a/straxen/config/check_superruns.py
+++ b/straxen/config/check_superruns.py
@@ -43,6 +43,7 @@ strax.Context.get_components = get_components_wrapper(strax.Context.get_componen
 
 @strax.Context.add_method
 def _superrun_configs(self, run_id, targets):
+    targets = strax.to_str_tuple(targets)
     plugins = self._get_plugins(targets=targets, run_id=run_id)
     configs = dict()
     for data_type, plugin in plugins.items():

--- a/straxen/config/check_superruns.py
+++ b/straxen/config/check_superruns.py
@@ -78,14 +78,19 @@ def _hashed_url_config(configs):
         # filter out plugin related kwargs
         _extra_kwargs = dict()
         for k, v in extra_kwargs.items():
-            if isinstance(v, str) and straxen.URLConfig.PLUGIN_ATTR_PREFIX not in v:
+            flag = not isinstance(v, str)
+            flag |= isinstance(v, str) and straxen.URLConfig.PLUGIN_ATTR_PREFIX not in v
+            if flag:
                 _extra_kwargs[k] = v
         url = straxen.URLConfig.format_url_kwargs(arg, **_extra_kwargs)
         if "resource" in url:
             protocol, arg, kwargs = straxen.URLConfig.url_to_ast(url)
             while protocol != "resource":
                 protocol, arg, kwargs = arg
-            url = straxen.URLConfig.ast_to_url(arg)
+            if isinstance(arg, tuple):
+                url = straxen.URLConfig.ast_to_url(arg)
+            else:
+                url = arg
         evaluated = straxen.URLConfig.evaluate_dry(url)
         try:
             strax.hashablize(evaluated)

--- a/straxen/config/check_superruns.py
+++ b/straxen/config/check_superruns.py
@@ -1,0 +1,90 @@
+import strax
+import straxen
+
+
+def get_components_wrapper(func):
+    """Check whether all configs for superruns-allowed plugins are the same for subruns."""
+
+    def wrapper(self, run_id, targets=tuple(), **kwargs):
+        is_superrun = run_id.startswith("_")
+        if not is_superrun:
+            return func(self, run_id=run_id, targets=targets, **kwargs)
+
+        configs = self._superrun_configs(run_id, targets)
+        if not configs:
+            return func(self, run_id=run_id, targets=targets, **kwargs)
+        superrun_hashes = {run_id: _hashed_url_config(configs)}
+
+        # collect all url config of all subruns and convert them into hash
+        sub_run_spec = self.run_metadata(run_id, projection="sub_run_spec")["sub_run_spec"]
+        for sub_run_id in sub_run_spec:
+            configs = self._superrun_configs(sub_run_id, targets)
+            superrun_hashes[sub_run_id] = _hashed_url_config(configs)
+
+        # check whether all subruns have the same configs
+        seen = strax.deterministic_hash(superrun_hashes[run_id])
+        for sub_run_id, value in superrun_hashes.items():
+            if seen != strax.deterministic_hash(value):
+                diff = [k for k in value if value[k] != superrun_hashes[run_id][k]]
+                raise ValueError(
+                    "Superrun configs are not the same for all subruns. "
+                    f"Specifically, the following configs are different: {diff}."
+                )
+
+    return wrapper
+
+
+strax.Context.get_components = get_components_wrapper(strax.Context.get_components)
+
+
+@strax.Context.add_method
+def _superrun_configs(self, run_id, targets):
+    plugins = self._get_plugins(targets=targets, run_id=run_id)
+    configs = dict()
+    for data_type, plugin in plugins.items():
+        if plugin.allow_superrun:
+            for k, v in plugin.config.items():
+                if not isinstance(v, str):
+                    continue
+                configs[k] = (v, plugins[data_type])
+    return configs
+
+
+def _hashed_url_config(configs):
+    """Convert all url into string and hash them."""
+    # get all configs for superruns-allowed plugins if they are str
+    hash = dict()
+    for key, value in configs.items():
+        url, plugin = value
+        url = straxen.URLConfig.format_url_kwargs(url)
+        arg, extra_kwargs = straxen.URLConfig.split_url_kwargs(url)
+        # only extract value, avoid attr=map
+        if "attr" in extra_kwargs:
+            extra_kwargs["attr"] = "value"
+        # transform run_id and algorithm from plugin
+        # run_id and algorithm are the only two keys that
+        # can be extracted from plugin for now
+        # if later we have more keys need to be converted from plugin
+        # to make xedocs work, we need to add them here
+        for k in ["run_id", "algorithm"]:
+            if k in extra_kwargs:
+                extra_kwargs[k] = getattr(
+                    plugin,
+                    extra_kwargs[k].partition(straxen.URLConfig.NAMESPACE_SEP)[-1],
+                )
+        # filter out plugin related kwargs
+        _extra_kwargs = dict()
+        for k, v in extra_kwargs.items():
+            if isinstance(v, str) and straxen.URLConfig.PLUGIN_ATTR_PREFIX not in v:
+                _extra_kwargs[k] = v
+        url = straxen.URLConfig.format_url_kwargs(arg, **_extra_kwargs)
+        if "resource" in url:
+            protocol, arg, kwargs = straxen.URLConfig.url_to_ast(url)
+            while protocol != "resource":
+                protocol, arg, kwargs = arg
+            url = straxen.URLConfig.ast_to_url(arg)
+        evaluated = straxen.URLConfig.evaluate_dry(url)
+        if not isinstance(evaluated, str):
+            raise ValueError(f"URL {url} is not evaluated to string.")
+        hash[key] = strax.deterministic_hash(evaluated)
+    return hash

--- a/straxen/config/check_superruns.py
+++ b/straxen/config/check_superruns.py
@@ -7,7 +7,7 @@ def get_components_wrapper(func):
 
     def wrapper(self, run_id, targets=tuple(), **kwargs):
         is_superrun = run_id.startswith("_")
-        if not is_superrun:
+        if not is_superrun or not self.context_config["check_superrun_configs"]:
             return func(self, run_id=run_id, targets=targets, **kwargs)
 
         configs = self._superrun_configs(run_id, targets)

--- a/straxen/config/check_superruns.py
+++ b/straxen/config/check_superruns.py
@@ -7,7 +7,11 @@ def get_components_wrapper(func):
 
     def wrapper(self, run_id, targets=tuple(), **kwargs):
         is_superrun = run_id.startswith("_")
-        if not is_superrun or not self.context_config["check_superrun_configs"]:
+        if (
+            not is_superrun
+            or not self.context_config["check_superrun_configs"]
+            or kwargs.get("combining", False)
+        ):
             return func(self, run_id=run_id, targets=targets, **kwargs)
 
         configs = self._superrun_configs(run_id, targets)

--- a/straxen/test_utils.py
+++ b/straxen/test_utils.py
@@ -112,9 +112,13 @@ def nt_test_context(
         "012882-raw_records-z7q2d2ye2t.tar"
     )
     if keep_default_storage:
-        st.storage += [strax.DataDirectory("./strax_test_data", deep_scan=True)]
+        st.storage += [
+            strax.DataDirectory("./strax_test_data", deep_scan=True, provide_run_metadata=True)
+        ]
     else:
-        st.storage = [strax.DataDirectory("./strax_test_data", deep_scan=True)]
+        st.storage = [
+            strax.DataDirectory("./strax_test_data", deep_scan=True, provide_run_metadata=True)
+        ]
     assert st.is_stored(nt_test_run_id, "raw_records"), os.listdir(st.storage[-1].path)
 
     to_remove = list(deregister)

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -495,7 +495,11 @@ class TestURLConfig(unittest.TestCase):
             json.dump(run_doc, fp, default=json_util.default)
         st.define_run("_" + nt_test_run_id, [nt_test_run_id])
         st.get_components("_" + nt_test_run_id, ("test_data",))
+        default = AlgorithmPlugin.takes_config["superrun_test_config_a"].default
+        st.set_config({"superrun_test_config_a": default.replace("run_id", "_run_id")})
+        with self.assertRaises(NotImplementedError):
+            # the raise NotImplementedError is expected from compute method
+            st.get_components("_" + nt_test_run_id, ("test_data",), combining=True)
         with self.assertRaises(ValueError):
-            default = AlgorithmPlugin.takes_config["superrun_test_config_a"].default
-            st.set_config({"superrun_test_config_a": default.replace("run_id", "_run_id")})
+            # the raise ValueError is expected from get_components in the wrapper
             st.get_components("_" + nt_test_run_id, ("test_data",))

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -15,6 +15,7 @@ import strax
 import straxen
 from straxen.test_utils import nt_test_context, nt_test_run_id
 from straxen.plugins.defaults import DEFAULT_POSREC_ALGO
+from straxen.config.check_superruns import _hashed_url_config
 
 
 class DummyObject:
@@ -474,6 +475,16 @@ class TestURLConfig(unittest.TestCase):
 
     def test_superrun_safeguard(self):
         """Test that the superrun safeguard works as expected."""
+
+        # test all configs can be checked
+        st = self.st.new_context()
+        for data_type in st._plugin_class_registry:
+            if st._plugin_class_registry[data_type].depends_on:
+                st._plugin_class_registry[data_type].allow_superrun = True
+        configs = st._superrun_configs("_" + nt_test_run_id, ("event_info",))
+        print(_hashed_url_config(configs))
+
+        # test the safeguard works
         straxen.config.check_superruns.PLUGIN_ATTR_CONVERT += ["take"]
         st = self.st.new_context()
         st.register((AlgorithmPlugin,))

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -473,6 +473,7 @@ class TestURLConfig(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             straxen.config.check_urls("cmt")
 
+    @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
     def test_superrun_safeguard(self):
         """Test that the superrun safeguard works as expected."""
 


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Depends on https://github.com/AxFoundation/strax/pull/964.
Similar to https://github.com/AxFoundation/strax/pull/934.

Because the time-dependent `URLConfig` are all implemented by xedocs, this PR tries to parse the xedocs URLConfig but not directly call heavy protocols like `tf://` and `itp_map://`.

## Can you briefly describe how it works?

Several things have been done to check the configs of subruns:
1. Remove everything after `resource://` protocol and only compare the file names
2. Assign all `attr` to `value` to only compare the file names
3. Extract the `"run_id", "algorithm"` attributes of the plugin

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
