### PR TITLE
Remove `event_n_channel`, add `top_n_channels` to `peak_basics`

### DIFF
--- a/straxen/plugins/events/_event_s2_positions_base.py
+++ b/straxen/plugins/events/_event_s2_positions_base.py
@@ -92,7 +92,7 @@ class EventS2PositionBase(strax.Plugin):
             if not np.sum(peak_mask):
                 continue
 
-            _top_pattern = events[p_type + "_area_per_channel"][peak_mask, 0 : self.n_top_pmts]
+            _top_pattern = events[p_type + "_area_per_channel"][peak_mask, : self.n_top_pmts]
             with np.errstate(divide="ignore", invalid="ignore"):
                 _top_pattern = _top_pattern / np.max(_top_pattern, axis=1).reshape(-1, 1)
 

--- a/straxen/plugins/events/event_area_per_channel.py
+++ b/straxen/plugins/events/event_area_per_channel.py
@@ -1,4 +1,3 @@
-from immutabledict import immutabledict
 import numpy as np
 import strax
 import straxen
@@ -11,9 +10,8 @@ class EventAreaPerChannel(strax.Plugin):
     """Simple plugin that provides area per channel for main and alternative S1/S2 in the event."""
 
     depends_on = ("event_basics", "peaks")
-    provides = ("event_area_per_channel", "event_n_channel")
-    data_kind = immutabledict(zip(provides, ("events", "events")))
-    __version__ = "0.1.1"
+    provides = "event_area_per_channel"
+    __version__ = "0.2.0"
 
     compressor = "zstd"
 
@@ -51,48 +49,22 @@ class EventAreaPerChannel(strax.Plugin):
                     pfields_["dt"][0],
                 )
             ]
-        # populating S1 n channel properties
-        n_channel_dtype = [
-            (("Main S1 count of contributing PMTs", "s1_n_channels"), np.int16),
-            (("Main S1 top count of contributing PMTs", "s1_top_n_channels"), np.int16),
-            (("Main S1 bottom count of contributing PMTs", "s1_bottom_n_channels"), np.int16),
-        ]
-        return {
-            "event_area_per_channel": dtype + n_channel_dtype + strax.time_fields,
-            "event_n_channel": n_channel_dtype + strax.time_fields,
-        }
+        dtype += strax.time_fields
+        return dtype
 
     def compute(self, events, peaks):
-        area_per_channel = np.zeros(len(events), self.dtype["event_area_per_channel"])
-        area_per_channel["time"] = events["time"]
-        area_per_channel["endtime"] = strax.endtime(events)
-        n_channel = np.zeros(len(events), self.dtype["event_n_channel"])
-        n_channel["time"] = events["time"]
-        n_channel["endtime"] = strax.endtime(events)
+        result = np.zeros(len(events), self.dtype)
+        result["time"] = events["time"]
+        result["endtime"] = strax.endtime(events)
 
         split_peaks = strax.split_by_containment(peaks, events)
         for event_i, (event, sp) in enumerate(zip(events, split_peaks)):
             for type_ in ["s1", "s2", "alt_s1", "alt_s2"]:
                 type_index = event[f"{type_}_index"]
                 if type_index != -1:
-                    type_area_per_channel = sp["area_per_channel"][type_index]
-                    area_per_channel[f"{type_}_area_per_channel"][event_i] = type_area_per_channel
-                    area_per_channel[f"{type_}_length"][event_i] = sp["length"][type_index]
-                    area_per_channel[f"{type_}_dt"][event_i] = sp["dt"][type_index]
-                    if type_ == "s1":
-                        area_per_channel["s1_n_channels"][event_i] = (
-                            type_area_per_channel > 0
-                        ).sum()
-                        area_per_channel["s1_top_n_channels"][event_i] = (
-                            type_area_per_channel[: self.n_top_pmts] > 0
-                        ).sum()
-                        area_per_channel["s1_bottom_n_channels"][event_i] = (
-                            type_area_per_channel[self.n_top_pmts :] > 0
-                        ).sum()
-        for field in ["s1_n_channels", "s1_top_n_channels", "s1_bottom_n_channels"]:
-            n_channel[field] = area_per_channel[field]
-        result = {
-            "event_area_per_channel": area_per_channel,
-            "event_n_channel": n_channel,
-        }
+                    result[f"{type_}_area_per_channel"][event_i] = sp["area_per_channel"][
+                        type_index
+                    ]
+                    result[f"{type_}_length"][event_i] = sp["length"][type_index]
+                    result[f"{type_}_dt"][event_i] = sp["dt"][type_index]
         return result

