### PR TITLE
Set Sum(S2 / dt) as S2 Time Shadow, not Max(S2 / dt) anymore

### DIFF
--- a/straxen/plugins/peaks/peak_shadow.py
+++ b/straxen/plugins/peaks/peak_shadow.py
@@ -35,7 +35,7 @@ class PeakShadow(strax.OverlapWindowPlugin):
     )
 
     shadow_sum = straxen.URLConfig(
-        default={"s1_time_shadow": False, "s2_time_shadow": False, "s2_position_shadow": False},
+        default={"s1_time_shadow": False, "s2_time_shadow": True, "s2_position_shadow": False},
         type=dict,
         track=True,
         help="Whether the shadow should be summed up rather than taking the largest one",


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

If the delayed electron strength is superpositioned, it is more natural to define the shadow as the sum of S2/dt in the previous time window, rather than the maximum S2 / dt of the previous time window.

The AC model validation can be compatible with the change after shadow cut values are updated.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
