### PR TITLE
Update print_versions to include all local packages

### DIFF
--- a/straxen/misc.py
+++ b/straxen/misc.py
@@ -92,6 +92,7 @@ def print_versions(
     include_python=True,
     return_string=False,
     include_git=True,
+    include_all_local=True
 ):
     """Print versions of modules installed.
 
@@ -99,6 +100,7 @@ def print_versions(
         print_versions(modules=('numpy', 'dddm',))
     :param return_string: optional. Instead of printing the message, return a string
     :param include_git: Include the current branch and latest commit hash
+    :param include_all_local: Include all local modules (not in /opt/XENONnT/).
     :return: optional, the message that would have been printed
 
     """
@@ -108,6 +110,17 @@ def print_versions(
         versions["version"] = [python_version()]
         versions["path"] = [sys.executable]
         versions["git"] = [None]
+        
+    local_modules = []
+    if include_all_local:
+        for mod_name, mod in sys.modules.items():
+            mod_version = getattr(mod, '__version__', None)
+            mod_file = getattr(mod, '__file__', '')
+            if mod_version and mod_file and not mod_file.startswith("/opt/XENONnT/"):
+                # include top-level module only
+                local_modules.append(mod_name.split('.')[0])  
+
+    modules = list(set(modules) | set(local_modules))
     for m in strax.to_str_tuple(modules):
         result = _version_info_for_module(m, include_git=include_git)
         if result is None:


### PR DESCRIPTION
With this simple PR I would like to propose an enhancement for print_versions(). 
With the proposed change, print_versions will by default print all the versions of the loaded python modules that are not sourced from an /opt/XENONnT path (the container path). 
I think this is very useful and educative as it keeps all of us always aware of which packages we are using. Because we are used to work with containers, we think we always use the packages in the containers, but this does not hold if we have locally installed packages. In this way, it's more in your eyes :) 