--- a/straxen/plugins/events/event_basics_vanilla.py
+++ b/straxen/plugins/events/event_basics_vanilla.py
@@ -17,7 +17,7 @@ class EventBasicsVanilla(strax.Plugin):
 
     """
 
-    __version__ = "1.3.4"
+    __version__ = "1.3.5"
 
     depends_on = ("events", "peak_basics", "peak_positions", "peak_proximity")
     provides = "event_basics"
@@ -139,6 +139,7 @@ class EventBasicsVanilla(strax.Plugin):
             ("endtime", np.int64, "end time since unix epoch [ns]"),
             ("area", np.float32, "area, uncorrected [PE]"),
             ("n_channels", np.int16, "count of contributing PMTs"),
+            ("top_n_channels", np.int16, "count of contributing top PMTs"),
             ("n_hits", np.int32, "count of hits contributing at least one sample to the peak"),
             ("n_competing", np.int32, "number of competing peaks"),
             ("max_pmt", np.int16, "PMT number which contributes the most PE"),

--- a/straxen/plugins/events/event_pattern_fit.py
+++ b/straxen/plugins/events/event_pattern_fit.py
@@ -450,7 +450,7 @@ class EventPatternFit(strax.Plugin):
 
             # Making expectation patterns [ in PE ]
             if np.sum(s2_mask):
-                s2_map_effs = self.s2_pattern_map(np.array([x, y]).T)[s2_mask, 0 : self.n_top_pmts]
+                s2_map_effs = self.s2_pattern_map(np.array([x, y]).T)[s2_mask, : self.n_top_pmts]
                 s2_map_effs = s2_map_effs[:, self.pmtbool_top]
                 s2_top_area = (events[t_ + "_area_fraction_top"] * events[t_ + "_area"])[s2_mask]
                 s2_pattern = (
@@ -459,7 +459,7 @@ class EventPatternFit(strax.Plugin):
 
                 # Getting pattern from data
                 s2_top_area_per_channel = events[t_ + "_area_per_channel"][
-                    s2_mask, 0 : self.n_top_pmts
+                    s2_mask, : self.n_top_pmts
                 ]
                 s2_top_area_per_channel = s2_top_area_per_channel[:, self.pmtbool_top]
 
@@ -498,7 +498,7 @@ class EventPatternFit(strax.Plugin):
             # Produce position and top pattern to feed tensorflow model, return chi2/N
             if np.sum(s2_mask):
                 s2_pos = np.stack((x, y)).T[s2_mask]
-                s2_pat = events[t_ + "_area_per_channel"][s2_mask, 0 : self.n_top_pmts]
+                s2_pat = events[t_ + "_area_per_channel"][s2_mask, : self.n_top_pmts]
                 # Output[0]: loss function, -2*log-likelihood, Output[1]: chi2
                 result[t_ + "_neural_2llh"][s2_mask] = self.model_chi2.predict(
                     {"xx": s2_pos, "yy": s2_pat}, verbose=0

--- a/straxen/plugins/events/event_waveform.py
+++ b/straxen/plugins/events/event_waveform.py
@@ -73,13 +73,6 @@ class EventWaveform(strax.Plugin):
                     pfields_["dt"][0],
                 )
             ]
-
-        # populating S1 n channel properties
-        dtype += [
-            (("Main S1 count of contributing PMTs", "s1_n_channels"), np.int16),
-            (("Main S1 top count of contributing PMTs", "s1_top_n_channels"), np.int16),
-        ]
-
         dtype += strax.time_fields
         return dtype
 
@@ -93,7 +86,6 @@ class EventWaveform(strax.Plugin):
             for type_ in ["s1", "s2", "alt_s1", "alt_s2"]:
                 type_index = event[f"{type_}_index"]
                 if type_index != -1:
-                    type_area_per_channel = sp["area_per_channel"][type_index]
                     result[f"{type_}_length"][event_i] = sp["length"][type_index]
                     result[f"{type_}_data"][event_i] = sp["data"][type_index]
                     if self._have_data("data_top"):
@@ -101,10 +93,4 @@ class EventWaveform(strax.Plugin):
                     if self._have_data("data_start"):
                         result[f"{type_}_data_start"][event_i] = sp["data_start"][type_index]
                     result[f"{type_}_dt"][event_i] = sp["dt"][type_index]
-
-                    if type_ == "s1":
-                        result["s1_n_channels"][event_i] = (type_area_per_channel > 0).sum()
-                        result["s1_top_n_channels"][event_i] = (
-                            type_area_per_channel[: self.n_top_pmts] > 0
-                        ).sum()
         return result

--- a/straxen/plugins/peaklets/_peaklet_positions_base.py
+++ b/straxen/plugins/peaklets/_peaklet_positions_base.py
@@ -91,7 +91,7 @@ class PeakletPositionsBase(strax.Plugin):
             return result
 
         # Getting actual position reconstruction
-        area_per_channel_top = peaklets["area_per_channel"][peak_mask, 0 : self.n_top_pmts]
+        area_per_channel_top = peaklets["area_per_channel"][peak_mask, : self.n_top_pmts]
         with np.errstate(divide="ignore", invalid="ignore"):
             area_per_channel_top = area_per_channel_top / np.max(
                 area_per_channel_top, axis=1

--- a/straxen/plugins/peaklets/peaklet_positions_cnf.py
+++ b/straxen/plugins/peaklets/peaklet_positions_cnf.py
@@ -227,7 +227,7 @@ class PeakletPositionsCNF(PeakletPositionsBase):
             return result
 
         # Prepare input data for the flow model
-        area_per_channel_top = peaklets["area_per_channel"][peaklet_mask, 0 : self.n_top_pmts]
+        area_per_channel_top = peaklets["area_per_channel"][peaklet_mask, : self.n_top_pmts]
         total_top_areas = np.sum(area_per_channel_top, axis=1)
         with np.errstate(divide="ignore", invalid="ignore"):
             flow_data = np.concatenate(

--- a/straxen/plugins/peaks/peak_basics_vanilla.py
+++ b/straxen/plugins/peaks/peak_basics_vanilla.py
@@ -14,7 +14,7 @@ class PeakBasicsVanilla(strax.Plugin):
 
     """
 
