### PR TITLE
Warn `xedocs_version` usage in `xenonnt`

### DIFF
--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -154,6 +154,11 @@ def xenonnt(
     :return: strax.Context
 
     """
+    if "xedocs_version" in kwargs:
+        raise ValueError(
+            "Please use xenonnt_* instead of xenonnt if you want to specify xedocs_version"
+        )
+
     context_options = {**straxen.contexts.common_opts, **kwargs}
 
     st = strax.Context(config=straxen.contexts.common_config, **context_options)
@@ -248,6 +253,17 @@ def xenonnt(
     )
 
     return st
+
+
+if "xedocs_version" not in strax.Context.takes_config:
+    strax.Context = strax.takes_config(
+        strax.Option(
+            name="xedocs_version",
+            default=None,
+            type=str,
+            help="The version of the xedocs database to use",
+        ),
+    )(strax.Context)
 
 
 @strax.Context.add_method

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -155,7 +155,7 @@ def xenonnt(
 
     """
     if "xedocs_version" in kwargs:
-        raise ValueError(
+        warnings.warn(
             "Please use xenonnt_* instead of xenonnt if you want to specify xedocs_version"
         )
 


### PR DESCRIPTION
The plot below shows the functionality of different functions to initialize contexts.

![xenonnt drawio](https://github.com/user-attachments/assets/e592f0d6-4ead-4252-9f25-303e8e9c667b)

`xedocs_version` should be used either in `xenonnt_online` and `xenonnt_offline`.