### PR TITLE
Add 'merged' field to vanilla plugins

### DIFF
--- a/straxen/plugins/events/event_basics_vanilla.py
+++ b/straxen/plugins/events/event_basics_vanilla.py
@@ -169,7 +169,7 @@ class EventBasicsVanilla(strax.Plugin):
             ("area_fraction_top", np.float32, "fraction of area seen by the top PMT array"),
             ("tight_coincidence", np.int16, "channel within tight range of mean"),
             ("n_saturated_channels", np.int16, "total number of saturated channels"),
-            # ("merged", bool, "is merged from peaklets"),
+            ("merged", bool, "is merged from peaklets"),
         )
 
     def setup(self):

--- a/straxen/plugins/merged_s2s/merged_s2s_vanilla.py
+++ b/straxen/plugins/merged_s2s/merged_s2s_vanilla.py
@@ -79,12 +79,14 @@ class MergedS2sVanilla(strax.OverlapWindowPlugin):
             "peaklet_classification"
         )
         peaklets_dtype = self.deps["peaklets"].dtype_for("peaklets")
+        # DON'T include indicator_dtype here! It causes dtype mismatch in strax.replace_merged()
+        # The merged field will be added later in PeaksVanilla
         # The merged dtype is argument position dependent!
         # It must be first classification then peaklet
         # Otherwise strax will raise an error
         # when checking for the returned dtype!
         merged_s2s_dtype = strax.merged_dtype(
-            (peaklet_classification_dtype, peaklets_dtype, self.indicator_dtype)
+            (peaklet_classification_dtype, peaklets_dtype)
         )
         return merged_s2s_dtype
 
@@ -153,13 +155,9 @@ class MergedS2sVanilla(strax.OverlapWindowPlugin):
 
         strax.compute_widths(merged_s2s)
 
-        # Add the merged field to the dtype and set it to True
-        # merged_s2s from strax.merge_peaks doesn't have the indicator_dtype fields yet
-        merged_s2s_with_field = np.zeros(len(merged_s2s), dtype=self.dtype)
-        strax.copy_to_buffer(merged_s2s, merged_s2s_with_field, "_add_merged_field")
-        merged_s2s_with_field["merged"] = True
-        merged_s2s = merged_s2s_with_field
-
+        # Don't add merged field here - it will be added in PeaksVanilla
+        # to avoid dtype mismatch in strax.replace_merged()
+        
         if n_top_pmts_if_digitize_top <= 0:
             merged_s2s = drop_data_top_field(merged_s2s, self.dtype, "_drop_top_merged_s2s")
         return merged_s2s

--- a/straxen/plugins/merged_s2s/merged_s2s_vanilla.py
+++ b/straxen/plugins/merged_s2s/merged_s2s_vanilla.py
@@ -157,8 +157,12 @@ class MergedS2sVanilla(strax.OverlapWindowPlugin):
 
         strax.compute_widths(merged_s2s)
 
-        # Mark all merged S2s as merged
-        merged_s2s["merged"] = True
+        # Add the merged field to the dtype and set it to True
+        # merged_s2s from strax.merge_peaks doesn't have the indicator_dtype fields yet
+        merged_s2s_with_field = np.zeros(len(merged_s2s), dtype=self.dtype)
+        strax.copy_to_buffer(merged_s2s, merged_s2s_with_field, "_add_merged_field")
+        merged_s2s_with_field["merged"] = True
+        merged_s2s = merged_s2s_with_field
 
         if n_top_pmts_if_digitize_top <= 0:
             merged_s2s = drop_data_top_field(merged_s2s, self.dtype, "_drop_top_merged_s2s")

--- a/straxen/plugins/merged_s2s/merged_s2s_vanilla.py
+++ b/straxen/plugins/merged_s2s/merged_s2s_vanilla.py
@@ -17,7 +17,7 @@ class MergedS2sVanilla(strax.OverlapWindowPlugin):
     """Merge together peaklets if peak finding favours that they would form a single peak
     instead."""
 
