### PR TITLE
Set `unique` when `times` and `center_times` are not assigned

### DIFF
--- a/straxen/analyses/bokeh_waveform_plot.py
+++ b/straxen/analyses/bokeh_waveform_plot.py
@@ -459,6 +459,7 @@ def peaks_display_interactive(
         unique = np.unique(center_times)
         field = "center_time"
     else:
+        unique = []
         warnings.warn("No times or center_times specified, will not plot any peak in detail.")
 
     signal = {}


### PR DESCRIPTION
Fix a bug in https://github.com/XENONnT/straxen/pull/1591 where `unique` is missing when `times` and `center_times` are not assigned.