### PR TITLE
Force `steps_per_execution` to be not None

### DIFF
--- a/straxen/plugins/peaklets/_peaklet_positions_base.py
+++ b/straxen/plugins/peaklets/_peaklet_positions_base.py
@@ -75,13 +75,15 @@ class PeakletPositionsBase(strax.Plugin):
                 f"Setting model to None for {self.__class__.__name__} will "
                 f"set only nans as output for {self.algorithm}"
             )
+        else:
+            if self.fix_steps_per_execution and hasattr(model, "steps_per_execution"):
+                if getattr(model, "steps_per_execution", None) is None:
+                    model.steps_per_execution = 1
         if isinstance(model, str):
             raise ValueError(
                 f"open files from tf:// protocol! Got {model} "
                 "instead, see tests/test_posrec.py for examples."
             )
-        if getattr(model, "steps_per_execution", None) is None:
-            model.steps_per_execution = 1
         return model
 
     def compute(self, peaklets):

--- a/straxen/plugins/peaklets/_peaklet_positions_base.py
+++ b/straxen/plugins/peaklets/_peaklet_positions_base.py
@@ -33,6 +33,16 @@ class PeakletPositionsBase(strax.Plugin):
         default=straxen.n_top_pmts, infer_type=False, help="Number of top PMTs"
     )
 
+    fix_steps_per_execution = straxen.URLConfig(
+        track=False,
+        default=True,
+        infer_type=False,
+        help=(
+            "Fix steps_per_execution to 1 for the model, "
+            "this is a patch when keras and tensorflow are not fully compatible"
+        ),
+    )
+
     def infer_dtype(self):
         if self.algorithm is None:
             raise NotImplementedError(
@@ -70,6 +80,8 @@ class PeakletPositionsBase(strax.Plugin):
                 f"open files from tf:// protocol! Got {model} "
                 "instead, see tests/test_posrec.py for examples."
             )
+        if getattr(model, "steps_per_execution", None) is None:
+            model.steps_per_execution = 1
         return model
 
     def compute(self, peaklets):


### PR DESCRIPTION
keras 2 and tensorflow > 2.14.x are not fully compatible so even only running `model.predict`, `model.steps_per_execution` will be invoked. But `model.steps_per_execution` might be `None` which cause error. This PR manually set `model.steps_per_execution` as 1.