### PR TITLE
Decorate superrun safeguard as method of `strax.Context`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -55,10 +55,19 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install -y graphviz
 
-      - name: Install requirements
+      - name: Install test tollkits
+        run: pip install pytest hypothesis coverage coveralls
+
+      - name: Install requirements for Python 3.10
+        if: matrix.python-version == '3.10'
+        run: pip install git+https://github.com/XENONnT/base_environment.git@el7.2025.01.3 --force-reinstall
+
+      - name: Install requirements for Python 3.11
+        if: matrix.python-version == '3.11'
+        run: pip install git+https://github.com/XENONnT/base_environment.git --force-reinstall
+
+      - name: Install strax and straxen
         run: |
-          pip install pytest hypothesis coverage coveralls
-          pip install git+https://github.com/XENONnT/base_environment.git --force-reinstall
           pip install git+https://github.com/AxFoundation/strax.git --force-reinstall
           pip install .
 

--- a/straxen/config/check_superruns.py
+++ b/straxen/config/check_superruns.py
@@ -14,16 +14,16 @@ def get_components_wrapper(func):
         ):
             return func(self, run_id=run_id, targets=targets, **kwargs)
 
-        configs = self._superrun_configs(run_id, targets)
+        configs = self.time_dependent_configs(run_id, targets)
         if not configs:
             return func(self, run_id=run_id, targets=targets, **kwargs)
-        superrun_hashes = {run_id: _hashed_url_config(configs)}
+        superrun_hashes = {run_id: self.hashed_url_configs(configs)}
 
         # collect all url config of all subruns and convert them into hash
         sub_run_spec = self.run_metadata(run_id, projection="sub_run_spec")["sub_run_spec"]
         for sub_run_id in sub_run_spec:
-            configs = self._superrun_configs(sub_run_id, targets)
-            superrun_hashes[sub_run_id] = _hashed_url_config(configs)
+            configs = self.time_dependent_configs(sub_run_id, targets)
+            superrun_hashes[sub_run_id] = self.hashed_url_configs(configs)
 
         # check whether all subruns have the same configs
         seen = strax.deterministic_hash(superrun_hashes[run_id])
@@ -38,16 +38,32 @@ def get_components_wrapper(func):
     return wrapper
 
 
+# Manually decorate context class
+strax.Context = strax.takes_config(
+    strax.Option(
+        name="check_superrun_configs",
+        default=True,
+        type=bool,
+        help="If True, check whether all subruns' config are the same.",
+    ),
+    strax.Option(
+        name="plugin_attr_convert",
+        default=("run_id", "algorithm"),
+        type=(list, tuple),
+        help="If True, check whether all subruns' config are the same.",
+    ),
+)(strax.Context)
+# Overwrite get_components method
 strax.Context.get_components = get_components_wrapper(strax.Context.get_components)
 
 
 @strax.Context.add_method
-def _superrun_configs(self, run_id, targets):
+def time_dependent_configs(self, run_id, targets, superrun_only=True):
     targets = strax.to_str_tuple(targets)
     plugins = self._get_plugins(targets=targets, run_id=run_id)
     configs = dict()
     for data_type, plugin in plugins.items():
-        if plugin.allow_superrun:
+        if not superrun_only or (plugin.allow_superrun and superrun_only):
             for k, v in plugin.config.items():
                 if not isinstance(v, str):
                     continue
@@ -55,14 +71,14 @@ def _superrun_configs(self, run_id, targets):
     return configs
 
 
-PLUGIN_ATTR_CONVERT = ["run_id", "algorithm"]
-
-
-def _hashed_url_config(configs):
+@strax.Context.add_method
+def hashed_url_configs(self, configs):
     """Convert all url into string and hash them."""
     # get all configs for superruns-allowed plugins if they are str
     hash = dict()
     for key, value in configs.items():
+        if key == "superrun_test_config_a":
+            print("HERE")
         url, plugin = value
         url = straxen.URLConfig.format_url_kwargs(url)
         arg, extra_kwargs = straxen.URLConfig.split_url_kwargs(url)
@@ -74,7 +90,7 @@ def _hashed_url_config(configs):
         # can be extracted from plugin for now
         # if later we have more keys need to be converted from plugin
         # to make xedocs work, we need to add them here
