### PR TITLE
pre-commit test fix

### DIFF
--- a/.github/workflows/pypi_install.yml
+++ b/.github/workflows/pypi_install.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,13 +33,13 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         test: ["coveralls", "pytest", "pytest_no_database"]
         # Drop some not crucial tests for python 3.10 and 3.11
         exclude:
-          - python-version: "3.11"
+          - python-version: "3.12"
             test: coveralls
-          - python-version: "3.11"
+          - python-version: "3.12"
             test: pytest_no_database
 
     steps:
@@ -64,6 +64,10 @@ jobs:
 
       - name: Install requirements for Python 3.11
         if: matrix.python-version == '3.11'
+        run: pip install git+https://github.com/XENONnT/base_environment.git@el8.2026.02.2 --force-reinstall
+
+      - name: Install requirements for Python 3.12
+        if: matrix.python-version == '3.12'
         run: pip install git+https://github.com/XENONnT/base_environment.git --force-reinstall
 
       - name: Install strax and straxen

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         language_version: python3
 
 -   repo: https://github.com/pycqa/docformatter
-    rev: v1.7.8
+    rev: v1.7.6
     hooks:
     -   id: docformatter
         additional_dependencies: [tomli]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
     rev: v1.7.6
     hooks:
     -   id: docformatter
+        language_version: python3.12
         additional_dependencies: [tomli]
         args: [--config, pyproject.toml]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         language_version: python3
 
 -   repo: https://github.com/pycqa/docformatter
-    rev: v1.7.6
+    rev: v1.7.8
     hooks:
     -   id: docformatter
         additional_dependencies: [tomli]


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
This PR was made to fix pre-commit test after the update on base_environment.
The problem was that docformatter 1.7.6 was having problems, but instead of updating it, it is easier to just fix the python version to 3.12.
Also updated some python versions in pytest workflow files.

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
