### PR TITLE
update new z bias map url

### DIFF
--- a/straxen/plugins/events/event_positions.py
+++ b/straxen/plugins/events/event_positions.py
@@ -47,7 +47,7 @@ class EventPositions(strax.Plugin):
 
     z_bias_map = straxen.URLConfig(
         default="itp_map://resource:///home/changcai/nt_analysis/electron_drift/XnT_z_bias_map_chargeup_20251001.json.gz"
-+        "?fmt=json.gz",
+        + "?fmt=json.gz",
         infer_type=False,
         help="Map of Z bias due to non uniform drift velocity/field",
     )


### PR DESCRIPTION
This PR update the default Z_biax_map URL for event_positions.py. Details about the new map can be found [here](https://xe1t-wiki.lngs.infn.it/doku.php?id=changcai:sr2_z_reconstruction_v2).
