### PR TITLE
Remove cAFT bottom corr form cS2

### DIFF
--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -37,7 +37,7 @@ class CorrectedAreas(strax.Plugin):
 
     """
 
-    __version__ = "0.5.6"
+    __version__ = "0.5.7"
 
     depends_on: Tuple[str, ...] = ("event_basics", "event_positions")
 
@@ -297,6 +297,15 @@ class CorrectedAreas(strax.Plugin):
         elife_correction,
     ):
         """Apply S2 corrections and return various corrected areas.
+        The variables include the following corrections:
+            cs2: peak bias, S2xy, SEG/EE, elife
+            cs2_area_fraction_top: peak bias, S2xy, SEG/EE, cAFT, elife
+            cs2_before_pi: peak bias, S2xy, SEG/EE
+            cs2_area_fraction_top_before_pi: peak bias, S2xy, SEG/EE
+            cs2_before_elife: peak bias, S2xy, SEG/EE, cAFT
+            cs2_area_fraction_top_before_elife: peak bias, S2xy, SEG/EE, cAFT
+            cs2_wo_segee_picorr: peak bias, S2xy, elife
+            cs2_area_fraction_top_wo_segee_picorr: peak bias, S2xy, elife
 
         Returns:
             cs2,
@@ -324,8 +333,10 @@ class CorrectedAreas(strax.Plugin):
         cs2_bottom_before_elife = cs2_bottom_before_pi * pi_corr_bottom
         cs2_before_elife = cs2_top_before_elife + cs2_bottom_before_elife
 
-        cs2 = cs2_before_elife * elife_correction
-        cs2_top_final = cs2_top_before_elife * elife_correction
+        # Do not correct total area for cAFT
+        cs2 = (cs2_top_before_pi + cs2_bottom_before_pi) * elife_correction
+        # Correct AFT for cAFT
+        cs2_area_fraction_top = cs2_top_before_pi / (cs2_top_before_pi + cs2_bottom_before_pi * pi_corr_bottom)
 
         cs2_top_wo_segee_picorr = s2_area_top / s2_bias_correction / s2_xy_correction_top
         cs2_bottom_wo_segee_picorr = s2_area_bottom / s2_bias_correction / s2_xy_correction_bottom
@@ -335,7 +346,7 @@ class CorrectedAreas(strax.Plugin):
         cs2_top_wo_segee_picorr = cs2_top_wo_segee_picorr * elife_correction
         return (
             cs2,
-            cs2_top_final / cs2,
+            cs2_area_fraction_top,
             cs2_before_pi,
             cs2_top_before_pi / cs2_before_pi,
             cs2_before_elife,


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
In [straxen 2.2.7](https://github.com/XENONnT/straxen/blob/v2.2.7/straxen/plugins/events/corrected_areas.py#L270) the corrected areas plugin specifically excluded the bottom top ratio correction that is caused by PI from the total area returned as cS2. Instead, this correction was only applied to the AFT correction.

In [straxen 3.2.3](https://github.com/XENONnT/straxen/blob/v3.2.3/straxen/plugins/events/corrected_areas.py#L324) the bottom PI correction is applied to the bottom area, and therefore the correction is included in the final returned cS2.

A discussion of this can be found in [this note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:svetter:sr2_cy_pi_correlation_plot_collection#plugin_rework_proposal).

## Can you briefly describe how it works?
The `cs2` variable is now computed as follows:
<code>
cs2_top_before_pi = s2_area_top / s2_bias_correction / s2_xy_correction_top / seg_ee_corr
cs2_bottom_before_pi = (
    s2_area_bottom / s2_bias_correction / s2_xy_correction_bottom / seg_ee_corr
)
cs2 = (cs2_top_before_pi + cs2_bottom_before_pi) * elife_correction
</code>

The `cs2_area_fraction_top` variable is computed as follows:
<code>
cs2_area_fraction_top = cs2_top_before_pi / (cs2_top_before_pi + cs2_bottom_before_pi * pi_corr_bottom)
</code>

## Can you give a minimal working example (or illustrate with a figure)?
The variable distributions of the resulting and intermediate variables for selected Kr runs look like this:

<img width="1623" height="3223" alt="sr2_cy_pi_corr_plugin_rework_distributions" src="https://github.com/user-attachments/assets/6e3ae6b0-efa2-466c-853b-96856a0db3d3" />

