### PR TITLE
Add online_event_stream plugin scaffold for Mongo web stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 xenon_secrets.py
 .xenon_config
 
+
 # Jupyter
 .ipynb_checkpoints
 
@@ -77,3 +78,4 @@ test_dict.json
 
 *.pkl
 *.pkl.gz
+*.DS_Store

--- a/straxen/contexts.py
+++ b/straxen/contexts.py
@@ -236,6 +236,7 @@ def xenonnt(
                     "veto_intervals",
                     "online_peak_monitor",
                     "event_basics",
+                    "online_event_stream",
                     "online_monitor_nv",
                     "online_monitor_mv",
                     "individual_peak_monitor",

--- a/straxen/plugins/__init__.py
+++ b/straxen/plugins/__init__.py
@@ -35,6 +35,9 @@ from .online_peak_monitor import *
 from . import individual_peak_monitor
 from .individual_peak_monitor import *
 
+from . import online_event_stream
+from .online_event_stream import *
+
 # NV chain
 from . import raw_records_coin_nv
 from .raw_records_coin_nv import *

--- a/straxen/plugins/online_event_stream/__init__.py
+++ b/straxen/plugins/online_event_stream/__init__.py
@@ -1,0 +1,2 @@
+from . import online_event_stream
+from .online_event_stream import *

--- a/straxen/plugins/online_event_stream/online_event_stream.py
+++ b/straxen/plugins/online_event_stream/online_event_stream.py
@@ -1,0 +1,185 @@
+import numpy as np
+import strax
+import straxen
+
+export, __all__ = strax.exporter()
+
+
+@export
+class OnlineEventStream(strax.Plugin):
+    """Compact event stream for website/monitoring use.
+
+    This plugin is designed for Mongo online storage and keeps only a small,
+    deterministic subset of fields from clean events in each chunk.
+    """
+
+    __version__ = "0.0.1"
+
+    depends_on = ("event_basics", "event_area_per_channel", "event_waveform")
+    provides = "online_event_stream"
+    data_kind = "online_event_stream"
+
+    online_event_stream_selection = straxen.URLConfig(
+        type=str,
+        default=(
+            "(s1_index >= 0) & (s2_index >= 0) & (drift_time > 0)"
+            " & (s1_area > 30) & (s2_area > 500)"
+        ),
+        help="Selection string for events included in the online event stream.",
+    )
+
+    online_event_stream_max_events_per_chunk = straxen.URLConfig(
+        type=int,
+        default=200,
+        help=(
+            "Maximum number of selected events stored per chunk. "
+            "Use a non-positive value to keep all selected events."
+        ),
+    )
+
+    online_event_stream_top_n_channels = straxen.URLConfig(
+        type=int,
+        default=16,
+        help="Number of top channels kept for S1/S2 hit-pattern summaries.",
+    )
+
+    online_event_stream_max_bytes = straxen.URLConfig(
+        type=int,
+        default=8_000_000,
+        help="Hard cap on bytes stored per chunk for this online data product.",
+    )
+
+    def infer_dtype(self):
+        n_top = self.online_event_stream_top_n_channels
+        dtype = strax.time_fields + [
+            (("Event number", "event_number"), np.int64),
+            (("S1 area [PE]", "s1_area"), np.float32),
+            (("S2 area [PE]", "s2_area"), np.float32),
+            (("S1 area fraction top", "s1_area_fraction_top"), np.float32),
+            (("S2 area fraction top", "s2_area_fraction_top"), np.float32),
+            (("S2 reconstructed x [cm]", "s2_x"), np.float32),
+            (("S2 reconstructed y [cm]", "s2_y"), np.float32),
+            (("Drift time [ns]", "drift_time"), np.float32),
+            (("S1 contributing channels", "s1_n_channels"), np.int16),
+            (("S2 contributing channels", "s2_n_channels"), np.int16),
+            (
+                ("S1 top channel indices by area contribution", "s1_top_channel_index"),
+                np.int16,
+                n_top,
+            ),
+            (("S1 top channel areas [PE]", "s1_top_channel_area"), np.float32, n_top),
+            (
+                ("S2 top channel indices by area contribution", "s2_top_channel_index"),
+                np.int16,
+                n_top,
+            ),
+            (("S2 top channel areas [PE]", "s2_top_channel_area"), np.float32, n_top),
+            (
+                ("Fraction of selected events retained in this chunk", "stored_fraction"),
+                np.float32,
+            ),
+        ]
+        wf_dtype = self.deps["event_waveform"].dtype_for("event_waveform")
+        dtype += [
+            (("Main S1 waveform [PE/sample]", "s1_data"), wf_dtype.fields["s1_data"][0]),
+            (("Main S2 waveform [PE/sample]", "s2_data"), wf_dtype.fields["s2_data"][0]),
+            (("Alt S1 waveform [PE/sample]", "alt_s1_data"), wf_dtype.fields["alt_s1_data"][0]),
+            (("Alt S2 waveform [PE/sample]", "alt_s2_data"), wf_dtype.fields["alt_s2_data"][0]),
+        ]
+        return dtype
+
+    def compute(self, event_basics, event_area_per_channel, event_waveform):
+        if len(event_basics) != len(event_area_per_channel) or len(event_basics) != len(event_waveform):
+            raise ValueError(
+                "event_basics, event_area_per_channel and event_waveform must have the same length, "
+                f"got {len(event_basics)}, {len(event_area_per_channel)}, {len(event_waveform)}"
+            )
+        if len(event_basics) and not np.array_equal(
+            event_basics["time"], event_area_per_channel["time"]
+        ):
+            raise ValueError("event_basics and event_area_per_channel are not aligned in time.")
+        if len(event_basics) and not np.array_equal(event_basics["time"], event_waveform["time"]):
+            raise ValueError("event_basics and event_waveform are not aligned in time.")
+
+        if not len(event_basics):
+            return np.zeros(0, dtype=self.dtype)
+
+        selection = self.online_event_stream_selection
+        if selection:
+            mask = strax.parse_selection(event_basics, selection)
+        else:
+            mask = np.ones(len(event_basics), dtype=np.bool_)
+
+        selected = np.flatnonzero(mask)
+        if not len(selected):
+            return np.zeros(0, dtype=self.dtype)
+
+        stored_fraction = np.float32(1.0)
+        max_events = self.online_event_stream_max_events_per_chunk
+        if max_events > 0 and len(selected) > max_events:
+            stored_fraction = np.float32(max_events / len(selected))
+            selected = selected[:max_events]
+
+        # Extra safety for Mongo document size.
+        bytes_per_row = np.dtype(self.dtype).itemsize
+        max_by_bytes = self.online_event_stream_max_bytes // bytes_per_row
+        if max_by_bytes <= 0:
+            return np.zeros(0, dtype=self.dtype)
+        if len(selected) > max_by_bytes:
+            stored_fraction *= np.float32(max_by_bytes / len(selected))
+            selected = selected[:max_by_bytes]
+
+        result = np.zeros(len(selected), dtype=self.dtype)
+        strax.set_nan_defaults(result)
+
+        selected_events = event_basics[selected]
+        selected_apc = event_area_per_channel[selected]
+        selected_wf = event_waveform[selected]
+
+        result["time"] = selected_events["time"]
+        result["endtime"] = strax.endtime(selected_events)
+        result["event_number"] = selected_events["event_number"]
+        result["s1_area"] = selected_events["s1_area"]
+        result["s2_area"] = selected_events["s2_area"]
+        result["s1_area_fraction_top"] = selected_events["s1_area_fraction_top"]
+        result["s2_area_fraction_top"] = selected_events["s2_area_fraction_top"]
+        result["s2_x"] = selected_events["s2_x"]
+        result["s2_y"] = selected_events["s2_y"]
+        result["drift_time"] = selected_events["drift_time"]
+        result["s1_n_channels"] = selected_events["s1_n_channels"]
+        result["s2_n_channels"] = selected_events["s2_n_channels"]
+        result["stored_fraction"] = stored_fraction
+        result["s1_data"] = selected_wf["s1_data"]
+        result["s2_data"] = selected_wf["s2_data"]
+        result["alt_s1_data"] = selected_wf["alt_s1_data"]
+        result["alt_s2_data"] = selected_wf["alt_s2_data"]
+
+        for i, row in enumerate(selected_apc):
+            s1_idx, s1_area = self._top_channels(row["s1_area_per_channel"])
+            s2_idx, s2_area = self._top_channels(row["s2_area_per_channel"])
+            result["s1_top_channel_index"][i] = s1_idx
+            result["s1_top_channel_area"][i] = s1_area
+            result["s2_top_channel_index"][i] = s2_idx
+            result["s2_top_channel_area"][i] = s2_area
+
+        return result
+
+    def _top_channels(self, area_per_channel):
+        n_top = self.online_event_stream_top_n_channels
+        idx = np.full(n_top, -1, dtype=np.int16)
+        values = np.zeros(n_top, dtype=np.float32)
+
+        if not len(area_per_channel):
+            return idx, values
+
+        order = np.argsort(area_per_channel)[::-1]
+        order = order[:n_top]
+        vals = area_per_channel[order]
+
+        valid = vals > 0
+        order = order[valid]
+        vals = vals[valid]
+
+        idx[: len(order)] = order.astype(np.int16, copy=False)
+        values[: len(vals)] = vals.astype(np.float32, copy=False)
+        return idx, values

--- a/straxen/plugins/online_event_stream/online_event_stream.py
+++ b/straxen/plugins/online_event_stream/online_event_stream.py
@@ -31,17 +31,11 @@ class OnlineEventStream(strax.Plugin):
 
     online_event_stream_max_events_per_chunk = straxen.URLConfig(
         type=int,
-        default=200,
+        default=40,
         help=(
             "Maximum number of selected events stored per chunk. "
             "Use a non-positive value to keep all selected events."
         ),
-    )
-
-    online_event_stream_top_n_channels = straxen.URLConfig(
-        type=int,
-        default=16,
-        help="Number of top channels kept for S1/S2 hit-pattern summaries.",
     )
 
     online_event_stream_max_bytes = straxen.URLConfig(
@@ -51,7 +45,7 @@ class OnlineEventStream(strax.Plugin):
     )
 
     def infer_dtype(self):
-        n_top = self.online_event_stream_top_n_channels
+        apc_dtype = self.deps["event_area_per_channel"].dtype_for("event_area_per_channel")
         dtype = strax.time_fields + [
             (("Event number", "event_number"), np.int64),
             (("S1 area [PE]", "s1_area"), np.float32),
@@ -64,17 +58,21 @@ class OnlineEventStream(strax.Plugin):
             (("S1 contributing channels", "s1_n_channels"), np.int16),
             (("S2 contributing channels", "s2_n_channels"), np.int16),
             (
-                ("S1 top channel indices by area contribution", "s1_top_channel_index"),
-                np.int16,
-                n_top,
+                ("Main S1 area per channel [PE]", "s1_area_per_channel"),
+                apc_dtype.fields["s1_area_per_channel"][0],
             ),
-            (("S1 top channel areas [PE]", "s1_top_channel_area"), np.float32, n_top),
             (
-                ("S2 top channel indices by area contribution", "s2_top_channel_index"),
-                np.int16,
-                n_top,
+                ("Main S2 area per channel [PE]", "s2_area_per_channel"),
+                apc_dtype.fields["s2_area_per_channel"][0],
             ),
-            (("S2 top channel areas [PE]", "s2_top_channel_area"), np.float32, n_top),
+            (
+                ("Alt S1 area per channel [PE]", "alt_s1_area_per_channel"),
+                apc_dtype.fields["alt_s1_area_per_channel"][0],
+            ),
+            (
+                ("Alt S2 area per channel [PE]", "alt_s2_area_per_channel"),
+                apc_dtype.fields["alt_s2_area_per_channel"][0],
+            ),
             (
                 ("Fraction of selected events retained in this chunk", "stored_fraction"),
                 np.float32,
@@ -89,29 +87,15 @@ class OnlineEventStream(strax.Plugin):
         ]
         return dtype
 
-    def compute(self, event_basics, event_area_per_channel, event_waveform):
-        if len(event_basics) != len(event_area_per_channel) or len(event_basics) != len(
-            event_waveform
-        ):
-            raise ValueError(
-                "event_basics, event_area_per_channel and event_waveform must have the same length, "
-                f"got {len(event_basics)}, {len(event_area_per_channel)}, {len(event_waveform)}"
-            )
-        if len(event_basics) and not np.array_equal(
-            event_basics["time"], event_area_per_channel["time"]
-        ):
-            raise ValueError("event_basics and event_area_per_channel are not aligned in time.")
-        if len(event_basics) and not np.array_equal(event_basics["time"], event_waveform["time"]):
-            raise ValueError("event_basics and event_waveform are not aligned in time.")
-
-        if not len(event_basics):
+    def compute(self, events):
+        if not len(events):
             return np.zeros(0, dtype=self.dtype)
 
         selection = self.online_event_stream_selection
         if selection:
-            mask = strax.parse_selection(event_basics, selection)
+            mask = strax.parse_selection(events, selection)
         else:
-            mask = np.ones(len(event_basics), dtype=np.bool_)
+            mask = np.ones(len(events), dtype=np.bool_)
 
         selected = np.flatnonzero(mask)
         if not len(selected):
@@ -135,9 +119,7 @@ class OnlineEventStream(strax.Plugin):
         result = np.zeros(len(selected), dtype=self.dtype)
         strax.set_nan_defaults(result)
 
-        selected_events = event_basics[selected]
-        selected_apc = event_area_per_channel[selected]
-        selected_wf = event_waveform[selected]
+        selected_events = events[selected]
 
         result["time"] = selected_events["time"]
         result["endtime"] = strax.endtime(selected_events)
@@ -152,37 +134,13 @@ class OnlineEventStream(strax.Plugin):
         result["s1_n_channels"] = selected_events["s1_n_channels"]
         result["s2_n_channels"] = selected_events["s2_n_channels"]
         result["stored_fraction"] = stored_fraction
-        result["s1_data"] = selected_wf["s1_data"]
-        result["s2_data"] = selected_wf["s2_data"]
-        result["alt_s1_data"] = selected_wf["alt_s1_data"]
-        result["alt_s2_data"] = selected_wf["alt_s2_data"]
-
-        for i, row in enumerate(selected_apc):
-            s1_idx, s1_area = self._top_channels(row["s1_area_per_channel"])
-            s2_idx, s2_area = self._top_channels(row["s2_area_per_channel"])
-            result["s1_top_channel_index"][i] = s1_idx
-            result["s1_top_channel_area"][i] = s1_area
-            result["s2_top_channel_index"][i] = s2_idx
-            result["s2_top_channel_area"][i] = s2_area
+        result["s1_area_per_channel"] = selected_events["s1_area_per_channel"]
+        result["s2_area_per_channel"] = selected_events["s2_area_per_channel"]
+        result["alt_s1_area_per_channel"] = selected_events["alt_s1_area_per_channel"]
+        result["alt_s2_area_per_channel"] = selected_events["alt_s2_area_per_channel"]
+        result["s1_data"] = selected_events["s1_data"]
+        result["s2_data"] = selected_events["s2_data"]
+        result["alt_s1_data"] = selected_events["alt_s1_data"]
+        result["alt_s2_data"] = selected_events["alt_s2_data"]
 
         return result
-
-    def _top_channels(self, area_per_channel):
-        n_top = self.online_event_stream_top_n_channels
-        idx = np.full(n_top, -1, dtype=np.int16)
-        values = np.zeros(n_top, dtype=np.float32)
-
-        if not len(area_per_channel):
-            return idx, values
-
-        order = np.argsort(area_per_channel)[::-1]
-        order = order[:n_top]
-        vals = area_per_channel[order]
-
-        valid = vals > 0
-        order = order[valid]
-        vals = vals[valid]
-
-        idx[: len(order)] = order.astype(np.int16, copy=False)
-        values[: len(vals)] = vals.astype(np.float32, copy=False)
-        return idx, values

--- a/straxen/plugins/online_event_stream/online_event_stream.py
+++ b/straxen/plugins/online_event_stream/online_event_stream.py
@@ -9,8 +9,9 @@ export, __all__ = strax.exporter()
 class OnlineEventStream(strax.Plugin):
     """Compact event stream for website/monitoring use.
 
-    This plugin is designed for Mongo online storage and keeps only a small,
-    deterministic subset of fields from clean events in each chunk.
+    This plugin is designed for Mongo online storage and keeps only a small, deterministic subset of
+    fields from clean events in each chunk.
+
     """
 
     __version__ = "0.0.1"
@@ -89,7 +90,9 @@ class OnlineEventStream(strax.Plugin):
         return dtype
 
     def compute(self, event_basics, event_area_per_channel, event_waveform):
-        if len(event_basics) != len(event_area_per_channel) or len(event_basics) != len(event_waveform):
+        if len(event_basics) != len(event_area_per_channel) or len(event_basics) != len(
+            event_waveform
+        ):
             raise ValueError(
                 "event_basics, event_area_per_channel and event_waveform must have the same length, "
                 f"got {len(event_basics)}, {len(event_area_per_channel)}, {len(event_waveform)}"

--- a/straxen/scripts/bootstrax.py
+++ b/straxen/scripts/bootstrax.py
@@ -67,8 +67,7 @@ parser.add_argument(
     "--targets",
     nargs="*",
     default=(
-        "event_info events_nv events_mv "
-        "online_peak_monitor online_event_stream veto_proximity"
+        "event_info events_nv events_mv " "online_peak_monitor online_event_stream veto_proximity"
     ).split(),
     help="Strax data type name(s) that should be produced with live processing",
 )

--- a/straxen/scripts/bootstrax.py
+++ b/straxen/scripts/bootstrax.py
@@ -66,7 +66,7 @@ parser.add_argument(
 parser.add_argument(
     "--targets",
     nargs="*",
-    default="event_info events_nv events_mv online_peak_monitor veto_proximity".split(),
+    default="event_info events_nv events_mv online_peak_monitor online_event_stream veto_proximity".split(),
     help="Strax data type name(s) that should be produced with live processing",
 )
 parser.add_argument(

--- a/straxen/scripts/bootstrax.py
+++ b/straxen/scripts/bootstrax.py
@@ -66,7 +66,10 @@ parser.add_argument(
 parser.add_argument(
     "--targets",
     nargs="*",
-    default="event_info events_nv events_mv online_peak_monitor online_event_stream veto_proximity".split(),
+    default=(
+        "event_info events_nv events_mv "
+        "online_peak_monitor online_event_stream veto_proximity"
+    ).split(),
     help="Strax data type name(s) that should be produced with live processing",
 )
 parser.add_argument(


### PR DESCRIPTION
This pull request introduces a new plugin, `OnlineEventStream`, to the Straxen codebase. The plugin generates a compact, efficient event stream intended for online monitoring and website use, storing only a small, deterministic set of fields for each event. The changes ensure that the new plugin is properly registered, included in the default processing targets, and available for import throughout the codebase.

**New Online Event Stream Plugin:**

* Added the `OnlineEventStream` plugin in `straxen/plugins/online_event_stream/online_event_stream.py`, which provides a compact event stream for online monitoring, with configurable selection criteria, field subsets, and storage limits.
* Registered the new plugin by updating imports in `straxen/plugins/online_event_stream/__init__.py` and `straxen/plugins/__init__.py`. [[1]](diffhunk://#diff-cb5d1f2e3ea3d4157722bfef6a86e4a0a5fcbe5fc0de2b0856bfded7bab7a38bR1-R2) [[2]](diffhunk://#diff-1fff93cacedf4e030c813f6758ddc4c5dc44e97737e23d90b4340f95179af421R38-R40)

**Integration with Processing Contexts and Scripts:**

* Included `online_event_stream` in the default list of plugins for the `xenonnt` context in `straxen/contexts.py`, ensuring it is available in standard data processing chains.
* Added `online_event_stream` to the default processing targets in the `bootstrax` live processing script, so it is produced automatically during live data processing.