### PR TITLE
Add relative z- t- dependent LY correction

### DIFF
--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -214,7 +214,7 @@ class CorrectedAreas(strax.Plugin):
         b = self.b_rel_light_yield
 
         # Compute full z- and t-dependent correction
-        rel_ly_zt_corr = self.rel_light_yield * (a * (events["z"]**2 + b * events["z"]) + 1)
+        rel_ly_zt_corr = self.rel_light_yield * (a * (events["z"] ** 2 + b * events["z"]) + 1)
 
         return rel_ly_zt_corr
 

--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -218,13 +218,12 @@ class CorrectedAreas(strax.Plugin):
 
         return seg, avg_seg, ee
 
-
     def rel_light_yield_correction(self, events):
         """Compute relative light yield correction (z- and t-dependent)."""
 
         z = events["z"]
         time = events["time"]
-        
+
         relLY = self.rel_light_yield
         slope = self.slope_rel_ly[self.sr]
         a = slope * (relLY - 1)
@@ -241,7 +240,6 @@ class CorrectedAreas(strax.Plugin):
         relLY_corr[lowPI_selection] = relLY
 
         return relLY_corr
-    
 
     def compute(self, events):
         result = np.zeros(len(events), self.dtype)
@@ -260,7 +258,7 @@ class CorrectedAreas(strax.Plugin):
                 event_positions
             )
 
-            # Apply relative LY correction 
+            # Apply relative LY correction
             relLY_corr = self.rel_light_yield_correction(events)
             result[f"{peak_type}cs1"] = result[f"{peak_type}cs1_wo_timecorr"] / relLY_corr
 


### PR DESCRIPTION
Adding a relative z- t- dependent LY correction, as described in [this note ](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:lucchetti:xenonnt:sr2:relativelycorrection).

As discussed in the [slack thread](https://xenonnt.slack.com/archives/C049JJZ2U3A/p1746798697119419), we apply the z- dependent correction only until the low PI period, as a conservative approach.

_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
