### PR TITLE
Use numbered version of `docformatter`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         language_version: python3
 
 -   repo: https://github.com/pycqa/docformatter
-    rev: master
+    rev: v1.7.6
     hooks:
     -   id: docformatter
         additional_dependencies: [tomli]


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Since https://github.com/PyCQA/docformatter/issues/293 is closed and v1.7.6 `docformatter` is released, we should be back to the numbered version.

This PR fixes further https://github.com/XENONnT/straxen/issues/1450.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
