### PR TITLE
Set targeted chunk size of peaklet as 2GB

### DIFF
--- a/straxen/plugins/peaklets/peaklets.py
+++ b/straxen/plugins/peaklets/peaklets.py
@@ -42,6 +42,10 @@ class Peaklets(strax.Plugin):
     rechunk_on_load = True
     chunk_source_size_mb = 100
 
+    # To reduce the number of chunks, we increase the target size
+    # This would not harm memory usage, because we rechunk on load
+    chunk_target_size_mb = 2000
+
     __version__ = "1.2.2"
 
     peaklet_gap_threshold = straxen.URLConfig(

--- a/straxen/scripts/bootstrax.py
+++ b/straxen/scripts/bootstrax.py
@@ -45,6 +45,10 @@ from glob import glob
 from straxen import daq_core
 from straxen.daq_core import now
 
+
+# Patch for targeted (uncompressed) chunk size
+straxen.Peaklets.chunk_target_size_mb = strax.DEFAULT_CHUNK_SIZE_MB
+
 parser = argparse.ArgumentParser(description="XENONnT online processing manager")
 parser.add_argument(
     "--debug", action="store_true", help="Start strax processes with debug logging."


### PR DESCRIPTION
To reduce the number of chunks of peaklets.

2GB peaklets seem to increase memory usage. But because the peaklets are rechunked when loading, the memory usage will not be very high.