### PR TITLE
fixed the order of the corrections in apply_s2_correction()

### DIFF
--- a/straxen/plugins/events/corrected_areas.py
+++ b/straxen/plugins/events/corrected_areas.py
@@ -38,7 +38,7 @@ class CorrectedAreas(strax.Plugin):
 
     """
 
-    __version__ = "0.5.11"
+    __version__ = "0.6.0"
 
     depends_on: Tuple[str, ...] = ("event_basics", "event_positions")
 


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
The order of two arguments: "rel_cy_correction" and "elife_correction" in the function apply_s2_correction() were inverted when it was defined and when it was called, making our cS2 look much smaller than it should, since we were applying the correction in the wrong way. This PR changes the order in the definition of the function in a way to leave the last correction to be "elife_correction".

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
