### PR TITLE
Added more colors+types to waveform_plot

### DIFF
--- a/straxen/analyses/bokeh_waveform_plot.py
+++ b/straxen/analyses/bokeh_waveform_plot.py
@@ -486,7 +486,7 @@ def plot_peaks(peaks, time_scalar=1, fig=None, colors=("gray", "blue", "green"),
     if not fig:
         fig = straxen.bokeh_utils.default_fig(width=1600, height=400, y_axis_type=yscale)
 
-    for i in range(0, 3):
+    for i in np.unique(peaks["type"]):
         _ind = np.where(peaks["type"] == i)[0]
         if not len(_ind):
             continue
@@ -498,19 +498,20 @@ def plot_peaks(peaks, time_scalar=1, fig=None, colors=("gray", "blue", "green"),
             keep_amplitude_per_sample=False,
         )
 
+        _i = i if i < len(colors) else 0
         fig.patches(
             source=source,
-            fill_color=colors[i],
+            fill_color=colors[_i],
             fill_alpha=0.2,
-            line_color=colors[i],
+            line_color=colors[_i],
             line_width=0.5,
-            legend_label=LEGENDS[i],
-            name=LEGENDS[i],
+            legend_label=LEGENDS[_i],
+            name=LEGENDS[_i],
         )
 
         tt = straxen.bokeh_utils.peak_tool_tip(i)
         tt = [v for k, v in tt.items() if k != "time_dynamic"]
-        fig.add_tools(bokeh.models.HoverTool(name=LEGENDS[i], tooltips=tt))
+        fig.add_tools(bokeh.models.HoverTool(name=LEGENDS[_i], tooltips=tt))
         fig.add_tools(bokeh.models.WheelZoomTool(dimensions="width", name="wheel"))
         fig.toolbar.active_scroll = [t for t in fig.tools if t.name == "wheel"][0]
 

--- a/straxen/analyses/holoviews_waveform_display.py
+++ b/straxen/analyses/holoviews_waveform_display.py
@@ -345,7 +345,7 @@ def hvdisp_plot_peak_waveforms(
     for p in peaks:
         # label = {1: 's1', 2: 's2'}.get(
         #     p['type'], 'unknown')
-        color = {1: "b", 2: "g"}.get(p["type"], "k")
+        color = {1: "blue", 2: "green"}.get(p["type"], "k")
 
         # It's better to plot amplitude /time than per bin, since
         # sampling times are now variable

--- a/straxen/analyses/waveform_plot.py
+++ b/straxen/analyses/waveform_plot.py
@@ -84,7 +84,13 @@ def plot_peaks(
     peaks = strax.sort_by_time(peaks)
 
     for p in peaks:
-        plot_peak(p, t0=t_reference, color={-1:'black', 0:'gray',1:'b',2:'g',3:'purple',20:'orange',22:'teal'}[p["type"]])
+        plot_peak(
+            p,
+            t0=t_reference,
+            color={-1: "black", 0: "gray", 1: "b", 2: "g", 3: "purple", 20: "orange", 22: "teal"}[
+                p["type"]
+            ],
+        )
 
     if xaxis == "since_start":
         seconds_range_xaxis(seconds_range, t0=seconds_range[0])

--- a/straxen/analyses/waveform_plot.py
+++ b/straxen/analyses/waveform_plot.py
@@ -83,14 +83,9 @@ def plot_peaks(
     peaks = peaks[strax.stable_argsort(-peaks["area"])[:show_largest]]
     peaks = strax.sort_by_time(peaks)
 
+    color_map = {1: "blue", 2: "green"}
     for p in peaks:
-        plot_peak(
-            p,
-            t0=t_reference,
-            color={-1: "black", 0: "gray", 1: "b", 2: "g", 3: "purple", 20: "orange", 22: "teal"}[
-                p["type"]
-            ],
-        )
+        plot_peak(p, t0=t_reference, color=color_map.get(p["type"], "gray"))
 
     if xaxis == "since_start":
         seconds_range_xaxis(seconds_range, t0=seconds_range[0])

--- a/straxen/analyses/waveform_plot.py
+++ b/straxen/analyses/waveform_plot.py
@@ -84,7 +84,7 @@ def plot_peaks(
     peaks = strax.sort_by_time(peaks)
 
     for p in peaks:
-        plot_peak(p, t0=t_reference, color={0: "gray", 1: "b", 2: "g"}[p["type"]])
+        plot_peak(p, t0=t_reference, color={-1:'black', 0:'gray',1:'b',2:'g',3:'purple',20:'orange',22:'teal'}[p["type"]])
 
     if xaxis == "since_start":
         seconds_range_xaxis(seconds_range, t0=seconds_range[0])

--- a/straxen/bokeh_utils.py
+++ b/straxen/bokeh_utils.py
@@ -57,6 +57,7 @@ def get_peaks_source(peaks, relative_start=0, time_scaler=1, keep_amplitude_per_
 
     source = bklt.ColumnDataSource(
         data={
+            "type": peaks["type"],
             "xs": x_p,  # Coordinates for peak patches
             "ys": y_p,
             "x": peaks["x"],  # XY-Pos in PMZ Hitpattern
@@ -118,12 +119,13 @@ def peak_tool_tip(peak_type):
 
     """
 
+    tool_tip = dict()
+    tool_tip["type"] = ("type", "@type")
+
     # Add static time parameters:
-    tool_tip = {
-        "time_static": ("time [ns]", "@time"),
-        "center_time": ("center_time [ns]", "@center_time"),
-        "endtime": ("endtime [ns]", "@endtime"),
-    }
+    tool_tip["time_static"] = ("time [ns]", "@time")
+    tool_tip["center_time"] = ("center_time [ns]", "@center_time")
+    tool_tip["endtime"] = ("endtime [ns]", "@endtime")
 
     # Now ns/µs parameters for S1 and S2
     tool_tip["dt"] = ("dt [ns/sample]", "@dt")


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
Due to recent low level changes (i.e. classification, merging, etc.) the ["type"] field of peaks has more than just [0,1,2]. Instead we can find [-1,0,1,2,3,20,22]. When using the plot_waveform function this results in a key error, because of this line:
`plot_peak(p, t0=t_reference, color={0: "gray", 1: "b", 2: "g"}[p["type"]])`
## Can you briefly describe how it works?
This is fixed by extending the dictionary, which assigns a color to the other types (image added below):
`plot_peak(p, t0=t_reference, color={-1:"black", 0:"gray",1:"b",2:"g",3:"purple",20:"orange",22:"teal"}[p["type"]])`
## Can you give a minimal working example (or illustrate with a figure)?
Here the image with the different colors
![ColorsWaveform](https://github.com/user-attachments/assets/7cff9311-650e-40b5-86c9-726e55de14d5)
