### PR TITLE
remove legacy packages and solve some warnings

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
     steps:
       - name: Setup python
         uses: actions/setup-python@v5.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ docs/_build
 # Documentation files
 docs/source/reference/datastructure*
 docs/source/reference/data_kinds*
-docs/source/reference/release_notes.rst
+docs/source/reference/release_notes.md
 
 test_dict.json
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.10"
+    python: "3.12"
 
 python:
   install:

--- a/docs/source/build_release_notes.py
+++ b/docs/source/build_release_notes.py
@@ -5,6 +5,6 @@ from straxen.docs_utils import convert_release_notes
 if __name__ == "__main__":
     this_dir = os.path.dirname(os.path.realpath(__file__))
     notes = os.path.join(this_dir, "..", "..", "HISTORY.md")
-    target = os.path.join(this_dir, "reference", "release_notes.rst")
+    target = os.path.join(this_dir, "reference", "release_notes.md")
     pull_url = "https://github.com/XENONnT/straxen/pull"
     convert_release_notes(notes, target, pull_url)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "myst_parser",
     "nbsphinx",
 ]
 
@@ -68,10 +69,6 @@ templates_path = ["_templates"]
 # You can specify multiple suffix as a list of string:
 #
 source_suffix = [".rst", ".md"]
-
-source_parsers = {
-    ".md": "recommonmark.parser.CommonMarkParser",
-}
 
 # The master toctree document.
 master_doc = "index"
@@ -205,7 +202,7 @@ def setup(app):
 
     this_dir = os.path.dirname(os.path.realpath(__file__))
     notes = os.path.join(this_dir, "..", "..", "HISTORY.md")
-    target = os.path.join(this_dir, "reference", "release_notes.rst")
+    target = os.path.join(this_dir, "reference", "release_notes.md")
     pull_url = "https://github.com/XENONnT/straxen/pull"
 
     convert_release_notes(notes, target, pull_url)

--- a/notebooks/tutorials/strax_demo.ipynb
+++ b/notebooks/tutorials/strax_demo.ipynb
@@ -1187,7 +1187,7 @@
     "        (p[\"time\"] - t0) + np.arange(n) * p[\"dt\"],\n",
     "        p[\"data\"][:n] / p[\"dt\"],\n",
     "        drawstyle=\"steps-mid\",\n",
-    "        **kwargs\n",
+    "        **kwargs,\n",
     "    )\n",
     "    plt.xlabel(\"Time (ns)\")\n",
     "    plt.ylabel(\"Sum waveform (PE / ns)\")\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
-[tool]
-[tool.poetry]
+[project]
 name = "straxen"
 version = "4.0.0"
 description = "Streaming analysis for XENON"
 readme = "README.md"
+requires-python = ">=3.11,<3.13"
 authors = [
-  "Straxen contributors, the XENON collaboration",
+  { name = "Straxen contributors, the XENON collaboration" },
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -17,9 +17,28 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Scientific/Engineering :: Physics",
 ]
-repository = "https://github.com/XENONnT/straxen"
+dependencies = [
+  "strax>=2.2.1",
+  "bokeh",
+  "commentjson",
+  "gitpython",
+  "graphviz",
+  "immutabledict",
+  "matplotlib",
+  "multihist>=0.6.3",
+  "numba>=0.50.0",
+  "numpy",
+  "pandas",
+  "pymongo",
+  "requests",
+  "utilix>=0.11.0",
+  "xedocs>=0.2.44",
+]
 
-[tool.poetry.scripts]
+[project.urls]
+Repository = "https://github.com/XENONnT/straxen"
+
+[project.scripts]
 ajax = "straxen.scripts.ajax:main"
 bootstrax = "straxen.scripts.bootstrax:main"
 microstrax = "straxen.scripts.microstrax:main"
@@ -28,50 +47,17 @@ restrax = "straxen.scripts.restrax:main"
 straxen_print_versions = "straxen.scripts.straxen_print_versions:main"
 straxer = "straxen.scripts.straxer:main"
 