-        for k in PLUGIN_ATTR_CONVERT:
+        for k in self.context_config["plugin_attr_convert"]:
             if k in extra_kwargs:
                 extra_kwargs[k] = getattr(
                     plugin,
@@ -88,6 +104,11 @@ def _hashed_url_config(configs):
             if flag:
                 _extra_kwargs[k] = v
         url = straxen.URLConfig.format_url_kwargs(arg, **_extra_kwargs)
+        # replace all possible missing attr like in runstart://plugin.run_id
+        # the remaining plugin related attr have not been replaced because they are not kwargs
+        for k in self.context_config["plugin_attr_convert"]:
+            if f"plugin.{k}" in url:
+                url = url.replace(f"plugin.{k}", getattr(plugin, k))
         if "resource" in url:
             protocol, arg, kwargs = straxen.URLConfig.url_to_ast(url)
             while protocol != "resource":

--- a/straxen/config/check_superruns.py
+++ b/straxen/config/check_superruns.py
@@ -39,22 +39,30 @@ def get_components_wrapper(func):
 
 
 # Manually decorate context class
-strax.Context = strax.takes_config(
-    strax.Option(
-        name="check_superrun_configs",
-        default=True,
-        type=bool,
-        help="If True, check whether all subruns' config are the same.",
-    ),
-    strax.Option(
-        name="plugin_attr_convert",
-        default=("run_id", "algorithm"),
-        type=(list, tuple),
-        help="If True, check whether all subruns' config are the same.",
-    ),
-)(strax.Context)
-# Overwrite get_components method
-strax.Context.get_components = get_components_wrapper(strax.Context.get_components)
+_strax_context_decorated = True
+if "check_superrun_configs" not in strax.Context.takes_config:
+    strax.Context = strax.takes_config(
+        strax.Option(
+            name="check_superrun_configs",
+            default=True,
+            type=bool,
+            help="If True, check whether all subruns' config are the same.",
+        ),
+    )(strax.Context)
+    _strax_context_decorated = False
+if "plugin_attr_convert" not in strax.Context.takes_config:
+    strax.Context = strax.takes_config(
+        strax.Option(
+            name="plugin_attr_convert",
+            default=("run_id", "algorithm"),
+            type=(list, tuple),
+            help="The attributes that should be get from the plugin.",
+        ),
+    )(strax.Context)
+    _strax_context_decorated = False
+if not _strax_context_decorated:
+    # Overwrite get_components method
+    strax.Context.get_components = get_components_wrapper(strax.Context.get_components)
 
 
 @strax.Context.add_method

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -15,7 +15,6 @@ import strax
 import straxen
 from straxen.test_utils import nt_test_context, nt_test_run_id
 from straxen.plugins.defaults import DEFAULT_POSREC_ALGO
-from straxen.config.check_superruns import _hashed_url_config
 
 
 class DummyObject:
@@ -482,12 +481,16 @@ class TestURLConfig(unittest.TestCase):
         for data_type in st._plugin_class_registry:
             if st._plugin_class_registry[data_type].depends_on:
                 st._plugin_class_registry[data_type].allow_superrun = True
-        configs = st._superrun_configs("_" + nt_test_run_id, ("event_info",))
-        print(_hashed_url_config(configs))
+        configs = st.time_dependent_configs(
+            "_" + nt_test_run_id, ("event_info", "events_nv", "events_mv")
+        )
+        st.hashed_url_configs(configs)
 
         # test the safeguard works
-        straxen.config.check_superruns.PLUGIN_ATTR_CONVERT += ["take"]
         st = self.st.new_context()
+        st.set_context_config(
+            {"plugin_attr_convert": st.context_config["plugin_attr_convert"] + ("take",)}
+        )
         st.register((AlgorithmPlugin,))
         start = pd.to_datetime(0, unit="ns", utc=True)
         end = pd.to_datetime(1, unit="ns", utc=True)


### PR DESCRIPTION
As the title describes.

The PR also adds special attribute conversion from `plugin` for URLConfig like `runstart://plugin.run_id`, where `plugin.run_id` is plugin attribute but is not `kwargs`.