### PR TITLE
Fix `cs2_area_fraction_top_wo_peakbiascorr`

### DIFF
--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -37,7 +37,7 @@ class CorrectedAreas(strax.Plugin):
 
     """
 
-    __version__ = "0.5.4"
+    __version__ = "0.5.5"
 
     depends_on: Tuple[str, ...] = ("event_basics", "event_positions")
 
@@ -424,7 +424,7 @@ class CorrectedAreas(strax.Plugin):
             # N-1: without peak bias
             (
                 result[f"{peak_type}cs2_wo_peakbiascorr"],
-                result[f"{peak_type}cs2_area_fraction_top_wo_timecorr"],
+                result[f"{peak_type}cs2_area_fraction_top_wo_peakbiascorr"],
             ) = self.apply_s2_corrections(
                 s2_area,
                 s2_aft,


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Fix a small bug in https://github.com/XENONnT/straxen/pull/1598

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