-    __version__ = "0.1.6"
+    __version__ = "0.1.7"
     depends_on = "peaks"
     provides = "peak_basics"
 
@@ -30,12 +30,15 @@ class PeakBasicsVanilla(strax.Plugin):
         ),
     )
 
+    n_top_pmts = straxen.URLConfig(default=straxen.n_top_pmts, type=int, help="Number of top PMTs")
+
     def infer_dtype(self):
         dtype = strax.time_fields + [
             (("Weighted average center time of the peak [ns]", "center_time"), np.int64),
             (("Peak integral in PE", "area"), np.float32),
             (("Number of hits contributing at least one sample to the peak", "n_hits"), np.int32),
             (("Number of PMTs contributing to the peak", "n_channels"), np.int16),
+            (("Number of top PMTs contributing to the peak", "top_n_channels"), np.int16),
             (("PMT number which contributes the most PE", "max_pmt"), np.int16),
             (("Area of signal in the largest-contributing PMT (PE)", "max_pmt_area"), np.float32),
             (("Total number of saturated channels", "n_saturated_channels"), np.int16),
@@ -82,6 +85,7 @@ class PeakBasicsVanilla(strax.Plugin):
             r[q] = p[q]
         r["endtime"] = p["time"] + p["dt"] * p["length"]
         r["n_channels"] = (p["area_per_channel"] > 0).sum(axis=1)
+        r["top_n_channels"] = (p["area_per_channel"][: self.n_top_pmts] > 0).sum(axis=1)
         r["n_hits"] = p["n_hits"]
         r["range_50p_area"] = p["width"][:, 5]
         r["range_90p_area"] = p["width"][:, 9]

--- a/straxen/plugins/peaks/peak_basics_vanilla.py
+++ b/straxen/plugins/peaks/peak_basics_vanilla.py
@@ -85,7 +85,7 @@ class PeakBasicsVanilla(strax.Plugin):
             r[q] = p[q]
         r["endtime"] = p["time"] + p["dt"] * p["length"]
         r["n_channels"] = (p["area_per_channel"] > 0).sum(axis=1)
-        r["top_n_channels"] = (p["area_per_channel"][: self.n_top_pmts] > 0).sum(axis=1)
+        r["top_n_channels"] = (p["area_per_channel"][:, : self.n_top_pmts] > 0).sum(axis=1)
         r["n_hits"] = p["n_hits"]
         r["range_50p_area"] = p["width"][:, 5]
         r["range_90p_area"] = p["width"][:, 9]


### PR DESCRIPTION
`event_n_channel` is never necessary and was an expedient when we could not change `event_basics` https://github.com/XENONnT/straxen/pull/1191. In this PR the `n_channel` and `top_n_channel` are stored in `peak_basics` and `event_basics` to simplify the dependency tree, and `event_n_channel` is removed.