### PR TITLE
Define "before" as the order of `center_time`

### DIFF
--- a/straxen/plugins/events/event_basics_vanilla.py
+++ b/straxen/plugins/events/event_basics_vanilla.py
@@ -374,7 +374,7 @@ class EventBasicsVanilla(strax.Plugin):
             s2_before_ms2 = peaks_before_ms2 & (peaks["type"] == 2)
             if np.any(s2_before_ms2):
                 i = np.arange(len(peaks))[s2_before_ms2][
-                    np.argmax(peaks["area"][s2_before_ms2]).items()
+                    np.argmax(peaks["area"][s2_before_ms2]).item()
                 ]
                 result["large_s2_before_main_s2_area"] = peaks["area"][i]
                 result["large_s2_before_main_s2_index"] = i

--- a/straxen/plugins/events/event_basics_vanilla.py
+++ b/straxen/plugins/events/event_basics_vanilla.py
@@ -17,7 +17,7 @@ class EventBasicsVanilla(strax.Plugin):
 
     """
 
-    __version__ = "1.4.0"
+    __version__ = "1.3.6"
 
     depends_on = ("events", "peak_basics", "peak_positions", "peak_proximity")
     provides = "event_basics"

--- a/straxen/plugins/events/event_basics_vanilla.py
+++ b/straxen/plugins/events/event_basics_vanilla.py
@@ -123,7 +123,11 @@ class EventBasicsVanilla(strax.Plugin):
             (f"alt_s2_x", np.float32, f"Alternate S2 reconstructed X position, uncorrected [cm]"),
             (f"alt_s2_y", np.float32, f"Alternate S2 reconstructed Y position, uncorrected [cm]"),
             (f"area_before_main_s2", np.float32, f"Sum of areas before Main S2 [PE]"),
-            (f"large_s2_before_main_s2", np.float32, f"The largest S2 before the Main S2 [PE]"),
+            (
+                f"large_s2_before_main_s2_area",
+                np.float32,
+                f"The largest S2 before the Main S2 [PE]",
+            ),
             (
                 f"large_s2_before_main_s2_index",
                 np.int32,
@@ -372,7 +376,7 @@ class EventBasicsVanilla(strax.Plugin):
                 i = np.arange(len(peaks))[s2_before_ms2][
                     np.argmax(peaks["area"][s2_before_ms2]).items()
                 ]
-                result["large_s2_before_main_s2"] = peaks["area"][i]
+                result["large_s2_before_main_s2_area"] = peaks["area"][i]
                 result["large_s2_before_main_s2_index"] = i
                 result["large_s2_before_main_s2_center_time"] = peaks["center_time"][i]
         return result

--- a/straxen/plugins/events/event_basics_vanilla.py
+++ b/straxen/plugins/events/event_basics_vanilla.py
@@ -124,6 +124,16 @@ class EventBasicsVanilla(strax.Plugin):
             (f"alt_s2_y", np.float32, f"Alternate S2 reconstructed Y position, uncorrected [cm]"),
             (f"area_before_main_s2", np.float32, f"Sum of areas before Main S2 [PE]"),
             (f"large_s2_before_main_s2", np.float32, f"The largest S2 before the Main S2 [PE]"),
+            (
+                f"large_s2_before_main_s2_index",
+                np.int32,
+                f"Index of the largest S2 before the Main S2",
+            ),
+            (
+                f"large_s2_before_main_s2_center_time",
+                np.int64,
+                f"Center time of the largest S2 before the Main S2 [ns]",
+            ),
         ]
 
         dtype += self._get_posrec_dtypes()
@@ -353,14 +363,18 @@ class EventBasicsVanilla(strax.Plugin):
 
         # areas before main S2
         if len(largest_s2s):
-            peaks_before_ms2 = peaks[peaks["center_time"] < largest_s2s[0]["center_time"]]
-            result["area_before_main_s2"] = np.sum(peaks_before_ms2["area"])
+            peaks_before_ms2 = ~np.isnan(peaks["area"])
+            peaks_before_ms2 &= peaks["center_time"] < largest_s2s[0]["center_time"]
+            result["area_before_main_s2"] = np.sum(peaks["area"][peaks_before_ms2])
 
-            s2peaks_before_ms2 = peaks_before_ms2[peaks_before_ms2["type"] == 2]
-            if len(s2peaks_before_ms2) == 0:
-                result["large_s2_before_main_s2"] = 0
-            else:
-                result["large_s2_before_main_s2"] = np.max(s2peaks_before_ms2["area"])
+            s2_before_ms2 = peaks_before_ms2 & (peaks["type"] == 2)
+            if np.any(s2_before_ms2):
+                i = np.arange(len(peaks))[s2_before_ms2][
+                    np.argmax(peaks["area"][s2_before_ms2]).items()
+                ]
+                result["large_s2_before_main_s2"] = peaks["area"][i]
+                result["large_s2_before_main_s2_index"] = i
+                result["large_s2_before_main_s2_center_time"] = peaks["center_time"][i]
         return result
 
     @staticmethod

--- a/straxen/plugins/events/event_basics_vanilla.py
+++ b/straxen/plugins/events/event_basics_vanilla.py
@@ -17,7 +17,7 @@ class EventBasicsVanilla(strax.Plugin):
 
     """
 
-    __version__ = "1.3.5"
+    __version__ = "1.4.0"
 
     depends_on = ("events", "peak_basics", "peak_positions", "peak_proximity")
     provides = "event_basics"
@@ -353,7 +353,7 @@ class EventBasicsVanilla(strax.Plugin):
 
         # areas before main S2
         if len(largest_s2s):
-            peaks_before_ms2 = peaks[peaks["time"] < largest_s2s[0]["time"]]
+            peaks_before_ms2 = peaks[peaks["center_time"] < largest_s2s[0]["center_time"]]
             result["area_before_main_s2"] = np.sum(peaks_before_ms2["area"])
 
             s2peaks_before_ms2 = peaks_before_ms2[peaks_before_ms2["type"] == 2]


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

To be consistent with other definitions, like in shadow/ambience and S1-S2 pairing.

Very small impact on the result. And no one has used `large_s2_before_main_s2` in any study.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