-[tool.poetry.dependencies]
-python = ">=3.10,<3.13"
-strax = ">=2.2.1"
-bokeh = "*"
-commentjson = "*"
-gitpython = "*"
-graphviz = "*"
-immutabledict = "*"
-matplotlib = "*"
-multihist = ">=0.6.3"
-numba = ">=0.50.0"
-numpy = "*"
-packaging = "*"
-pandas = "*"
-m2r = "==0.2.1"
-docutils = "==0.18.1"
-mistune = "==0.8.4"
-pymongo = "*"
-requests = "*"
-utilix = ">=0.11.0"
-xedocs = ">=0.2.44"
-commonmark = { version = "0.9.1", optional = true }
-nbsphinx = { version = "0.8.9", optional = true }
-recommonmark = { version = "0.7.1", optional = true }
-sphinx = { version = "7.1.2", optional = true }
-sphinx_rtd_theme = { version = "1.3.0", optional = true }
-Jinja2 = { version = "3.1.5", optional = true }
-urllib3 = { version = "2.2.2", optional = true }
-lxml_html_clean = { version = "*", optional = true }
-
-[tool.poetry.extras]
+[project.optional-dependencies]
 docs = [
-  "commonmark",
-  "nbsphinx",
-  "recommonmark",
-  "sphinx",
-  "sphinx_rtd_theme",
-  "Jinja2",
-  "urllib3",
-  "lxml_html_clean",
+  "myst-parser>=4,<6",
+  "nbsphinx>=0.8.9,<1",
+  "sphinx>=7,<9",
+  "sphinx-rtd-theme>=3,<4",
+  "lxml-html-clean",
 ]
 
 [build-system]
-requires = ["poetry-core>=1.0.8", "setuptools>=61.0"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.black]

--- a/straxen/docs_utils.py
+++ b/straxen/docs_utils.py
@@ -1,40 +1,22 @@
-from m2r import convert
+import re
 
 from .misc import kind_colors
 
-header = """
-Release notes
-==============
-
-"""
+header = "# Release notes\n\n"
 
 
 def convert_release_notes(notes, target, pull_url):
-    """Convert the release notes to an RST page with links to PRs."""
-    with open(notes, "r") as f:
+    """Write the release notes as Markdown with links to PRs."""
+    with open(notes, "r", encoding="utf-8") as f:
         notes = f.read()
-    rst = convert(notes)
-    with_ref = ""
-    for line in rst.split("\n"):
-        # Get URL for PR
-        if "#" in line:
-            pr_number = line.split("#")[1]
-            while len(pr_number):
-                try:
-                    pr_number = int(pr_number)
-                    break
-                except ValueError:
-                    # Too many tailing characters to be an int
-                    pr_number = pr_number[:-1]
-            if pr_number:
-                line = line.replace(
-                    f"#{pr_number}",
-                    f"`#{pr_number} <{pull_url}/{pr_number}>`_",
-                )
-        with_ref += line + "\n"
 
-    with open(target, "w") as f:
-        f.write(header + with_ref)
+    def link_pull_request(match):
+        number = match.group(1)
+        return f"[#{number}]({pull_url}/{number})"
+
+    notes = re.sub(r"(?<![\w/\[])#(\d+)", link_pull_request, notes)
+    with open(target, "w", encoding="utf-8") as f:
+        f.write(header + notes)
 
 
 def add_spaces(x):


### PR DESCRIPTION
This pull request modernizes the project's packaging and documentation system, transitioning from the deprecated `recommonmark`/`.rst` setup to a Markdown-first approach using `myst-parser`, and updates the packaging configuration to the new PEP 621-compatible `pyproject.toml` format. It also simplifies and improves the release notes conversion utility to generate Markdown with proper pull request links.

**Packaging and dependency management modernization:**

* Refactored `pyproject.toml` to use the `[project]` table (PEP 621), moved dependencies to the new format, and specified Python 3.11+ requirement. Optional documentation dependencies now use `myst-parser` instead of `recommonmark`, and several unused or redundant dependencies were removed or updated. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L1-R8) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L20-R41) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L31-R60)

**Documentation build system migration:**

* Switched Sphinx configuration to support Markdown using `myst_parser`, removed `recommonmark` and its parser, and updated `source_suffix` to include `.md`. [[1]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698R51) [[2]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698L72-L75)
* Updated release notes output from `.rst` to `.md` in both the build script and Sphinx config. [[1]](diffhunk://#diff-3a07aeb61f32c6e1488658f4588d2e47f9ac2187d812b85eee2004af26e9ab47L8-R8) [[2]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698L208-R205)

**Release notes conversion improvements:**

* Rewrote `convert_release_notes` in `straxen/docs_utils.py` to directly process Markdown, auto-link pull request references, and drop the dependency on `m2r`. The function now writes Markdown output with proper PR links.

These changes collectively modernize the project's developer workflow and documentation pipeline, making it more maintainable and future-proof.

Also removed some remaining python 3.10 support