-    __version__ = "1.0.2"
+    __version__ = "1.0.3"
 
     depends_on: Tuple[str, ...] = ("peaklets", "peaklet_classification", "lone_hits")
     data_kind = "merged_s2s"
@@ -79,14 +79,14 @@ class MergedS2sVanilla(strax.OverlapWindowPlugin):
             "peaklet_classification"
         )
         peaklets_dtype = self.deps["peaklets"].dtype_for("peaklets")
-        # DON'T include indicator_dtype here! It causes dtype mismatch in strax.replace_merged()
-        # The merged field will be added later in PeaksVanilla
+        # Include indicator_dtype - the merged field will be in the output
+        # peaklet_classification now has merged field, so final dtype will have it too
         # The merged dtype is argument position dependent!
         # It must be first classification then peaklet
         # Otherwise strax will raise an error
         # when checking for the returned dtype!
         merged_s2s_dtype = strax.merged_dtype(
-            (peaklet_classification_dtype, peaklets_dtype)
+            (peaklet_classification_dtype, peaklets_dtype, self.indicator_dtype)
         )
         return merged_s2s_dtype
 
@@ -155,8 +155,8 @@ class MergedS2sVanilla(strax.OverlapWindowPlugin):
 
         strax.compute_widths(merged_s2s)
 
-        # Don't add merged field here - it will be added in PeaksVanilla
-        # to avoid dtype mismatch in strax.replace_merged()
+        # Set merged field to True for all merged S2s
+        merged_s2s["merged"] = True
         
         if n_top_pmts_if_digitize_top <= 0:
             merged_s2s = drop_data_top_field(merged_s2s, self.dtype, "_drop_top_merged_s2s")

--- a/straxen/plugins/merged_s2s/merged_s2s_vanilla.py
+++ b/straxen/plugins/merged_s2s/merged_s2s_vanilla.py
@@ -84,11 +84,7 @@ class MergedS2sVanilla(strax.OverlapWindowPlugin):
         # Otherwise strax will raise an error
         # when checking for the returned dtype!
         merged_s2s_dtype = strax.merged_dtype(
-            (
-                peaklet_classification_dtype,
-                peaklets_dtype,
-                self.indicator_dtype
-            )
+            (peaklet_classification_dtype, peaklets_dtype, self.indicator_dtype)
         )
         return merged_s2s_dtype
 

--- a/straxen/plugins/merged_s2s/merged_s2s_vanilla.py
+++ b/straxen/plugins/merged_s2s/merged_s2s_vanilla.py
@@ -87,7 +87,7 @@ class MergedS2sVanilla(strax.OverlapWindowPlugin):
             (
                 peaklet_classification_dtype,
                 peaklets_dtype,
-                # self.indicator_dtype
+                self.indicator_dtype
             )
         )
         return merged_s2s_dtype
@@ -156,6 +156,9 @@ class MergedS2sVanilla(strax.OverlapWindowPlugin):
         strax.add_lone_hits(merged_s2s, lh, self.to_pe, n_top_channels=n_top_pmts_if_digitize_top)
 
         strax.compute_widths(merged_s2s)
+
+        # Mark all merged S2s as merged
+        merged_s2s["merged"] = True
 
         if n_top_pmts_if_digitize_top <= 0:
             merged_s2s = drop_data_top_field(merged_s2s, self.dtype, "_drop_top_merged_s2s")

--- a/straxen/plugins/peaklets/peaklet_classification_vanilla.py
+++ b/straxen/plugins/peaklets/peaklet_classification_vanilla.py
@@ -12,11 +12,14 @@ export, __all__ = strax.exporter()
 class PeakletClassificationVanilla(strax.Plugin):
     """Classify peaklets as unknown, S1, or S2."""
 
-    __version__ = "3.0.4"
+    __version__ = "3.0.5"
 
     depends_on = "peaklets"
     provides: Union[str, tuple] = "peaklet_classification"
