### PR TITLE
Swap `xenonnt_online` and `xenonnt`

### DIFF
--- a/docs/source/build_datastructure_doc.py
+++ b/docs/source/build_datastructure_doc.py
@@ -147,10 +147,10 @@ def get_context():
     """Need to init a context without initializing the runs_db as that requires the appropriate
     passwords.
 
-    :return: straxen context that mimics the xenonnt_online context without the rundb init
+    :return: straxen context that mimics the xenonnt context without the rundb init
 
     """
-    st = straxen.contexts.xenonnt_online(_database_init=False)
+    st = straxen.contexts.xenonnt(_database_init=False)
     st.context_config["forbid_creation_of"] = straxen.daqreader.DAQReader.provides
     return st
 
@@ -168,7 +168,7 @@ def build_datastructure_doc():
     # Make graph for each suffix ('' referring to TPC)
     for suffix in tree_suffices:
         title = titles[suffix]
-        out = page_header.format(title=title, context="xenonnt_online")
+        out = page_header.format(title=title, context="xenonnt")
 
         print(f"------------ {suffix} ------------")
         os.makedirs(this_dir + f"/graphs{suffix}", exist_ok=True)

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -70,43 +70,6 @@ common_config = dict(
 )
 
 
-@strax.Context.add_method
-def apply_xedocs_configs(context: strax.Context, db="straxen_db", **kwargs) -> None:
-    import xedocs
-
-    if isinstance(db, str):
-        func = getattr(xedocs.databases, db)
-        db_kwargs = straxen.filter_kwargs(func, kwargs)
-        db = func(**db_kwargs)
-
-    filter_kwargs = {k: v for k, v in kwargs.items() if k in db.context_configs.schema.__fields__}
-
-    docs = db.context_configs.find_docs(**filter_kwargs)
-
-    global_config = {doc.config_name: doc.value for doc in docs}
-
-    if len(global_config):
-        context.set_config(global_config)
-        context.set_context_config({"xedocs_version": filter_kwargs["version"]})
-    else:
-        warnings.warn(
-            f"Could not find any context configs matchin {filter_kwargs}",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-
-
-def xenonnt(xedocs_version="global_ONLINE", _from_cutax=False, **kwargs):
-    """XENONnT context."""
-    if not _from_cutax and xedocs_version != "global_ONLINE":
-        warnings.warn("Don't load a context directly from straxen, use cutax instead!")
-
-    st = straxen.contexts.xenonnt_online(**kwargs)
-    st.apply_xedocs_configs(version=xedocs_version, **kwargs)
-
-    return st
-
-
 def find_rucio_local_path(include_rucio_local, _rucio_local_path):
     """Check the hostname to determine which rucio local path to use. Note that access to
     /dali/lgrandi/rucio/ is possible only if you are on dali compute node or login node.
@@ -135,7 +98,7 @@ def find_rucio_local_path(include_rucio_local, _rucio_local_path):
     return _include_rucio_local, __rucio_local_path
 
 
-def xenonnt_online(
+def xenonnt(
     output_folder: str = "./strax_data",
     we_are_the_daq: bool = False,
     minimum_run_number: int = 7157,
@@ -282,7 +245,7 @@ def xenonnt_online(
 
 
 def xenonnt_led(**kwargs):
-    st = xenonnt_online(**kwargs)
+    st = xenonnt(**kwargs)
     st.set_context_config(
         {
             "check_available": ("raw_records", "led_calibration"),
@@ -302,4 +265,41 @@ def xenonnt_led(**kwargs):
         ]
     )
     st.set_config({"coincidence_level_recorder_nv": 1})
+    return st
+
+
+@strax.Context.add_method
+def apply_xedocs_configs(context: strax.Context, db="straxen_db", **kwargs) -> None:
+    import xedocs
+
+    if isinstance(db, str):
+        func = getattr(xedocs.databases, db)
+        db_kwargs = straxen.filter_kwargs(func, kwargs)
+        db = func(**db_kwargs)
+
+    filter_kwargs = {k: v for k, v in kwargs.items() if k in db.context_configs.schema.__fields__}
+
+    docs = db.context_configs.find_docs(**filter_kwargs)
+
+    global_config = {doc.config_name: doc.value for doc in docs}
+
+    if len(global_config):
+        context.set_config(global_config)
+        context.set_context_config({"xedocs_version": filter_kwargs["version"]})
+    else:
+        warnings.warn(
+            f"Could not find any context configs matchin {filter_kwargs}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+def xenonnt_online(xedocs_version="global_ONLINE", _from_cutax=False, **kwargs):
+    """XENONnT context."""
+    if not _from_cutax and xedocs_version != "global_ONLINE":
+        warnings.warn("Don't load a context directly from straxen, use cutax instead!")
+
+    st = straxen.contexts.xenonnt(**kwargs)
+    st.apply_xedocs_configs(version=xedocs_version, **kwargs)
+
     return st

--- a/tests/storage/test_mongo_interactions.py
+++ b/tests/storage/test_mongo_interactions.py
@@ -21,7 +21,7 @@ class TestSelectRuns(unittest.TestCase):
 
         """
         self.assertTrue(check_n_runs >= 1)
-        st = straxen.contexts.xenonnt_online(use_rucio=False)
+        st = straxen.contexts.xenonnt(use_rucio=False)
         run_col = st.storage[0].collection
 
         # Find the latest run in the runs collection

--- a/tests/storage/test_rucio_local.py
+++ b/tests/storage/test_rucio_local.py
@@ -125,7 +125,7 @@ class TestBasics(unittest.TestCase):
 
     def test_load_context_defaults(self):
         """Don't fail immediately if we start a context due to Rucio."""
-        st = straxen.contexts.xenonnt_online(
+        st = straxen.contexts.xenonnt(
             minimum_run_number=10_000,
             maximum_run_number=10_010,
         )

--- a/tests/storage/test_rucio_remote.py
+++ b/tests/storage/test_rucio_remote.py
@@ -14,7 +14,7 @@ class TestRucioRemote(unittest.TestCase):
 
     def get_context(self, download_heavy: bool) -> strax.Context:
         os.makedirs(self.staging_dir, exist_ok=True)
-        context = straxen.contexts.xenonnt_online(
+        context = straxen.contexts.xenonnt(
             output_folder=os.path.join(self.staging_dir, "output"),
             include_rucio_remote=True,
             download_heavy=download_heavy,

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -3,7 +3,7 @@ build the dependencies in the context correctly) See issue #233 and PR #236."""
 
 import unittest
 import straxen
-from straxen.contexts import xenonnt_led, xenonnt_online, xenonnt
+from straxen.contexts import xenonnt_led, xenonnt_online
 
 
 ##
@@ -11,6 +11,7 @@ from straxen.contexts import xenonnt_led, xenonnt_online, xenonnt
 ##
 
 
+@unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
 def test_xenonnt_online():
     st = xenonnt_online(_database_init=False)
     st.search_field("time")
@@ -38,7 +39,7 @@ def test_xenonnt_online_rucio_local():
 
 @unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
 def test_xennonnt():
-    st = xenonnt(_database_init=False)
+    st = xenonnt_online(_database_init=False)
     st.search_field("time")
 
 

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -45,16 +45,3 @@ def test_xennonnt():
 def test_xenonnt_led():
     st = xenonnt_led(_database_init=False)
     st.search_field("time")
-
-
-@unittest.skipIf(not straxen.utilix_is_configured(), "No db access, cannot test!")
-def test_nt_is_nt_online():
-    # Test that nT and nT online are the same
-    st_online = xenonnt_online(_database_init=False)
-
-    st = xenonnt(_database_init=False)
-    for plugin in st._plugin_class_registry.keys():
-        print(f"Checking {plugin}")
-        nt_key = st.key_for("0", plugin)
-        nt_online_key = st_online.key_for("0", plugin)
-        assert str(nt_key) == str(nt_online_key)

--- a/tests/test_holoviews_utils.py
+++ b/tests/test_holoviews_utils.py
@@ -141,7 +141,7 @@ def test_tpc_display_components():
     array_plotter = PlotPMTArrayTPC()
     array_plotter.plot_pmt_array(dummy_peak[0])
 
-    st = straxen.contexts.xenonnt_online(_database_init=False)
+    st = straxen.contexts.xenonnt(_database_init=False)
     p = st.get_single_plugin("0", "event_info")
     dummy_events = np.zeros(10, p.dtype)
     dummy_events[0]["endtime"] = 10
@@ -157,7 +157,7 @@ def test_tpc_display_components():
 
 
 def test_inspector_plot():
-    st = straxen.contexts.xenonnt_online(_database_init=False)
+    st = straxen.contexts.xenonnt(_database_init=False)
     p = st.get_single_plugin("0", "event_info")
     dummy_events = np.zeros(10, p.dtype)
     dummy_events[0]["endtime"] = 10

--- a/tests/test_scada.py
+++ b/tests/test_scada.py
@@ -185,7 +185,7 @@ class SCInterfaceTest(unittest.TestCase):
         See also: xenon:xenon1t:slowcontrol:webservicenew
 
         """
-        st = straxen.contexts.xenonnt_online()
+        st = straxen.contexts.xenonnt()
         self.sc.context = st
         res = self.sc.get_scada_values(
             parameters={"test": "XE1T.CRY_PT101_PCHAMBER_AI.PI"},


### PR DESCRIPTION
Because `xenonnt` uses the default configs, but `xenonnt_online` uses `global_ONLINE`.