### PR TITLE
Add cS2 without elife correction

### DIFF
--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -169,14 +169,14 @@ class CorrectedAreas(strax.Plugin):
     # peak bias, SEG/EE, PI and relCY
     # '111111' is the fully corrected cS2.
 
-    name_postfixes = ["_bias", "_xy", "_segee", "_pi", "_elife", "_relcy"]
+    name_postfixes = ["_bias", "_xy", "_segee", "_pi", "_relcy", "_elife"]
     description_strs = [
         "peak bias",
         "S2 xy",
         "SEG/EE",
         "photoionization",
-        "elife",
         "relative charge yield",
+        "elife",
     ]
     intermediate_cs2s = [
         "111111",
@@ -184,16 +184,16 @@ class CorrectedAreas(strax.Plugin):
         "110000",
         "101000",
         "111000",
-        "110010",
-        "000010",
-        "010010",
-        "011110",
-        "101110",
-        "110110",
-        "111010",
+        "110001",
+        "000001",
+        "010001",
+        "011101",
+        "101101",
+        "110101",
+        "111001",
         "111100",
-        "111110",
         "111101",
+        "111110",
     ]
 
     def infer_dtype(self):
@@ -341,11 +341,11 @@ class CorrectedAreas(strax.Plugin):
             s2_area_bottom / s2_bias_correction / s2_xy_correction_bottom / seg_ee_corr
         )
 
-        # Apply elife to get total cS2
-        cs2_elife = (cs2_top_wo_elife + cs2_bottom_wo_elife) * elife_correction
+        # Apply rel_cy_correction
+        cs2_relcy = (cs2_top_wo_elife + cs2_bottom_wo_elife) * rel_cy_correction
 
-        # Apply rel_cy_correction to get total cS2
-        cs2 = cs2_elife * rel_cy_correction
+        # Apply elife to get total cS2
+        cs2 = cs2_relcy * elife_correction
 
         # Apply PI AFT correction to get cAFT
         # Do this on the cS2 without elife, because S2-only events have NaN as elife,


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

In https://github.com/XENONnT/straxen/pull/1629, we forgot to maintain the cS2 without elife correction.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