-    dtype = strax.peak_interval_dtype + [("type", np.int8, "Classification of the peak(let)")]
+    dtype = strax.peak_interval_dtype + [
+        ("type", np.int8, "Classification of the peak(let)"),
+        ("merged", bool, "Peaklet is merging input or peak is merged from peaklets"),
+    ]
 
     s1_risetime_area_parameters = straxen.URLConfig(
         default=(50, 80, 12),
@@ -104,5 +107,6 @@ class PeakletClassificationVanilla(strax.Plugin):
         peaklets_classification["dt"] = peaklets["dt"]
         peaklets_classification["length"] = peaklets["length"]
         peaklets_classification["channel"] = -1
+        peaklets_classification["merged"] = False  # Peaklets are not merged yet
 
         return peaklets_classification

--- a/straxen/plugins/peaks/peak_basics_vanilla.py
+++ b/straxen/plugins/peaks/peak_basics_vanilla.py
@@ -54,7 +54,7 @@ class PeakBasicsVanilla(strax.Plugin):
                 np.int16,
             ),
             (("Classification of the peak(let)", "type"), np.int8),
-            # ("merged", bool, "is merged from peaklets"),
+            (("Peak is merged from peaklets", "merged"), bool),
             (
                 ("Largest time difference between apexes of hits inside peak [ns]", "max_diff"),
                 np.int32,
@@ -81,8 +81,7 @@ class PeakBasicsVanilla(strax.Plugin):
         p = peaks
         r = np.zeros(len(p), self.dtype)
         needed_fields = "time center_time length dt median_time area area_fraction_top type "
-        # needed_fields += "merged max_diff min_diff first_channel last_channel"
-        needed_fields += "max_diff min_diff first_channel last_channel"
+        needed_fields += "merged max_diff min_diff first_channel last_channel"
         for q in needed_fields.split():
             r[q] = p[q]
         r["endtime"] = p["time"] + p["dt"] * p["length"]

--- a/straxen/plugins/peaks/peaks_vanilla.py
+++ b/straxen/plugins/peaks/peaks_vanilla.py
@@ -17,7 +17,7 @@ class PeaksVanilla(strax.Plugin):
 
     """
 
-    __version__ = "0.1.2"
+    __version__ = "0.1.3"
 
     depends_on: Union[Tuple[str, ...], str] = (
         "peaklets",
@@ -49,19 +49,19 @@ class PeaksVanilla(strax.Plugin):
         peaklet_classification_dtype = self.deps["peaklet_classification"].dtype_for(
             "peaklet_classification"
         )
-        # Add indicator_dtype for the merged field
-        indicator_dtype = np.dtype(
-            [(("Peaklet is merging input or peak is merged from peaklets", "merged"), bool)]
-        )
-        merged_dtype = strax.merged_dtype(
-            (peaklets_dtype, peaklet_classification_dtype, indicator_dtype)
-        )
+        # merged field comes from peaklet_classification (which now has it)
+        merged_dtype = strax.merged_dtype((peaklets_dtype, peaklet_classification_dtype))
         # Numba is very picky about alignment for structured dtypes. Ensure an aligned dtype
         # so assignments inside strax.replace_merged don't see "unaligned array(...)".
         return np.dtype(merged_dtype, align=True)
 
     def compute(self, peaklets, merged_s2s):
-        _peaks = self.replace_merged(peaklets, merged_s2s, merge_s0=self.merge_s0)
+        # Convert merged_s2s dtype to match peaklets (like PeaksSOM does)
+        # This drops the merged field from merged_s2s temporarily
+        _merged_s2s = strax.merge_arrs([merged_s2s], dtype=peaklets.dtype)
+        
+        # Now both inputs have the same dtype (no merged field)
+        _peaks = self.replace_merged(peaklets, _merged_s2s, merge_s0=self.merge_s0)
 
         if self.diagnose_sorting:
             assert np.all(np.diff(_peaks["time"]) >= 0), "Peaks not sorted"
@@ -70,15 +70,14 @@ class PeaksVanilla(strax.Plugin):
                 _peaks["time"][to_check][1:] >= strax.endtime(_peaks)[to_check][:-1]
             ), "Peaks not disjoint"
 
+        # Copy to output dtype (which has merged field from peaklet_classification)
         peaks = np.zeros(len(_peaks), dtype=self.dtype)
         strax.copy_to_buffer(_peaks, peaks, f"_copy_requested_{self.provides[0]}_fields")
         
-        # Set merged field: True for peaks that came from merged_s2s, False for unmerged peaklets
-        # We identify merged peaks by checking if they exist in merged_s2s timewindows
+        # Merged field was copied from peaklets (via peaklet_classification)
+        # All values are False by default. Set to True for peaks from merged_s2s
         if len(merged_s2s) > 0:
             peaks["merged"] = strax.fully_contained_in(peaks, merged_s2s) >= 0
-        else:
-            peaks["merged"] = False
         
         return peaks
 

--- a/straxen/plugins/peaks/peaks_vanilla.py
+++ b/straxen/plugins/peaks/peaks_vanilla.py
@@ -49,7 +49,13 @@ class PeaksVanilla(strax.Plugin):
         peaklet_classification_dtype = self.deps["peaklet_classification"].dtype_for(
             "peaklet_classification"
         )
-        merged_dtype = strax.merged_dtype((peaklets_dtype, peaklet_classification_dtype))
+        # Add indicator_dtype for the merged field
+        indicator_dtype = np.dtype(
+            [(("Peaklet is merging input or peak is merged from peaklets", "merged"), bool)]
+        )
+        merged_dtype = strax.merged_dtype(
+            (peaklets_dtype, peaklet_classification_dtype, indicator_dtype)
+        )
         # Numba is very picky about alignment for structured dtypes. Ensure an aligned dtype
         # so assignments inside strax.replace_merged don't see "unaligned array(...)".
         return np.dtype(merged_dtype, align=True)
@@ -66,6 +72,14 @@ class PeaksVanilla(strax.Plugin):
 
         peaks = np.zeros(len(_peaks), dtype=self.dtype)
         strax.copy_to_buffer(_peaks, peaks, f"_copy_requested_{self.provides[0]}_fields")
+        
+        # Set merged field: True for peaks that came from merged_s2s, False for unmerged peaklets
+        # We identify merged peaks by checking if they exist in merged_s2s timewindows
+        if len(merged_s2s) > 0:
+            peaks["merged"] = strax.fully_contained_in(peaks, merged_s2s) >= 0
+        else:
+            peaks["merged"] = False
+        
         return peaks
 
     @staticmethod


### PR DESCRIPTION
This pull request reintroduces and standardizes the `merged` field across several event and peak data structures in the codebase. The main goal is to ensure that merged peaks and S2 signals are consistently marked and their data types are correctly defined throughout the relevant plugins.

**Data structure and field standardization:**

* Added the `merged` boolean field back to the dtype definitions in `event_basics_vanilla.py` and `peak_basics_vanilla.py`, ensuring that merged peaks/events are explicitly tracked in the data schema. [[1]](diffhunk://#diff-92307fc79e5c77d8453f8256945b0cbdd9320789e1785af9bbaef73214ff95e5L172-R172) [[2]](diffhunk://#diff-d8c89bad729519104f11621873316097e1e10c4a00c2f70e36e01705fafec026L57-R57)
* Updated the list of fields copied in the `compute` method of `peak_basics_vanilla.py` to include `merged`, so this property is preserved in output arrays.

**Merged S2 plugin improvements:**

* Restored the `indicator_dtype` to the dtype inference in `merged_s2s_vanilla.py`, ensuring all relevant fields are included in the merged S2s data type.
* Explicitly set the `merged` field to `True` for all merged S2s in the `compute` method, providing a clear marker for downstream processing.