### PR TITLE
Make sure `version=ONLINE` is not used when global version is not `global_ONLINE`

### DIFF
--- a/straxen/config/__init__.py
+++ b/straxen/config/__init__.py
@@ -2,3 +2,4 @@ from .url_config import *
 from .protocols import *
 from .preprocessors import *
 from .check_superruns import *
+from .check_global_version import *

--- a/straxen/config/check_global_version.py
+++ b/straxen/config/check_global_version.py
@@ -9,7 +9,7 @@ def check_global_version_wrapper(func):
         if (
             not self.context_config["check_global_version_configs"]
             or "xedocs_version" not in self.context_config
-            or self.context_config["xedocs_version"] is not None
+            or self.context_config["xedocs_version"] is None
             or self.context_config["xedocs_version"] == "global_ONLINE"
         ):
             return func(self, run_id=run_id, targets=targets, **kwargs)

--- a/straxen/config/check_global_version.py
+++ b/straxen/config/check_global_version.py
@@ -1,0 +1,67 @@
+import strax
+import straxen
+
+
+def check_global_version_wrapper(func):
+    """Check whether all configs for superruns-allowed plugins are the same for subruns."""
+
+    def wrapper(self, run_id, targets=tuple(), **kwargs):
+        if (
+            not self.context_config["check_global_version_configs"]
+            or "xedocs_version" not in self.context_config
+            or self.context_config["xedocs_version"] == "global_ONLINE"
+        ):
+            return func(self, run_id=run_id, targets=targets, **kwargs)
+
+        configs = self.versioned_configs(run_id, targets)
+        if not configs:
+            return func(self, run_id=run_id, targets=targets, **kwargs)
+
+        for key, value in configs.items():
+            url, plugin = value
+            arg, extra_kwargs = straxen.URLConfig.split_url_kwargs(url)
+            if extra_kwargs["version"] == "ONLINE":
+                raise ValueError(
+                    f"The global version is set to be {self.context_config['xedocs_version']}. "
+                    f"But {plugin.__class__.__name__} is still using ONLINE version "
+                    f"config {key}, which is {url}."
+                )
+
+        return func(self, run_id=run_id, targets=targets, **kwargs)
+
+    return wrapper
+
+
+# Manually decorate context class
+_strax_context_check_global_version_decorated = True
+if "check_global_version_configs" not in strax.Context.takes_config:
+    strax.Context = strax.takes_config(
+        strax.Option(
+            name="check_global_version_configs",
+            default=True,
+            type=bool,
+            help=(
+                "If True, check whether version=ONLINE is not used "
+                "when global version is not global_ONLINE."
+            ),
+        ),
+    )(strax.Context)
+    _strax_context_check_global_version_decorated = False
+if not _strax_context_check_global_version_decorated:
+    # Overwrite get_components method
+    strax.Context.get_components = check_global_version_wrapper(strax.Context.get_components)
+
+
+@strax.Context.add_method
+def versioned_configs(self, run_id, targets, superrun_only=True):
+    targets = strax.to_str_tuple(targets)
+    plugins = self._get_plugins(targets=targets, run_id=run_id)
+    configs = dict()
+    for data_type, plugin in plugins.items():
+        for k, v in plugin.config.items():
+            if not isinstance(v, str):
+                continue
+            arg, extra_kwargs = straxen.URLConfig.split_url_kwargs(v)
+            if "version" in extra_kwargs:
+                configs[k] = (v, plugins[data_type])
+    return configs

--- a/straxen/config/check_global_version.py
+++ b/straxen/config/check_global_version.py
@@ -9,6 +9,7 @@ def check_global_version_wrapper(func):
         if (
             not self.context_config["check_global_version_configs"]
             or "xedocs_version" not in self.context_config
+            or self.context_config["xedocs_version"] is not None
             or self.context_config["xedocs_version"] == "global_ONLINE"
         ):
             return func(self, run_id=run_id, targets=targets, **kwargs)

--- a/straxen/config/check_superruns.py
+++ b/straxen/config/check_superruns.py
@@ -2,7 +2,7 @@ import strax
 import straxen
 
 
-def get_components_wrapper(func):
+def check_superruns_wrapper(func):
     """Check whether all configs for superruns-allowed plugins are the same for subruns."""
 
     def wrapper(self, run_id, targets=tuple(), **kwargs):
@@ -41,7 +41,7 @@ def get_components_wrapper(func):
 
 
 # Manually decorate context class
-_strax_context_decorated = True
+_strax_context_check_superruns_decorated = True
 if "check_superrun_configs" not in strax.Context.takes_config:
     strax.Context = strax.takes_config(
         strax.Option(
@@ -51,7 +51,7 @@ if "check_superrun_configs" not in strax.Context.takes_config:
             help="If True, check whether all subruns' config are the same.",
         ),
     )(strax.Context)
-    _strax_context_decorated = False
+    _strax_context_check_superruns_decorated = False
 if "plugin_attr_convert" not in strax.Context.takes_config:
     strax.Context = strax.takes_config(
         strax.Option(
@@ -61,10 +61,10 @@ if "plugin_attr_convert" not in strax.Context.takes_config:
             help="The attributes that should be get from the plugin.",
         ),
     )(strax.Context)
-    _strax_context_decorated = False
-if not _strax_context_decorated:
+    _strax_context_check_superruns_decorated = False
+if not _strax_context_check_superruns_decorated:
     # Overwrite get_components method
-    strax.Context.get_components = get_components_wrapper(strax.Context.get_components)
+    strax.Context.get_components = check_superruns_wrapper(strax.Context.get_components)
 
 
 @strax.Context.add_method
@@ -87,8 +87,6 @@ def hashed_url_configs(self, configs):
     # get all configs for superruns-allowed plugins if they are str
     hash = dict()
     for key, value in configs.items():
-        if key == "superrun_test_config_a":
-            print("HERE")
         url, plugin = value
         url = straxen.URLConfig.format_url_kwargs(url)
         arg, extra_kwargs = straxen.URLConfig.split_url_kwargs(url)

--- a/tests/test_url_config.py
+++ b/tests/test_url_config.py
@@ -517,7 +517,7 @@ class TestURLConfig(unittest.TestCase):
 
         # test all configs can be checked
         st = self.st.new_context()
-        st.set_context_config({"global_version": "global_OFFLINE"})
+        st.set_context_config({"xedocs_version": "global_OFFLINE"})
         st.register((AlgorithmPlugin,))
         st.set_config({"global_version_test_config": "format://{version}?version=ONLINE"})
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Similar to https://github.com/XENONnT/straxen/pull/1546

Sometimes you might forget to overwrite some config when initializing the offline context. This happens when the offline global config does not provide enough configuration.

To bypass the check, run

```
st.set_context_config({'check_global_version_configs': False})
```