### PR TITLE
Assign xedocs ONLINE to `som_files`

### DIFF
--- a/straxen/plugins/peaklets/peaklet_classification_som.py
+++ b/straxen/plugins/peaklets/peaklet_classification_som.py
@@ -50,7 +50,8 @@ class PeakletClassificationSOM(PeakletClassificationVanilla):
     )
 
     som_files = straxen.URLConfig(
-        default="resource://xedocs://som_classifiers?attr=value&version=v1&run_id=045000&fmt=npy"
+        default="resource://xedocs://som_classifiers?attr=value"
+        "&version=ONLINE&run_id=pluigin.run_id&fmt=npy"
     )
 
     use_som_as_default = straxen.URLConfig(

--- a/straxen/plugins/peaklets/peaklet_classification_som.py
+++ b/straxen/plugins/peaklets/peaklet_classification_som.py
@@ -51,7 +51,7 @@ class PeakletClassificationSOM(PeakletClassificationVanilla):
 
     som_files = straxen.URLConfig(
         default="resource://xedocs://som_classifiers?attr=value"
-        "&version=ONLINE&run_id=pluigin.run_id&fmt=npy"
+        "&version=ONLINE&run_id=plugin.run_id&fmt=npy"
     )
 
     use_som_as_default = straxen.URLConfig(


### PR DESCRIPTION
Minor fix. It seems previously, people forgot to update this URLConfig.