### PR TITLE
Fixing PR: Aqmon adjustment for busy firmware change

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install requirements for Python 3.11
         if: matrix.python-version == '3.11'
-        run: pip install git+https://github.com/XENONnT/base_environment.git --force-reinstall
+        run: pip install git+https://github.com/XENONnT/base_environment.git@el8.2026.03.1 --force-reinstall
 
       - name: Install strax and straxen
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ test_dict.json
 
 *.pkl
 *.pkl.gz
+
+
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Streaming analysis for XENON(nT)
 
 For installation instructions and usage information, please see the [straxen documentation](https://straxen.readthedocs.io/en/latest/setup.html).
 
-
 ## Further status
 [![Python Versions](https://img.shields.io/pypi/pyversions/straxen.svg)](https://pypi.python.org/pypi/straxen)
 [![PyPI downloads](https://img.shields.io/pypi/dm/straxen.svg)](https://pypistats.org/packages/straxen)

--- a/straxen/plugins/led_cal/led_calibration.py
+++ b/straxen/plugins/led_cal/led_calibration.py
@@ -61,7 +61,7 @@ class LEDCalibration(strax.Plugin):
     parallel = "process"
     rechunk_on_save = False
 
-    run_doc = straxen.URLConfig(
+    run_doc_comments = straxen.URLConfig(
         default="run_doc://comments?run_id=plugin.run_id",
         infer_type=False,
         help=(
@@ -181,7 +181,7 @@ class LEDCalibration(strax.Plugin):
         """
 
         self.is_led_on = is_the_led_on(
-            self.run_doc, self.default_run_comments, self.noise_run_comments
+            self.run_doc_comments, self.default_run_comments, self.noise_run_comments
         )
 
         mask = np.where(np.in1d(raw_records["channel"], self.channel_list))[0]
@@ -235,7 +235,7 @@ class LEDCalibration(strax.Plugin):
         return temp
 
 
-def is_the_led_on(run_doc, default_run_comments, noise_run_comments):
+def is_the_led_on(run_doc_comments, default_run_comments, noise_run_comments):
     """Utilizing the run database metadata to determine whether the run ID corresponds to LED on or
     LED off runs.
 
@@ -243,10 +243,10 @@ def is_the_led_on(run_doc, default_run_comments, noise_run_comments):
     'SPE_calibration_step0' in the comment.
 
     """
-    # Check if run_doc is a list with a dictionary
-    if isinstance(run_doc, list) and isinstance(run_doc[0], dict):
+    # Check if run_doc_comments is a list with a dictionary
+    if isinstance(run_doc_comments, list) and isinstance(run_doc_comments[0], dict):
         # Extract the dictionary
-        doc = run_doc[0]
+        doc = run_doc_comments[0]
 
         # Check if the required keys are present
         required_keys = {"user", "date", "comment"}

--- a/straxen/plugins/veto_intervals/veto_intervals.py
+++ b/straxen/plugins/veto_intervals/veto_intervals.py
@@ -121,7 +121,7 @@ class VetoIntervals(strax.ExhaustPlugin):
         if n_artificial:
             result[vetos_seen:n_artificial]["time"] = artificial_deadtime["time"]
             result[vetos_seen:n_artificial]["endtime"] = strax.endtime(artificial_deadtime)
-            result[vetos_seen:n_artificial]["veto_type"] = "straxen_deadtime_veto"
+            result[vetos_seen:n_artificial]["veto_type"] = "straxen_deadtime"
             vetos_seen += n_artificial
 
         result = result[:vetos_seen]

--- a/tests/test_aqmon.py
+++ b/tests/test_aqmon.py
@@ -193,6 +193,7 @@ class TestAqmonProcessing(TestCase):
         # get a thousand warnings that some config is not used, make
         # sure to mark all configs as "free options".
         st.set_context_config({"free_options": list(st.config.keys())})
+        st.set_config({"v1495_config": {"firmware_version": 9}})
         st._plugin_class_registry = {}
 
         self.TOTAL_DEADTIME: List = []

--- a/tests/test_daq_reader.py
+++ b/tests/test_daq_reader.py
@@ -3,9 +3,6 @@
 import os
 import shutil
 import unittest
-from unittest import TestCase
-from straxen.config.url_config import URLConfig, clear_config_caches
-import straxen.config.protocols as protocols
 import strax
 import straxen
 from straxen import download_test_data, get_resource
@@ -64,18 +61,6 @@ class TestDAQReader(unittest.TestCase):
     rundoc_file = "https://raw.githubusercontent.com/XENONnT/strax_auxiliary_files/6a6b02d7ff9cb5731e25ef39931ce0a803f2e150/strax_files/rundoc_999999.json"  # noqa
     data_file = "https://raw.githubusercontent.com/XAMS-nikhef/amstrax_files/73681f112d748f6cd0e95045970dd29c44e983b0/data/999999.tar"  # noqa
 
-    fake_rundoc_999999 = {
-        "number": 999999,
-        "mode": "tpc_bkg",
-        "start": 0,
-        "end": 1,
-        "tags": [],
-        "detectors": [
-            "tpc",
-        ],
-        "daq_config": {"V1495": {"tpc": {"fractional_mode_active": 0}}},
-    }
-
     # # Part A. the actual tests
     def test_make(self) -> None:
         """Test if we can run the daq-reader without chrashing and if we actually stored the data
@@ -101,6 +86,7 @@ class TestDAQReader(unittest.TestCase):
             {
                 "safe_break_in_pulses": int(0.5e9),
                 "dummy_version": "test_insert_deadtime",
+                "v1495_config": {"firmware_version": 9},
             }
         )
 
@@ -152,23 +138,11 @@ class TestDAQReader(unittest.TestCase):
         self.st = st
         self.assertFalse(self.st.is_stored(self.run_id, "raw_records"))
 
-        # load fake rundocs
-        self._orig = protocols.read_rundoc
-
-        def _fake(*args, **kwargs):
-            return self.fake_rundoc_999999
-
-        clear_config_caches()
-        URLConfig.register("rundoc", _fake)
-
     def tearDown(self) -> None:
         data_path = self.st.storage[0].path
         if os.path.exists(data_path):
             shutil.rmtree(data_path)
             print(f"rm {data_path}")
-
-        URLConfig.register("rundoc", self._orig)
-        clear_config_caches()
 
     # # Part C. Some utility functions for A & B
     def download_test_data(self):


### PR DESCRIPTION
This pull request mainly focuses on improving code clarity and correctness in DAQ reader tests, with a minor update in the veto intervals plugin. The most significant changes involve renaming variables for clarity, updating function signatures and usages, and cleaning up unused test code.

### Veto Intervals Plugin update

* Changed the value assigned to the `veto_type` field for artificial deadtime events from `"straxen_deadtime_veto"` to `"straxen_deadtime"` in `veto_intervals.py` to better reflect its meaning. This was a bug!!


### DAQ Reader Tests cleanup

* Removed the unused `fake_rundoc_999999` dictionary and related mocking logic from `test_daq_reader.py`, simplifying the test setup and teardown. [[1]](diffhunk://#diff-c2978153f3dded7a1ec6268711c9df39df3da7d35171a6e3f823e83e9b551147L67-L78) [[2]](diffhunk://#diff-c2978153f3dded7a1ec6268711c9df39df3da7d35171a6e3f823e83e9b551147L155-L172)
* Added `v1495_config` to the test configuration dictionary in `test_insert_deadtime` for more complete test coverage.
* Cleaned up imports in `test_daq_reader.py` by removing unused modules and functions.




-----

A bit OT: 

### LED Calibration Plugin improvements

* Renamed the `run_doc` variable and related function parameters to `run_doc_comments` throughout `led_calibration.py` for clearer intent and consistency. Updated all usages in the plugin and helper function `is_the_led_on`. [[1]](diffhunk://#diff-5b73fb2b1583eaaed7d4293063a7e41ca2d4fefb2da2a739fa8e9648878e376eL64-R64) [[2]](diffhunk://#diff-5b73fb2b1583eaaed7d4293063a7e41ca2d4fefb2da2a739fa8e9648878e376eL184-R184) [[3]](diffhunk://#diff-5b73fb2b1583eaaed7d4293063a7e41ca2d4fefb2da2a739fa8e9648878e376eL238-R249)