### PR TITLE
Restrax make childs and stop infinite loop on failed

### DIFF
--- a/straxen/scripts/restrax.py
+++ b/straxen/scripts/restrax.py
@@ -17,6 +17,9 @@ __version__ = "0.3.1"
 import argparse
 import logging
 import os
+import shlex
+import subprocess
+import sys
 import typing
 
 import immutabledict
@@ -84,10 +87,20 @@ def parse_args():
         action="store_true",
         help="Stop recompression and just rename folders. Use with care!",
     )
+    parser.add_argument(
+        "--process_per_run",
+        action="store_true",
+        help=(
+            "Run a lightweight supervisor loop and spawn a fresh restrax worker process per run. "
+            "Use this to free all worker memory after each processed run."
+        ),
+    )
     actions = parser.add_mutually_exclusive_group()
     actions.add_argument("--undying", action="store_true", help="Except any error and ignore it")
     actions.add_argument("--process", type=int, help="Handle a single run")
     args = parser.parse_args()
+    if args.process_per_run and args.process is not None:
+        raise ValueError("--process_per_run cannot be combined with --process")
     if args.input_folder != daq_core.pre_folder and args.production:
         raise ValueError(
             "Thou shall not pass, don't upload files from non production"
@@ -98,6 +111,10 @@ def parse_args():
 
 def main():
     args = parse_args()
+    if args.process_per_run:
+        run_process_per_run_supervisor(args)
+        return
+
     restrax = ReStrax(args=args)
 
     while True:
@@ -127,6 +144,92 @@ def main():
 def run_restrax(restrax, args):
     """Run the infinite loop of ReStrax."""
     restrax.infinite_loop(close=bool(args.process))
+
+
+def _build_worker_cmd(parent: "ReStrax", args: argparse.Namespace, run_number: int) -> ty.List[str]:
+    """Build CLI command for a one-run child worker."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "straxen.scripts.restrax",
+        "--process",
+        str(run_number),
+        "--max_threads",
+        str(parent.max_threads),
+        "--recompress_min_chunks",
+        str(parent.recompress_min_chunks),
+    ]
+
+    if parent.production:
+        cmd.append("--production")
+    else:
+        cmd.extend(["--input_folder", args.input_folder])
+
+    if parent.ignore_checks:
+        cmd.append("--ignore_checks")
+    if parent.deep_compare:
+        cmd.append("--deep_compare")
+    if parent.bypass_mode:
+        cmd.append("--bypass_mode")
+
+    if parent.skip_compression is not None:
+        cmd.append("--skip_compression")
+        cmd.extend(strax.to_str_tuple(parent.skip_compression))
+
+    # Parent handles retry policy, do not pass --undying / --process_per_run.
+    return cmd
+
+
+def run_process_per_run_supervisor(args: argparse.Namespace) -> None:
+    """Run restrax in supervisor mode, spawning one process per run."""
+    parent = ReStrax(args=args)
+
+    while True:
+        try:
+            parent.overwrite_settings()
+            run_doc = parent.find_work(projection={"number": 1})
+            parent.log.info("Start")
+
+            if run_doc is None:
+                parent.log.info("No work to do, sleep")
+                parent.take_a_nap()
+                continue
+
+            run_number = run_doc["number"]
+            cmd = _build_worker_cmd(parent, args, run_number)
+            parent.log.info(
+                f"Launching one-run child for {run_number}: "
+                f"{' '.join(shlex.quote(part) for part in cmd)}"
+            )
+
+            child = subprocess.run(cmd, check=False)
+            if child.returncode == 0:
+                parent.log.info(f"Child worker finished {run_number}")
+                continue
+
+            raise RuntimeError(
+                f"Child worker failed for run {run_number} with exit code {child.returncode}"
+            )
+        except (KeyboardInterrupt, SystemExit):
+            break
+        except Exception as fatal_error:
+            parent.log.error(
+                f"Fatal warning: ran into {fatal_error}. "
+                "Trying to log error and restart ReStrax."
+            )
+            try:
+                parent.log_warning(
+                    f"Fatal warning: ran into {fatal_error}",
+                    priority="error",
+                )
+            except Exception as warning_error:
+                parent.error(f"Fatal warning: could not log {warning_error}")
+
+            if not args.undying:
+                raise
+
+            parent.log.warning("Restarting main loop after 60 seconds due to fatal error.")
+            time.sleep(60)
 
 
 class ReStrax(daq_core.DataBases):


### PR DESCRIPTION
This pull request introduces a new supervisor mode to the `restrax` script, allowing it to spawn a separate worker process for each run. This approach helps manage memory usage by freeing all worker memory after each processed run. The changes include a new command-line argument, logic to prevent incompatible argument combinations, and the implementation of the supervisor loop and worker command construction.

**New supervisor mode and process management:**

* Added a `--process_per_run` argument to the CLI, enabling supervisor mode that spawns a fresh worker process for each run. This helps free all worker memory after each processed run.
* Implemented the `run_process_per_run_supervisor` function, which manages the supervisor loop, launches a child process for each run, and handles errors and restarts.
* Added the `_build_worker_cmd` helper function to construct the command-line invocation for the child worker process, ensuring proper argument passing and separation of retry policy.
* Updated argument parsing to prevent combining `--process_per_run` with `--process`, which could lead to conflicting behavior.
* Modified the main entrypoint to call the supervisor loop when `--process_per_run` is set, ensuring the new mode is activated appropriately.